### PR TITLE
feat: add non-interactive CLI mode with asm shorthand

### DIFF
--- a/bin/skill-manager.ts
+++ b/bin/skill-manager.ts
@@ -1,46 +1,12 @@
 #!/usr/bin/env bun
 
-import { VERSION, VERSION_STRING } from "../src/utils/version";
+import { isCLIMode, runCLI } from "../src/cli";
 
-const arg = process.argv[2];
-
-if (arg === "--help" || arg === "-h") {
-  console.log(`\x1b[1m\x1b[36magent-skill-manager\x1b[0m ${VERSION_STRING}
-
-Interactive TUI for managing installed skills for AI coding agents (Claude Code, Codex, OpenClaw, and more).
-
-\x1b[1mUsage:\x1b[0m
-  agent-skill-manager              Launch the interactive TUI dashboard
-  agent-skill-manager --help       Show this help message
-  agent-skill-manager --version    Show version
-
-\x1b[1mRequirements:\x1b[0m
-  Bun >= 1.0.0  (https://bun.sh)
-
-\x1b[1mConfig:\x1b[0m
-  ~/.config/agent-skill-manager/config.json
-
-\x1b[1mTUI Keybindings:\x1b[0m
-  ↑/↓ or j/k   Navigate skill list
-  Enter         View skill details
-  d             Uninstall selected skill
-  /             Search / filter skills
-  Esc           Back / clear filter / close dialog
-  Tab           Cycle scope: Global → Project → Both
-  s             Cycle sort: Name → Version → Location
-  r             Refresh / rescan skills
-  c             Open configuration
-  q             Quit
-  ?             Toggle help overlay`);
-  process.exit(0);
+if (isCLIMode(process.argv)) {
+  await runCLI(process.argv);
+} else {
+  // No args — launch interactive TUI
+  await import("../src/index.ts");
 }
-
-if (arg === "--version" || arg === "-v") {
-  console.log(`agent-skill-manager ${VERSION_STRING}`);
-  process.exit(0);
-}
-
-// Launch the TUI
-await import("../src/index.ts");
 
 export {};

--- a/docs/CLI_PLAN.md
+++ b/docs/CLI_PLAN.md
@@ -1,0 +1,173 @@
+# CLI Implementation Plan
+
+## Overview
+
+Add a non-interactive CLI mode to `agent-skill-manager` so that all TUI features (list, search, inspect, uninstall, config) are accessible from scripts and pipelines.
+
+**Approach:** Zero new dependencies — hand-rolled arg parser in `src/cli.ts`, reusing existing core modules (`scanner`, `config`, `uninstaller`). `bin/skill-manager.ts` updated to route to CLI or TUI based on arguments.
+
+---
+
+## Design Summary
+
+### Command Tree
+
+```
+agent-skill-manager                        # (no args) Launch interactive TUI
+agent-skill-manager list                   # List all discovered skills
+agent-skill-manager search <query>         # Search skills by name/description/provider
+agent-skill-manager inspect <skill-name>   # Show detailed info for a skill
+agent-skill-manager uninstall <skill-name> # Remove a skill (with confirmation)
+agent-skill-manager config show            # Print current config
+agent-skill-manager config path            # Print config file path
+agent-skill-manager config reset           # Reset config to defaults
+agent-skill-manager config edit            # Open config in $EDITOR
+```
+
+### Global Options
+
+| Flag              | Short | Description                                                    |
+| ----------------- | ----- | -------------------------------------------------------------- |
+| `--help`          | `-h`  | Show help for any command                                      |
+| `--version`       | `-v`  | Print version and exit                                         |
+| `--json`          |       | Output as JSON (for `list`, `search`, `inspect`)               |
+| `--scope <scope>` | `-s`  | Filter scope: `global`, `project`, or `both` (default: `both`) |
+| `--no-color`      |       | Disable ANSI colors (also respects `NO_COLOR` env)             |
+
+### Command Details
+
+**`list`**
+
+- Options: `--sort <name|version|location>` (default: `name`), `--scope`, `--json`
+- Output: table (name, version, provider, scope, type, path) or JSON array
+- Piping: clean table to stdout, no ANSI when piped
+
+**`search <query>`**
+
+- Arguments: `<query>` (required)
+- Options: `--sort`, `--scope`, `--json`
+- Output: same as `list` but filtered
+
+**`inspect <skill-name>`**
+
+- Arguments: `<skill-name>` (the directory name of the skill)
+- Options: `--scope`, `--json`
+- Output: full skill metadata (name, version, description, path, provider, symlink info, file count)
+
+**`uninstall <skill-name>`**
+
+- Arguments: `<skill-name>` (required)
+- Options: `--yes` / `-y` (skip confirmation), `--scope`
+- Behavior: shows removal plan, asks for confirmation (unless `--yes`), executes removal
+- Stderr: confirmation prompt + result log
+- Exit codes: 0 success, 1 error, 2 usage error
+
+**`config show`** — prints config JSON to stdout
+**`config path`** — prints config file path
+**`config reset`** — resets to defaults (with confirmation unless `--yes`)
+**`config edit`** — opens in `$EDITOR`
+
+### Example Invocations
+
+```bash
+# List all skills as a table
+agent-skill-manager list
+
+# List global skills as JSON (for piping to jq)
+agent-skill-manager list --scope global --json
+
+# Search for "code-review" skills
+agent-skill-manager search code-review
+
+# Inspect a specific skill
+agent-skill-manager inspect blog-draft
+
+# Uninstall a skill non-interactively
+agent-skill-manager uninstall blog-draft --yes
+
+# Check config
+agent-skill-manager config show
+```
+
+### I/O Conventions
+
+- Stdout: command output (tables, JSON)
+- Stderr: errors, confirmation prompts, progress messages
+- Respects `NO_COLOR` env var and `--no-color` flag
+- Detects non-TTY stdout and auto-disables colors when piped
+- Exit codes: 0 = success, 1 = runtime error, 2 = usage error
+
+---
+
+## Phase 1 — Foundation (skeleton + `list` command)
+
+| #   | Task                                   | Files                                            | Expected Behavior                                                                            | Test                                        | Effort |
+| --- | -------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------- | ------------------------------------------- | ------ |
+| 1   | Create CLI arg parser & command router | `src/cli.ts` (new)                               | Parse `process.argv` into command + options, dispatch to handlers                            | Unit test: parse known args, reject unknown | M      |
+| 2   | Create output formatter (table + JSON) | `src/formatter.ts` (new)                         | Format `SkillInfo[]` as aligned table or JSON array                                          | Unit test: table output, JSON output        | S      |
+| 3   | Implement `list` command               | `src/cli.ts`                                     | `agent-skill-manager list` prints skill table; `--json` prints JSON; `--scope`/`--sort` work | Unit test + manual verify                   | S      |
+| 4   | Update entry point to route CLI vs TUI | `bin/skill-manager.ts`                           | Subcommands route to CLI, no args launches TUI, `--help` shows full help with commands       | Unit test: help output includes commands    | S      |
+| 5   | Tests for Phase 1                      | `src/cli.test.ts`, `src/formatter.test.ts` (new) | All tests pass                                                                               | `bun test`                                  | M      |
+
+### Phase 1 deliverables
+
+```bash
+agent-skill-manager list
+agent-skill-manager list --json
+agent-skill-manager list --scope global --sort version
+agent-skill-manager --help     # updated to show subcommands
+agent-skill-manager --version  # still works
+```
+
+---
+
+## Phase 2 — Complete (all remaining commands)
+
+| #   | Task                                    | Files                            | Expected Behavior                                                                    | Test                                  | Effort |
+| --- | --------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------- | ------ |
+| 6   | Implement `search <query>`              | `src/cli.ts`                     | Filtered list output, same formatting as `list`                                      | Unit test: filters correctly          | S      |
+| 7   | Implement `inspect <skill-name>`        | `src/cli.ts`                     | Detailed single-skill output (table + JSON modes)                                    | Unit test: finds skill, shows details | S      |
+| 8   | Implement `uninstall <skill-name>`      | `src/cli.ts`                     | Shows plan, prompts confirmation, executes removal; `--yes` skips prompt             | Unit test: plan output, `--yes` flag  | M      |
+| 9   | Implement `config` subcommands          | `src/cli.ts`                     | `config show`, `config path`, `config reset`, `config edit` all work                 | Unit test per subcommand              | M      |
+| 10  | Color/NO_COLOR support + pipe detection | `src/formatter.ts`, `src/cli.ts` | `--no-color`, `NO_COLOR` env, non-TTY auto-disable                                   | Unit test: color stripping            | S      |
+| 11  | Error handling + exit codes             | `src/cli.ts`                     | Unknown command → exit 2 with help hint, runtime errors → exit 1 with stderr message | Unit test: exit codes                 | S      |
+
+### Phase 2 deliverables
+
+```bash
+agent-skill-manager search code-review
+agent-skill-manager search code-review --json
+agent-skill-manager inspect blog-draft
+agent-skill-manager inspect blog-draft --json
+agent-skill-manager uninstall blog-draft
+agent-skill-manager uninstall blog-draft --yes
+agent-skill-manager config show
+agent-skill-manager config path
+agent-skill-manager config reset
+agent-skill-manager config edit
+```
+
+---
+
+## Phase 3 — Polish
+
+| #   | Task                              | Files        | Expected Behavior                                       | Test          | Effort |
+| --- | --------------------------------- | ------------ | ------------------------------------------------------- | ------------- | ------ |
+| 12  | Update README with CLI usage docs | `README.md`  | New CLI section with all commands and examples          | Manual review | S      |
+| 13  | Update help text for all commands | `src/cli.ts` | Per-command `--help` shows usage, options, and examples | Manual verify | S      |
+
+---
+
+## Files Created / Modified
+
+### New files
+
+- `src/cli.ts` — CLI arg parser, command handlers, help text
+- `src/formatter.ts` — Table and JSON output formatting
+- `src/cli.test.ts` — CLI tests
+- `src/formatter.test.ts` — Formatter tests
+
+### Modified files
+
+- `bin/skill-manager.ts` — Route to CLI commands or TUI
+- `README.md` — CLI documentation section (Phase 3)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Interactive TUI for managing installed skills for AI coding agents (Claude Code, Codex, OpenClaw, and more)",
   "type": "module",
   "bin": {
-    "agent-skill-manager": "bin/skill-manager.ts"
+    "agent-skill-manager": "bin/skill-manager.ts",
+    "asm": "bin/skill-manager.ts"
   },
   "scripts": {
     "start": "bun run src/index.ts",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,627 @@
+import { describe, test, expect } from "bun:test";
+import { parseArgs, isCLIMode } from "./cli";
+import { join } from "path";
+
+// Helper: path to the CLI entry point
+const CLI_BIN = join(import.meta.dir, "..", "bin", "skill-manager.ts");
+
+// Helper: run CLI as subprocess, returns { stdout, stderr, exitCode }
+async function runCLI(
+  ...args: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["bun", CLI_BIN, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+// ─── parseArgs unit tests ───────────────────────────────────────────────────
+
+describe("parseArgs", () => {
+  const parse = (...args: string[]) => parseArgs(["bun", "script.ts", ...args]);
+
+  test("no args yields null command", () => {
+    const result = parse();
+    expect(result.command).toBeNull();
+    expect(result.subcommand).toBeNull();
+    expect(result.flags.help).toBe(false);
+  });
+
+  test("parses list command", () => {
+    const result = parse("list");
+    expect(result.command).toBe("list");
+  });
+
+  test("parses search with query", () => {
+    const result = parse("search", "code-review");
+    expect(result.command).toBe("search");
+    expect(result.subcommand).toBe("code-review");
+  });
+
+  test("parses inspect with skill name", () => {
+    const result = parse("inspect", "blog-draft");
+    expect(result.command).toBe("inspect");
+    expect(result.subcommand).toBe("blog-draft");
+  });
+
+  test("parses uninstall with skill name and --yes", () => {
+    const result = parse("uninstall", "blog-draft", "--yes");
+    expect(result.command).toBe("uninstall");
+    expect(result.subcommand).toBe("blog-draft");
+    expect(result.flags.yes).toBe(true);
+  });
+
+  test("parses -y as alias for --yes", () => {
+    const result = parse("uninstall", "test", "-y");
+    expect(result.flags.yes).toBe(true);
+  });
+
+  test("parses config with subcommand", () => {
+    const result = parse("config", "show");
+    expect(result.command).toBe("config");
+    expect(result.subcommand).toBe("show");
+  });
+
+  test("parses --help flag", () => {
+    const result = parse("--help");
+    expect(result.flags.help).toBe(true);
+  });
+
+  test("parses -h flag", () => {
+    const result = parse("-h");
+    expect(result.flags.help).toBe(true);
+  });
+
+  test("parses --version flag", () => {
+    const result = parse("--version");
+    expect(result.flags.version).toBe(true);
+  });
+
+  test("parses -v flag", () => {
+    const result = parse("-v");
+    expect(result.flags.version).toBe(true);
+  });
+
+  test("parses --json flag", () => {
+    const result = parse("list", "--json");
+    expect(result.command).toBe("list");
+    expect(result.flags.json).toBe(true);
+  });
+
+  test("parses --no-color flag", () => {
+    const result = parse("list", "--no-color");
+    expect(result.flags.noColor).toBe(true);
+  });
+
+  test("parses --scope global", () => {
+    const result = parse("list", "--scope", "global");
+    expect(result.flags.scope).toBe("global");
+  });
+
+  test("parses -s project", () => {
+    const result = parse("list", "-s", "project");
+    expect(result.flags.scope).toBe("project");
+  });
+
+  test("parses --scope both", () => {
+    const result = parse("list", "--scope", "both");
+    expect(result.flags.scope).toBe("both");
+  });
+
+  test("parses --sort version", () => {
+    const result = parse("list", "--sort", "version");
+    expect(result.flags.sort).toBe("version");
+  });
+
+  test("parses --sort location", () => {
+    const result = parse("list", "--sort", "location");
+    expect(result.flags.sort).toBe("location");
+  });
+
+  test("parses --sort name", () => {
+    const result = parse("list", "--sort", "name");
+    expect(result.flags.sort).toBe("name");
+  });
+
+  test("defaults scope to both", () => {
+    const result = parse("list");
+    expect(result.flags.scope).toBe("both");
+  });
+
+  test("defaults sort to name", () => {
+    const result = parse("list");
+    expect(result.flags.sort).toBe("name");
+  });
+
+  test("defaults json to false", () => {
+    const result = parse("list");
+    expect(result.flags.json).toBe(false);
+  });
+
+  test("defaults yes to false", () => {
+    const result = parse("uninstall", "x");
+    expect(result.flags.yes).toBe(false);
+  });
+
+  test("defaults noColor to false", () => {
+    const result = parse("list");
+    expect(result.flags.noColor).toBe(false);
+  });
+
+  test("parses --help with command", () => {
+    const result = parse("list", "--help");
+    expect(result.command).toBe("list");
+    expect(result.flags.help).toBe(true);
+  });
+
+  test("parses multiple flags together", () => {
+    const result = parse(
+      "list",
+      "--json",
+      "--scope",
+      "global",
+      "--sort",
+      "version",
+      "--no-color",
+    );
+    expect(result.command).toBe("list");
+    expect(result.flags.json).toBe(true);
+    expect(result.flags.scope).toBe("global");
+    expect(result.flags.sort).toBe("version");
+    expect(result.flags.noColor).toBe(true);
+  });
+
+  test("collects extra positional args", () => {
+    const result = parse("search", "query", "extra");
+    expect(result.command).toBe("search");
+    expect(result.subcommand).toBe("query");
+    expect(result.positional).toEqual(["extra"]);
+  });
+
+  test("collects multiple extra positional args", () => {
+    const result = parse("search", "query", "extra1", "extra2");
+    expect(result.positional).toEqual(["extra1", "extra2"]);
+  });
+
+  test("flags before command still parsed", () => {
+    const result = parse("--json", "list");
+    expect(result.flags.json).toBe(true);
+    expect(result.command).toBe("list");
+  });
+
+  test("flags interspersed with positional args", () => {
+    const result = parse("search", "--json", "code-review");
+    expect(result.command).toBe("search");
+    expect(result.flags.json).toBe(true);
+    // "code-review" parsed as subcommand since --json consumes no value
+    expect(result.subcommand).toBe("code-review");
+  });
+
+  test("config subcommands: path, reset, edit", () => {
+    for (const sub of ["path", "reset", "edit"]) {
+      const result = parse("config", sub);
+      expect(result.command).toBe("config");
+      expect(result.subcommand).toBe(sub);
+    }
+  });
+
+  test("--help combined with --version", () => {
+    const result = parse("--help", "--version");
+    expect(result.flags.help).toBe(true);
+    expect(result.flags.version).toBe(true);
+  });
+
+  test("empty positional array by default", () => {
+    const result = parse("list");
+    expect(result.positional).toEqual([]);
+  });
+
+  test("--yes without uninstall still parses", () => {
+    const result = parse("list", "--yes");
+    expect(result.flags.yes).toBe(true);
+    expect(result.command).toBe("list");
+  });
+});
+
+// ─── isCLIMode unit tests ──────────────────────────────────────────────────
+
+describe("isCLIMode", () => {
+  const check = (...args: string[]) => isCLIMode(["bun", "script.ts", ...args]);
+
+  test("no args → not CLI mode", () => {
+    expect(check()).toBe(false);
+  });
+
+  test("list → CLI mode", () => {
+    expect(check("list")).toBe(true);
+  });
+
+  test("search → CLI mode", () => {
+    expect(check("search")).toBe(true);
+  });
+
+  test("inspect → CLI mode", () => {
+    expect(check("inspect")).toBe(true);
+  });
+
+  test("uninstall → CLI mode", () => {
+    expect(check("uninstall")).toBe(true);
+  });
+
+  test("config → CLI mode", () => {
+    expect(check("config")).toBe(true);
+  });
+
+  test("--help → CLI mode", () => {
+    expect(check("--help")).toBe(true);
+  });
+
+  test("-h → CLI mode", () => {
+    expect(check("-h")).toBe(true);
+  });
+
+  test("--version → CLI mode", () => {
+    expect(check("--version")).toBe(true);
+  });
+
+  test("-v → CLI mode", () => {
+    expect(check("-v")).toBe(true);
+  });
+
+  test("unknown command → CLI mode (will error)", () => {
+    expect(check("foobar")).toBe(true);
+  });
+
+  test("unknown flag → CLI mode (will error)", () => {
+    expect(check("--unknown")).toBe(true);
+  });
+
+  test("single-char flag → CLI mode", () => {
+    expect(check("-x")).toBe(true);
+  });
+});
+
+// ─── runCLI integration tests (subprocess) ─────────────────────────────────
+
+describe("CLI integration: --version", () => {
+  test("prints version and exits 0", async () => {
+    const { stdout, exitCode } = await runCLI("--version");
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/^asm v\d+\.\d+\.\d+/);
+  });
+
+  test("-v is alias for --version", async () => {
+    const { stdout, exitCode } = await runCLI("-v");
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/^asm v\d+\.\d+\.\d+/);
+  });
+});
+
+describe("CLI integration: --help", () => {
+  test("prints help and exits 0", async () => {
+    const { stdout, exitCode } = await runCLI("--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("agent-skill-manager");
+    expect(stdout).toContain("asm");
+    expect(stdout).toContain("Commands:");
+    expect(stdout).toContain("list");
+    expect(stdout).toContain("search");
+    expect(stdout).toContain("inspect");
+    expect(stdout).toContain("uninstall");
+    expect(stdout).toContain("config");
+  });
+
+  test("-h is alias for --help", async () => {
+    const { stdout, exitCode } = await runCLI("-h");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Commands:");
+  });
+
+  test("help includes global options", async () => {
+    const { stdout } = await runCLI("--help");
+    expect(stdout).toContain("--json");
+    expect(stdout).toContain("--scope");
+    expect(stdout).toContain("--sort");
+    expect(stdout).toContain("--no-color");
+    expect(stdout).toContain("--yes");
+  });
+});
+
+describe("CLI integration: per-command --help", () => {
+  test("list --help shows list usage", async () => {
+    const { stdout, exitCode } = await runCLI("list", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("asm list");
+    expect(stdout).toContain("--sort");
+    expect(stdout).toContain("--json");
+  });
+
+  test("search --help shows search usage", async () => {
+    const { stdout, exitCode } = await runCLI("search", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("asm search");
+    expect(stdout).toContain("<query>");
+  });
+
+  test("inspect --help shows inspect usage", async () => {
+    const { stdout, exitCode } = await runCLI("inspect", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("asm inspect");
+    expect(stdout).toContain("<skill-name>");
+  });
+
+  test("uninstall --help shows uninstall usage", async () => {
+    const { stdout, exitCode } = await runCLI("uninstall", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("asm uninstall");
+    expect(stdout).toContain("--yes");
+  });
+
+  test("config --help shows config subcommands", async () => {
+    const { stdout, exitCode } = await runCLI("config", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("asm config");
+    expect(stdout).toContain("show");
+    expect(stdout).toContain("path");
+    expect(stdout).toContain("reset");
+    expect(stdout).toContain("edit");
+  });
+});
+
+describe("CLI integration: unknown command", () => {
+  test("exits 2 with error message", async () => {
+    const { stderr, exitCode } = await runCLI("foobar");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain('Unknown command: "foobar"');
+    expect(stderr).toContain("asm --help");
+  });
+});
+
+describe("CLI integration: unknown option", () => {
+  test("exits 2 with error message", async () => {
+    const { stderr, exitCode } = await runCLI("--bogus");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Unknown option: --bogus");
+  });
+});
+
+describe("CLI integration: invalid --scope", () => {
+  test("exits 2 with error for bad scope value", async () => {
+    const { stderr, exitCode } = await runCLI("list", "--scope", "invalid");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Invalid scope");
+  });
+});
+
+describe("CLI integration: invalid --sort", () => {
+  test("exits 2 with error for bad sort value", async () => {
+    const { stderr, exitCode } = await runCLI("list", "--sort", "invalid");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Invalid sort");
+  });
+});
+
+describe("CLI integration: list", () => {
+  test("lists skills as table", async () => {
+    const { stdout, exitCode } = await runCLI("list");
+    expect(exitCode).toBe(0);
+    // Should have header row
+    expect(stdout).toContain("Name");
+    expect(stdout).toContain("Version");
+    expect(stdout).toContain("Provider");
+  });
+
+  test("lists skills as JSON with --json", async () => {
+    const { stdout, exitCode } = await runCLI("list", "--json");
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(Array.isArray(data)).toBe(true);
+    if (data.length > 0) {
+      expect(data[0]).toHaveProperty("name");
+      expect(data[0]).toHaveProperty("version");
+      expect(data[0]).toHaveProperty("path");
+    }
+  });
+
+  test("--scope global filters to global only", async () => {
+    const { stdout, exitCode } = await runCLI(
+      "list",
+      "--scope",
+      "global",
+      "--json",
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    for (const skill of data) {
+      expect(skill.scope).toBe("global");
+    }
+  });
+
+  test("--scope project filters to project only", async () => {
+    const { stdout, exitCode } = await runCLI(
+      "list",
+      "--scope",
+      "project",
+      "--json",
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    for (const skill of data) {
+      expect(skill.scope).toBe("project");
+    }
+  });
+
+  test("--sort version sorts by version", async () => {
+    const { stdout, exitCode } = await runCLI(
+      "list",
+      "--sort",
+      "version",
+      "--json",
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    if (data.length > 1) {
+      for (let i = 1; i < data.length; i++) {
+        expect(data[i].version >= data[i - 1].version).toBe(true);
+      }
+    }
+  });
+});
+
+describe("CLI integration: search", () => {
+  test("missing query exits 2", async () => {
+    const { stderr, exitCode } = await runCLI("search");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Missing required argument");
+  });
+
+  test("search returns filtered results", async () => {
+    const { stdout, exitCode } = await runCLI("search", "code-review");
+    expect(exitCode).toBe(0);
+    // Every output line (after header/separator) should relate to code-review
+    const lines = stdout.split("\n").slice(2); // skip header and separator
+    for (const line of lines) {
+      if (line.trim()) {
+        expect(line.toLowerCase()).toContain("code-review");
+      }
+    }
+  });
+
+  test("search with --json returns JSON array", async () => {
+    const { stdout, exitCode } = await runCLI(
+      "search",
+      "code-review",
+      "--json",
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  test("search with no matches returns empty table", async () => {
+    const { stdout, exitCode } = await runCLI(
+      "search",
+      "zzz-nonexistent-skill-xyz-99999",
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("No skills found.");
+  });
+
+  test("search with no matches returns empty JSON array", async () => {
+    const { stdout, exitCode } = await runCLI(
+      "search",
+      "zzz-nonexistent-skill-xyz-99999",
+      "--json",
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data).toEqual([]);
+  });
+});
+
+describe("CLI integration: inspect", () => {
+  test("missing skill name exits 2", async () => {
+    const { stderr, exitCode } = await runCLI("inspect");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Missing required argument");
+  });
+
+  test("non-existent skill exits 1", async () => {
+    const { stderr, exitCode } = await runCLI(
+      "inspect",
+      "zzz-nonexistent-skill-xyz-99999",
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("not found");
+  });
+
+  test("inspect --json returns JSON", async () => {
+    // Use a skill likely to exist from list
+    const listResult = await runCLI("list", "--json");
+    const skills = JSON.parse(listResult.stdout);
+    if (skills.length === 0) return; // skip if no skills
+
+    const { stdout, exitCode } = await runCLI(
+      "inspect",
+      skills[0].dirName,
+      "--json",
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    // Could be object or array depending on number of matches
+    if (Array.isArray(data)) {
+      expect(data[0]).toHaveProperty("name");
+    } else {
+      expect(data).toHaveProperty("name");
+    }
+  });
+
+  test("inspect shows detail fields", async () => {
+    const listResult = await runCLI("list", "--json");
+    const skills = JSON.parse(listResult.stdout);
+    if (skills.length === 0) return;
+
+    const { stdout, exitCode } = await runCLI("inspect", skills[0].dirName);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Name:");
+    expect(stdout).toContain("Version:");
+    expect(stdout).toContain("Provider:");
+    expect(stdout).toContain("Scope:");
+    expect(stdout).toContain("Path:");
+  });
+});
+
+describe("CLI integration: uninstall", () => {
+  test("missing skill name exits 2", async () => {
+    const { stderr, exitCode } = await runCLI("uninstall");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Missing required argument");
+  });
+
+  test("non-existent skill exits 1", async () => {
+    const { stderr, exitCode } = await runCLI(
+      "uninstall",
+      "zzz-nonexistent-skill-xyz-99999",
+      "--yes",
+    );
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("not found");
+  });
+});
+
+describe("CLI integration: config", () => {
+  test("config show prints valid JSON", async () => {
+    const { stdout, exitCode } = await runCLI("config", "show");
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(data).toHaveProperty("version");
+    expect(data).toHaveProperty("providers");
+    expect(Array.isArray(data.providers)).toBe(true);
+  });
+
+  test("config path prints a file path", async () => {
+    const { stdout, exitCode } = await runCLI("config", "path");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("config.json");
+    expect(stdout).toContain("agent-skill-manager");
+  });
+
+  test("config with no subcommand exits 2", async () => {
+    const { stderr, exitCode } = await runCLI("config");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Missing subcommand");
+  });
+
+  test("config with unknown subcommand exits 2", async () => {
+    const { stderr, exitCode } = await runCLI("config", "bogus");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Unknown config subcommand");
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,488 @@
+import {
+  loadConfig,
+  getConfigPath,
+  getDefaultConfig,
+  saveConfig,
+} from "./config";
+import { scanAllSkills, searchSkills, sortSkills } from "./scanner";
+import {
+  buildFullRemovalPlan,
+  executeRemoval,
+  getExistingTargets,
+} from "./uninstaller";
+import {
+  formatSkillTable,
+  formatSkillDetail,
+  formatJSON,
+  ansi,
+} from "./formatter";
+import { VERSION_STRING } from "./utils/version";
+import type { Scope, SortBy } from "./utils/types";
+
+// ─── Arg Parser ─────────────────────────────────────────────────────────────
+
+interface ParsedArgs {
+  command: string | null;
+  subcommand: string | null;
+  positional: string[];
+  flags: {
+    help: boolean;
+    version: boolean;
+    json: boolean;
+    yes: boolean;
+    noColor: boolean;
+    scope: Scope;
+    sort: SortBy;
+  };
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const args = argv.slice(2); // skip bun and script path
+
+  const result: ParsedArgs = {
+    command: null,
+    subcommand: null,
+    positional: [],
+    flags: {
+      help: false,
+      version: false,
+      json: false,
+      yes: false,
+      noColor: false,
+      scope: "both",
+      sort: "name",
+    },
+  };
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    // Flags
+    if (arg === "--help" || arg === "-h") {
+      result.flags.help = true;
+    } else if (arg === "--version" || arg === "-v") {
+      result.flags.version = true;
+    } else if (arg === "--json") {
+      result.flags.json = true;
+    } else if (arg === "--yes" || arg === "-y") {
+      result.flags.yes = true;
+    } else if (arg === "--no-color") {
+      result.flags.noColor = true;
+    } else if (arg === "--scope" || arg === "-s") {
+      i++;
+      const val = args[i];
+      if (val === "global" || val === "project" || val === "both") {
+        result.flags.scope = val;
+      } else {
+        error(`Invalid scope: "${val}". Must be global, project, or both.`);
+        process.exit(2);
+      }
+    } else if (arg === "--sort") {
+      i++;
+      const val = args[i];
+      if (val === "name" || val === "version" || val === "location") {
+        result.flags.sort = val;
+      } else {
+        error(`Invalid sort: "${val}". Must be name, version, or location.`);
+        process.exit(2);
+      }
+    } else if (arg.startsWith("-")) {
+      error(`Unknown option: ${arg}`);
+      console.error(`Run "asm --help" for usage.`);
+      process.exit(2);
+    } else {
+      // Positional: first is command, second is subcommand, rest are positional args
+      if (!result.command) {
+        result.command = arg;
+      } else if (!result.subcommand) {
+        result.subcommand = arg;
+      } else {
+        result.positional.push(arg);
+      }
+    }
+
+    i++;
+  }
+
+  return result;
+}
+
+// ─── Output helpers ─────────────────────────────────────────────────────────
+
+function error(msg: string) {
+  console.error(ansi.red(`Error: ${msg}`));
+}
+
+// ─── Help text ──────────────────────────────────────────────────────────────
+
+function printMainHelp() {
+  console.log(`${ansi.blueBold("agent-skill-manager")} (${ansi.bold("asm")}) ${VERSION_STRING}
+
+Interactive TUI and CLI for managing installed skills for AI coding agents.
+
+${ansi.bold("Usage:")}
+  asm                        Launch interactive TUI
+  asm <command> [options]     Run a CLI command
+
+${ansi.bold("Commands:")}
+  list                   List all discovered skills
+  search <query>         Search skills by name/description/provider
+  inspect <skill-name>   Show detailed info for a skill
+  uninstall <skill-name> Remove a skill (with confirmation)
+  config show            Print current config
+  config path            Print config file path
+  config reset           Reset config to defaults
+  config edit            Open config in $EDITOR
+
+${ansi.bold("Global Options:")}
+  -h, --help             Show help for any command
+  -v, --version          Print version and exit
+  --json                 Output as JSON (list, search, inspect)
+  -s, --scope <scope>    Filter: global, project, or both (default: both)
+  --no-color             Disable ANSI colors
+  --sort <field>         Sort by: name, version, or location (default: name)
+  -y, --yes              Skip confirmation prompts`);
+}
+
+function printListHelp() {
+  console.log(`${ansi.bold("Usage:")} asm list [options]
+
+List all discovered skills.
+
+${ansi.bold("Options:")}
+  --sort <field>     Sort by: name, version, or location (default: name)
+  -s, --scope <s>    Filter: global, project, or both (default: both)
+  --json             Output as JSON array
+  --no-color         Disable ANSI colors`);
+}
+
+function printSearchHelp() {
+  console.log(`${ansi.bold("Usage:")} asm search <query> [options]
+
+Search skills by name, description, or provider.
+
+${ansi.bold("Options:")}
+  --sort <field>     Sort by: name, version, or location (default: name)
+  -s, --scope <s>    Filter: global, project, or both (default: both)
+  --json             Output as JSON array
+  --no-color         Disable ANSI colors`);
+}
+
+function printInspectHelp() {
+  console.log(`${ansi.bold("Usage:")} asm inspect <skill-name> [options]
+
+Show detailed information for a skill. The <skill-name> is the directory name.
+
+${ansi.bold("Options:")}
+  -s, --scope <s>    Filter: global, project, or both (default: both)
+  --json             Output as JSON object
+  --no-color         Disable ANSI colors`);
+}
+
+function printUninstallHelp() {
+  console.log(`${ansi.bold("Usage:")} asm uninstall <skill-name> [options]
+
+Remove a skill and its associated rule files.
+
+${ansi.bold("Options:")}
+  -y, --yes          Skip confirmation prompt
+  -s, --scope <s>    Filter: global, project, or both (default: both)
+  --no-color         Disable ANSI colors`);
+}
+
+function printConfigHelp() {
+  console.log(`${ansi.bold("Usage:")} asm config <subcommand>
+
+Manage configuration.
+
+${ansi.bold("Subcommands:")}
+  show     Print current config as JSON
+  path     Print config file path
+  reset    Reset config to defaults (with confirmation)
+  edit     Open config in $EDITOR`);
+}
+
+// ─── Command Handlers ───────────────────────────────────────────────────────
+
+async function cmdList(args: ParsedArgs) {
+  if (args.flags.help) {
+    printListHelp();
+    return;
+  }
+
+  const config = await loadConfig();
+  const allSkills = await scanAllSkills(config, args.flags.scope);
+  const sorted = sortSkills(allSkills, args.flags.sort);
+
+  if (args.flags.json) {
+    console.log(formatJSON(sorted));
+  } else {
+    console.log(formatSkillTable(sorted));
+  }
+}
+
+async function cmdSearch(args: ParsedArgs) {
+  if (args.flags.help) {
+    printSearchHelp();
+    return;
+  }
+
+  const query = args.subcommand;
+  if (!query) {
+    error("Missing required argument: <query>");
+    console.error(`Run "asm search --help" for usage.`);
+    process.exit(2);
+  }
+
+  const config = await loadConfig();
+  const allSkills = await scanAllSkills(config, args.flags.scope);
+  const filtered = searchSkills(allSkills, query);
+  const sorted = sortSkills(filtered, args.flags.sort);
+
+  if (args.flags.json) {
+    console.log(formatJSON(sorted));
+  } else {
+    console.log(formatSkillTable(sorted));
+  }
+}
+
+async function cmdInspect(args: ParsedArgs) {
+  if (args.flags.help) {
+    printInspectHelp();
+    return;
+  }
+
+  const skillName = args.subcommand;
+  if (!skillName) {
+    error("Missing required argument: <skill-name>");
+    console.error(`Run "asm inspect --help" for usage.`);
+    process.exit(2);
+  }
+
+  const config = await loadConfig();
+  const allSkills = await scanAllSkills(config, args.flags.scope);
+  const matches = allSkills.filter((s) => s.dirName === skillName);
+
+  if (matches.length === 0) {
+    error(`Skill "${skillName}" not found.`);
+    process.exit(1);
+  }
+
+  if (args.flags.json) {
+    console.log(formatJSON(matches.length === 1 ? matches[0] : matches));
+  } else {
+    for (let i = 0; i < matches.length; i++) {
+      if (i > 0) console.log("\n" + "─".repeat(40) + "\n");
+      console.log(formatSkillDetail(matches[i]));
+    }
+  }
+}
+
+async function cmdUninstall(args: ParsedArgs) {
+  if (args.flags.help) {
+    printUninstallHelp();
+    return;
+  }
+
+  const skillName = args.subcommand;
+  if (!skillName) {
+    error("Missing required argument: <skill-name>");
+    console.error(`Run "asm uninstall --help" for usage.`);
+    process.exit(2);
+  }
+
+  const config = await loadConfig();
+  const allSkills = await scanAllSkills(config, args.flags.scope);
+  const plan = buildFullRemovalPlan(skillName, allSkills, config);
+
+  const existing = await getExistingTargets(plan);
+  if (existing.length === 0) {
+    error(`Skill "${skillName}" not found or nothing to remove.`);
+    process.exit(1);
+  }
+
+  // Show removal plan
+  console.error(ansi.bold("Removal plan:"));
+  for (const target of existing) {
+    console.error(`  ${ansi.red("•")} ${target}`);
+  }
+
+  if (!args.flags.yes) {
+    // Interactive confirmation
+    if (!process.stdin.isTTY) {
+      error(
+        "Cannot prompt for confirmation in non-interactive mode. Use --yes to skip.",
+      );
+      process.exit(2);
+    }
+    process.stderr.write(`\n${ansi.bold("Proceed with removal?")} [y/N] `);
+    const answer = await readLine();
+    if (answer.toLowerCase() !== "y" && answer.toLowerCase() !== "yes") {
+      console.error("Aborted.");
+      process.exit(0);
+    }
+  }
+
+  const log = await executeRemoval(plan);
+  for (const entry of log) {
+    console.error(entry);
+  }
+  console.error(ansi.green("\nDone."));
+}
+
+function readLine(): Promise<string> {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf-8");
+    process.stdin.on("data", (chunk: string) => {
+      data += chunk;
+      if (data.includes("\n")) {
+        process.stdin.removeAllListeners("data");
+        resolve(data.trim());
+      }
+    });
+    process.stdin.resume();
+  });
+}
+
+async function cmdConfig(args: ParsedArgs) {
+  if (args.flags.help) {
+    printConfigHelp();
+    return;
+  }
+
+  const sub = args.subcommand;
+
+  if (!sub) {
+    error("Missing subcommand. Use: show, path, reset, or edit.");
+    console.error(`Run "asm config --help" for usage.`);
+    process.exit(2);
+  }
+
+  switch (sub) {
+    case "show": {
+      const config = await loadConfig();
+      console.log(formatJSON(config));
+      break;
+    }
+    case "path": {
+      console.log(getConfigPath());
+      break;
+    }
+    case "reset": {
+      if (!args.flags.yes) {
+        if (!process.stdin.isTTY) {
+          error(
+            "Cannot prompt for confirmation in non-interactive mode. Use --yes to skip.",
+          );
+          process.exit(2);
+        }
+        process.stderr.write(
+          `${ansi.bold("Reset config to defaults?")} [y/N] `,
+        );
+        const answer = await readLine();
+        if (answer.toLowerCase() !== "y" && answer.toLowerCase() !== "yes") {
+          console.error("Aborted.");
+          process.exit(0);
+        }
+      }
+      const defaults = getDefaultConfig();
+      await saveConfig(defaults);
+      console.error(ansi.green("Config reset to defaults."));
+      break;
+    }
+    case "edit": {
+      const editor = process.env.VISUAL || process.env.EDITOR || "vi";
+      const configPath = getConfigPath();
+      // Ensure config file exists
+      await loadConfig();
+      const proc = Bun.spawn([editor, configPath], {
+        stdin: "inherit",
+        stdout: "inherit",
+        stderr: "inherit",
+      });
+      await proc.exited;
+      break;
+    }
+    default: {
+      error(
+        `Unknown config subcommand: "${sub}". Use: show, path, reset, or edit.`,
+      );
+      process.exit(2);
+    }
+  }
+}
+
+// ─── Main CLI dispatcher ────────────────────────────────────────────────────
+
+export async function runCLI(argv: string[]): Promise<void> {
+  const args = parseArgs(argv);
+
+  // Apply --no-color
+  if (args.flags.noColor) {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  }
+
+  // --version at top level
+  if (args.flags.version) {
+    console.log(`asm ${VERSION_STRING}`);
+    return;
+  }
+
+  // --help at top level (no command)
+  if (!args.command && args.flags.help) {
+    printMainHelp();
+    return;
+  }
+
+  // No command → return null to signal TUI launch
+  if (!args.command) {
+    return;
+  }
+
+  switch (args.command) {
+    case "list":
+      await cmdList(args);
+      break;
+    case "search":
+      await cmdSearch(args);
+      break;
+    case "inspect":
+      await cmdInspect(args);
+      break;
+    case "uninstall":
+      await cmdUninstall(args);
+      break;
+    case "config":
+      await cmdConfig(args);
+      break;
+    default:
+      error(`Unknown command: "${args.command}"`);
+      console.error(`Run "asm --help" for usage.`);
+      process.exit(2);
+  }
+}
+
+// ─── Check if CLI mode should run ──────────────────────────────────────────
+
+export function isCLIMode(argv: string[]): boolean {
+  const args = argv.slice(2);
+  if (args.length === 0) return false;
+
+  // Known commands
+  const commands = ["list", "search", "inspect", "uninstall", "config"];
+  const first = args[0];
+
+  // If the first arg is a known command, it's CLI mode
+  if (commands.includes(first)) return true;
+
+  // --help and --version are handled in CLI mode too
+  if (first === "--help" || first === "-h") return true;
+  if (first === "--version" || first === "-v") return true;
+
+  // Unknown flags/commands → CLI mode (will show error)
+  if (first.startsWith("-") || first.length > 0) return true;
+
+  return false;
+}

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -1,0 +1,304 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  formatSkillTable,
+  formatSkillDetail,
+  formatJSON,
+  ansi,
+} from "./formatter";
+import type { SkillInfo } from "./utils/types";
+
+function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
+  return {
+    name: "test-skill",
+    version: "1.0.0",
+    description: "A test skill",
+    dirName: "test-skill",
+    path: "/home/user/.claude/skills/test-skill",
+    originalPath: "~/.claude/skills/test-skill",
+    location: "global-claude",
+    scope: "global",
+    provider: "claude",
+    providerLabel: "Claude Code",
+    isSymlink: false,
+    symlinkTarget: null,
+    fileCount: 3,
+    ...overrides,
+  };
+}
+
+// ─── formatSkillTable ──────────────────────────────────────────────────────
+
+describe("formatSkillTable", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("returns 'No skills found.' for empty array", () => {
+    expect(formatSkillTable([])).toBe("No skills found.");
+  });
+
+  test("formats a single skill as table", () => {
+    const output = formatSkillTable([makeSkill()]);
+    expect(output).toContain("Name");
+    expect(output).toContain("Version");
+    expect(output).toContain("Provider");
+    expect(output).toContain("test-skill");
+    expect(output).toContain("1.0.0");
+    expect(output).toContain("Claude Code");
+    expect(output).toContain("global");
+    expect(output).toContain("directory");
+  });
+
+  test("marks symlinks correctly", () => {
+    const output = formatSkillTable([makeSkill({ isSymlink: true })]);
+    expect(output).toContain("symlink");
+  });
+
+  test("formats multiple skills with aligned columns", () => {
+    const skills = [
+      makeSkill({ name: "short" }),
+      makeSkill({ name: "a-much-longer-name", version: "2.0.0" }),
+    ];
+    const output = formatSkillTable(skills);
+    const lines = output.split("\n");
+    // Header + separator + 2 data lines
+    expect(lines.length).toBe(4);
+  });
+
+  test("includes separator line", () => {
+    const output = formatSkillTable([makeSkill()]);
+    const lines = output.split("\n");
+    expect(lines[1]).toMatch(/^─+/);
+  });
+
+  test("shows all six columns", () => {
+    const output = formatSkillTable([makeSkill()]);
+    const headerLine = output.split("\n")[0];
+    expect(headerLine).toContain("Name");
+    expect(headerLine).toContain("Version");
+    expect(headerLine).toContain("Provider");
+    expect(headerLine).toContain("Scope");
+    expect(headerLine).toContain("Type");
+    expect(headerLine).toContain("Path");
+  });
+
+  test("column widths accommodate long values", () => {
+    const longName = "a-very-long-skill-name-that-exceeds-header";
+    const output = formatSkillTable([makeSkill({ name: longName })]);
+    const lines = output.split("\n");
+    // Data line should contain the full long name without truncation
+    expect(lines[2]).toContain(longName);
+    // The separator line should be wider than a short-name table
+    const shortOutput = formatSkillTable([makeSkill({ name: "x" })]);
+    const shortSep = shortOutput.split("\n")[1].length;
+    expect(lines[1].length).toBeGreaterThan(shortSep);
+  });
+
+  test("shows project scope in scope column", () => {
+    const output = formatSkillTable([makeSkill({ scope: "project" })]);
+    expect(output).toContain("project");
+  });
+
+  test("formats three skills with correct line count", () => {
+    const skills = [
+      makeSkill({ name: "a" }),
+      makeSkill({ name: "b" }),
+      makeSkill({ name: "c" }),
+    ];
+    const output = formatSkillTable(skills);
+    const lines = output.split("\n");
+    expect(lines.length).toBe(5); // header + separator + 3 data
+  });
+});
+
+// ─── formatSkillDetail ─────────────────────────────────────────────────────
+
+describe("formatSkillDetail", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("includes all fields", () => {
+    const output = formatSkillDetail(makeSkill());
+    expect(output).toContain("Name: test-skill");
+    expect(output).toContain("Version: 1.0.0");
+    expect(output).toContain("Provider: Claude Code");
+    expect(output).toContain("Scope: global");
+    expect(output).toContain("Location: global-claude");
+    expect(output).toContain("File Count: 3");
+    expect(output).toContain("Type: directory");
+    expect(output).toContain("Description: A test skill");
+  });
+
+  test("shows symlink target when symlink", () => {
+    const output = formatSkillDetail(
+      makeSkill({ isSymlink: true, symlinkTarget: "/opt/skills/test" }),
+    );
+    expect(output).toContain("Type: symlink");
+    expect(output).toContain("Symlink Target: /opt/skills/test");
+  });
+
+  test("omits symlink target when not symlink", () => {
+    const output = formatSkillDetail(makeSkill());
+    expect(output).not.toContain("Symlink Target");
+  });
+
+  test("omits symlink target when symlink but target is null", () => {
+    const output = formatSkillDetail(
+      makeSkill({ isSymlink: true, symlinkTarget: null }),
+    );
+    expect(output).toContain("Type: symlink");
+    expect(output).not.toContain("Symlink Target");
+  });
+
+  test("omits description section when empty", () => {
+    const output = formatSkillDetail(makeSkill({ description: "" }));
+    expect(output).not.toContain("Description:");
+  });
+
+  test("shows project scope", () => {
+    const output = formatSkillDetail(makeSkill({ scope: "project" }));
+    expect(output).toContain("Scope: project");
+  });
+
+  test("shows zero file count", () => {
+    const output = formatSkillDetail(makeSkill({ fileCount: 0 }));
+    expect(output).toContain("File Count: 0");
+  });
+
+  test("shows large file count", () => {
+    const output = formatSkillDetail(makeSkill({ fileCount: 12345 }));
+    expect(output).toContain("File Count: 12345");
+  });
+
+  test("description appears after a blank line", () => {
+    const output = formatSkillDetail(makeSkill({ description: "Some desc" }));
+    const lines = output.split("\n");
+    const descIndex = lines.findIndex((l) => l.includes("Description:"));
+    // There should be a blank line before the description
+    expect(lines[descIndex - 1]).toBe("");
+  });
+});
+
+// ─── formatJSON ────────────────────────────────────────────────────────────
+
+describe("formatJSON", () => {
+  test("formats array as pretty JSON", () => {
+    const data = [{ a: 1 }, { b: 2 }];
+    expect(formatJSON(data)).toBe(JSON.stringify(data, null, 2));
+  });
+
+  test("formats object as pretty JSON", () => {
+    const data = { name: "test", version: "1.0.0" };
+    expect(formatJSON(data)).toBe(JSON.stringify(data, null, 2));
+  });
+
+  test("formats empty array", () => {
+    expect(formatJSON([])).toBe("[]");
+  });
+
+  test("formats empty object", () => {
+    expect(formatJSON({})).toBe("{}");
+  });
+
+  test("formats null", () => {
+    expect(formatJSON(null)).toBe("null");
+  });
+
+  test("formats string", () => {
+    expect(formatJSON("hello")).toBe('"hello"');
+  });
+
+  test("formats nested objects", () => {
+    const data = { a: { b: { c: 1 } } };
+    expect(formatJSON(data)).toBe(JSON.stringify(data, null, 2));
+  });
+});
+
+// ─── ansi helpers ──────────────────────────────────────────────────────────
+
+describe("ansi helpers (with color disabled)", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("bold returns plain text when color disabled", () => {
+    expect(ansi.bold("hello")).toBe("hello");
+  });
+
+  test("cyan returns plain text when color disabled", () => {
+    expect(ansi.cyan("hello")).toBe("hello");
+  });
+
+  test("green returns plain text when color disabled", () => {
+    expect(ansi.green("hello")).toBe("hello");
+  });
+
+  test("yellow returns plain text when color disabled", () => {
+    expect(ansi.yellow("hello")).toBe("hello");
+  });
+
+  test("dim returns plain text when color disabled", () => {
+    expect(ansi.dim("hello")).toBe("hello");
+  });
+
+  test("red returns plain text when color disabled", () => {
+    expect(ansi.red("hello")).toBe("hello");
+  });
+
+  test("blueBold returns plain text when color disabled", () => {
+    expect(ansi.blueBold("hello")).toBe("hello");
+  });
+});
+
+describe("ansi helpers (with NO_COLOR env)", () => {
+  const origNoColor = process.env.NO_COLOR;
+
+  beforeEach(() => {
+    process.env.NO_COLOR = "1";
+  });
+  afterEach(() => {
+    if (origNoColor === undefined) {
+      delete process.env.NO_COLOR;
+    } else {
+      process.env.NO_COLOR = origNoColor;
+    }
+  });
+
+  test("bold returns plain text with NO_COLOR env set", () => {
+    expect(ansi.bold("test")).toBe("test");
+  });
+
+  test("red returns plain text with NO_COLOR env set", () => {
+    expect(ansi.red("test")).toBe("test");
+  });
+});
+
+describe("ansi helpers (empty NO_COLOR)", () => {
+  const origNoColor = process.env.NO_COLOR;
+
+  beforeEach(() => {
+    process.env.NO_COLOR = "";
+  });
+  afterEach(() => {
+    if (origNoColor === undefined) {
+      delete process.env.NO_COLOR;
+    } else {
+      process.env.NO_COLOR = origNoColor;
+    }
+  });
+
+  test("NO_COLOR='' still disables color", () => {
+    // Per spec, NO_COLOR being defined (even empty) disables color
+    expect(ansi.bold("test")).toBe("test");
+  });
+});

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,92 @@
+import type { SkillInfo } from "./utils/types";
+
+// ─── Color helpers ──────────────────────────────────────────────────────────
+
+const useColor = (): boolean => {
+  if (process.env.NO_COLOR !== undefined) return false;
+  if ((globalThis as any).__CLI_NO_COLOR) return false;
+  if (!process.stdout.isTTY) return false;
+  return true;
+};
+
+const ansi = {
+  bold: (s: string) => (useColor() ? `\x1b[1m${s}\x1b[0m` : s),
+  cyan: (s: string) => (useColor() ? `\x1b[36m${s}\x1b[0m` : s),
+  green: (s: string) => (useColor() ? `\x1b[32m${s}\x1b[0m` : s),
+  yellow: (s: string) => (useColor() ? `\x1b[33m${s}\x1b[0m` : s),
+  dim: (s: string) => (useColor() ? `\x1b[2m${s}\x1b[0m` : s),
+  red: (s: string) => (useColor() ? `\x1b[31m${s}\x1b[0m` : s),
+  blueBold: (s: string) => (useColor() ? `\x1b[1m\x1b[34m${s}\x1b[0m` : s),
+};
+
+export { ansi };
+
+// ─── Table formatter ────────────────────────────────────────────────────────
+
+export function formatSkillTable(skills: SkillInfo[]): string {
+  if (skills.length === 0) {
+    return "No skills found.";
+  }
+
+  const headers = ["Name", "Version", "Provider", "Scope", "Type", "Path"];
+
+  const rows = skills.map((s) => [
+    s.name,
+    s.version,
+    s.providerLabel,
+    s.scope,
+    s.isSymlink ? "symlink" : "directory",
+    s.path,
+  ]);
+
+  // Calculate column widths
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => r[i].length)),
+  );
+
+  const pad = (str: string, width: number) => str.padEnd(width);
+
+  const headerLine = headers.map((h, i) => pad(h, widths[i])).join("  ");
+  const separator = widths.map((w) => "─".repeat(w)).join("──");
+  const dataLines = rows.map((row) =>
+    row.map((cell, i) => pad(cell, widths[i])).join("  "),
+  );
+
+  return [
+    useColor() ? ansi.bold(headerLine) : headerLine,
+    separator,
+    ...dataLines,
+  ].join("\n");
+}
+
+// ─── Detail formatter ───────────────────────────────────────────────────────
+
+export function formatSkillDetail(skill: SkillInfo): string {
+  const lines: string[] = [];
+  const label = (key: string, value: string) =>
+    `${useColor() ? ansi.bold(key + ":") : key + ":"} ${value}`;
+
+  lines.push(label("Name", skill.name));
+  lines.push(label("Version", skill.version));
+  lines.push(label("Provider", skill.providerLabel));
+  lines.push(label("Scope", skill.scope));
+  lines.push(label("Location", skill.location));
+  lines.push(label("Path", skill.path));
+  lines.push(label("Type", skill.isSymlink ? "symlink" : "directory"));
+  if (skill.isSymlink && skill.symlinkTarget) {
+    lines.push(label("Symlink Target", skill.symlinkTarget));
+  }
+  lines.push(label("File Count", String(skill.fileCount)));
+  if (skill.description) {
+    lines.push("");
+    lines.push(label("Description", skill.description));
+  }
+
+  return lines.join("\n");
+}
+
+// ─── JSON formatter ─────────────────────────────────────────────────────────
+
+export function formatJSON(data: unknown): string {
+  return JSON.stringify(data, null, 2);
+}


### PR DESCRIPTION
## Summary
- Add full non-interactive CLI with commands: `list`, `search`, `inspect`, `uninstall`, `config` (show/path/reset/edit)
- Register `asm` as a short bin alias alongside `agent-skill-manager`
- Zero new dependencies — hand-rolled arg parser reusing existing core modules (scanner, config, uninstaller)
- Support for `--json`, `--scope`, `--sort`, `--no-color`, `NO_COLOR` env, and pipe detection
- Entry point (`bin/skill-manager.ts`) routes to CLI or TUI based on arguments

## Test plan
- [x] 179 tests passing (up from 106), 537 assertions (up from 159)
- [x] Unit tests for `parseArgs` and `isCLIMode` covering all flags, defaults, edge cases
- [x] Unit tests for `formatSkillTable`, `formatSkillDetail`, `formatJSON`, and `ansi` helpers
- [x] Integration tests via subprocess for all commands, per-command `--help`, error exits, invalid args
- [x] Verified manually: `asm list`, `asm search`, `asm inspect`, `asm config show/path`, `asm --help`, `asm --version`