### PR TITLE
fix: guard ingester/audit against local paths and restrict tilde expansion

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -789,6 +789,12 @@ async function cmdAuditSecuritySource(args: ParsedArgs, target: string) {
   try {
     let source = parseSource(target);
 
+    if (source.isLocal) {
+      throw new Error(
+        "Local paths are not supported for remote security audits. Use: asm audit security <installed-skill-name>",
+      );
+    }
+
     await checkGitAvailable();
 
     // Resolve ref/subpath for subfolder URLs

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -34,6 +34,15 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
     return { success: false, repoIndex: null, error: err.message };
   }
 
+  if (source.isLocal) {
+    return {
+      success: false,
+      repoIndex: null,
+      error:
+        "Local paths are not supported for indexing. Use a GitHub source instead.",
+    };
+  }
+
   debug(`ingester: cloning ${source.owner}/${source.repo}`);
 
   let tempDir: string | null = null;

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -1059,8 +1059,11 @@ describe("isLocalPath", () => {
 
   test("detects tilde paths", () => {
     expect(isLocalPath("~/skills/my-skill")).toBe(true);
-    expect(isLocalPath("~user/skills")).toBe(true);
     expect(isLocalPath("~")).toBe(true);
+  });
+
+  test("does not match ~user syntax (unsupported shell expansion)", () => {
+    expect(isLocalPath("~user/skills")).toBe(false);
   });
 
   test("detects bare dot and double dot", () => {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -46,7 +46,8 @@ export function isLocalPath(input: string): boolean {
     input.startsWith("/") ||
     input.startsWith("./") ||
     input.startsWith("../") ||
-    input.startsWith("~") ||
+    input.startsWith("~/") ||
+    input === "~" ||
     input === "." ||
     input === ".."
   );
@@ -54,8 +55,10 @@ export function isLocalPath(input: string): boolean {
 
 export function parseLocalSource(input: string): ParsedSource {
   let absPath: string;
-  if (input.startsWith("~")) {
-    absPath = resolve(homedir(), input.slice(input.startsWith("~/") ? 2 : 1));
+  if (input === "~") {
+    absPath = homedir();
+  } else if (input.startsWith("~/")) {
+    absPath = resolve(homedir(), input.slice(2));
   } else {
     absPath = resolve(input);
   }


### PR DESCRIPTION
## Summary

Follow-up fixes from the PR #26 review:

- **Guard `ingestRepo()` against local paths** — `asm index ingest ./path` now returns a clear error instead of attempting to git-clone an empty URL
- **Guard `cmdAuditSecuritySource()` against local paths** — `asm audit security ./path` now throws a helpful error directing users to audit installed skills instead
- **Restrict tilde detection to `~/` and bare `~`** — `~user/path` syntax (shell-only expansion unavailable in Node) is no longer misidentified as a local path
- **Updated tests** to match corrected tilde behavior

## Test plan

- [x] All 664 tests pass
- [x] `isLocalPath("~user/skills")` now returns `false`
- [x] `isLocalPath("~/skills")` and `isLocalPath("~")` still return `true`