### PR TITLE
Fix: change shebang to node for npm global install compatibility

### DIFF
--- a/bin/agent-skill-manager.ts
+++ b/bin/agent-skill-manager.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 
 import { isCLIMode, runCLI } from "../src/cli";
 


### PR DESCRIPTION
Closes #30

## Summary

Users installing via `npm install -g agent-skill-manager` on systems without Bun encountered a "no such file or directory" error because the entrypoint shebang was `#!/usr/bin/env bun`. Since the build already targets Node.js (`target: "node"` in the Bun bundler config), the generated JavaScript is fully Node-compatible — only the shebang was wrong.

## Approach

Changed the shebang in `bin/agent-skill-manager.ts` from `#!/usr/bin/env bun` to `#!/usr/bin/env node`. When `bun run build` (or `prepublishOnly`) runs, this propagates to `dist/agent-skill-manager.js`, making the published package runnable with Node.

## Changes

| File | Change |
|------|--------|
| `bin/agent-skill-manager.ts` | Changed shebang from `#!/usr/bin/env bun` to `#!/usr/bin/env node` |

## Test Results

- 674 tests passed, 0 failures
- Verified `node dist/agent-skill-manager.js --version` works correctly
- Verified `node dist/agent-skill-manager.js --help` works correctly

## Acceptance Criteria

- [x] ASM CLI commands execute successfully after `npm install -g` on systems with Node.js (no Bun required)
- [x] The "no such file or directory" error is resolved
- [x] Binary/entrypoint paths are correctly configured in package.json