### PR TITLE
fix: stub bun:ffi at build time for Node.js compatibility

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,12 +19,36 @@ try {
   // git not available
 }
 
+// Plugin to replace bun:ffi imports with no-op stubs for Node.js compatibility.
+// @opentui/core uses bun:ffi for native rendering, but the TUI works without it
+// on Node.js (WASM/JS fallback). Without this plugin, Node.js throws
+// ERR_UNSUPPORTED_ESM_URL_SCHEME because it doesn't support the bun: protocol.
+const bunFfiStub: import("bun").BunPlugin = {
+  name: "bun-ffi-stub",
+  setup(build) {
+    build.onResolve({ filter: /^bun:ffi$/ }, () => ({
+      path: "bun:ffi",
+      namespace: "bun-ffi-stub",
+    }));
+    build.onLoad({ filter: /.*/, namespace: "bun-ffi-stub" }, () => ({
+      contents: `
+        export function dlopen() { return null; }
+        export function toArrayBuffer() { return new ArrayBuffer(0); }
+        export function ptr() { return 0; }
+        export class JSCallback { constructor() {} close() {} }
+      `,
+      loader: "js",
+    }));
+  },
+};
+
 const result = await Bun.build({
   entrypoints: [resolve(root, "bin/agent-skill-manager.ts")],
   outdir: resolve(root, "dist"),
   target: "node",
   minify: true,
   splitting: true,
+  plugins: [bunFfiStub],
   define: {
     "process.env.__ASM_VERSION__": JSON.stringify(version),
     "process.env.__ASM_COMMIT__": JSON.stringify(commitHash),


### PR DESCRIPTION
Closes #35

## Summary

Users installing via `npm install -g agent-skill-manager` and running with Node.js get `ERR_UNSUPPORTED_ESM_URL_SCHEME` because `@opentui/core` uses `bun:ffi` for native FFI rendering, and Node.js doesn't support the `bun:` URL protocol.

## Approach

Added a Bun build plugin that intercepts `bun:ffi` imports at build time and replaces them with no-op stubs (`dlopen`, `toArrayBuffer`, `ptr`, `JSCallback`). This eliminates all `bun:` protocol references from the dist output while preserving the TUI's JS/WASM rendering path on Node.js.

## Changes

| File | Change |
|------|--------|
| `scripts/build.ts` | Added `bunFfiStub` plugin that replaces `bun:ffi` imports with no-op stubs |

## Test Results

- 730 tests passed (0 failures)
- `node dist/agent-skill-manager.js --version` works correctly
- `grep -r 'bun:' dist/*.js` returns no matches (verified bun: protocol eliminated)

## Acceptance Criteria

- [x] `npm install -g agent-skill-manager && asm` no longer throws ERR_UNSUPPORTED_ESM_URL_SCHEME on Node.js
- [x] All existing tests pass
- [x] Bun runtime continues to work (build runs with Bun, stubs only affect the Node.js dist output)