### PR TITLE
Extract curated skill repos into skill-index-resources.json

### DIFF
--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -1,0 +1,104 @@
+{
+  "updatedAt": "2026-03-18T00:00:00Z",
+  "repos": [
+    {
+      "source": "github:anthropics/skills",
+      "url": "https://github.com/anthropics/skills",
+      "owner": "anthropics",
+      "repo": "skills",
+      "description": "Official Agent Skills from Anthropic",
+      "maintainer": "@anthropics",
+      "enabled": true
+    },
+    {
+      "source": "github:obra/superpowers",
+      "url": "https://github.com/obra/superpowers",
+      "owner": "obra",
+      "repo": "superpowers",
+      "description": "Agentic skills framework & development methodology",
+      "maintainer": "@obra",
+      "enabled": true
+    },
+    {
+      "source": "github:affaan-m/everything-claude-code",
+      "url": "https://github.com/affaan-m/everything-claude-code",
+      "owner": "affaan-m",
+      "repo": "everything-claude-code",
+      "description": "Performance optimization system for Claude Code, Codex, and beyond",
+      "maintainer": "@affaan-m",
+      "enabled": true
+    },
+    {
+      "source": "github:msitarzewski/agency-agents",
+      "url": "https://github.com/msitarzewski/agency-agents",
+      "owner": "msitarzewski",
+      "repo": "agency-agents",
+      "description": "Specialized expert agents with personality and proven deliverables",
+      "maintainer": "@msitarzewski",
+      "enabled": true
+    },
+    {
+      "source": "github:nextlevelbuilder/ui-ux-pro-max-skill",
+      "url": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill",
+      "owner": "nextlevelbuilder",
+      "repo": "ui-ux-pro-max-skill",
+      "description": "Design intelligence for building professional UI/UX",
+      "maintainer": "@nextlevelbuilder",
+      "enabled": true
+    },
+    {
+      "source": "github:sickn33/antigravity-awesome-skills",
+      "url": "https://github.com/sickn33/antigravity-awesome-skills",
+      "owner": "sickn33",
+      "repo": "antigravity-awesome-skills",
+      "description": "1,000+ battle-tested skills for Claude Code, Cursor, and more",
+      "maintainer": "@sickn33",
+      "enabled": true
+    },
+    {
+      "source": "github:coreyhaines31/marketingskills",
+      "url": "https://github.com/coreyhaines31/marketingskills",
+      "owner": "coreyhaines31",
+      "repo": "marketingskills",
+      "description": "Marketing skills — CRO, copywriting, SEO, analytics, growth",
+      "maintainer": "@coreyhaines31",
+      "enabled": true
+    },
+    {
+      "source": "github:agentskills/agentskills",
+      "url": "https://github.com/agentskills/agentskills",
+      "owner": "agentskills",
+      "repo": "agentskills",
+      "description": "Specification and documentation for Agent Skills",
+      "maintainer": "@agentskills",
+      "enabled": true
+    },
+    {
+      "source": "github:Leonxlnx/taste-skill",
+      "url": "https://github.com/Leonxlnx/taste-skill",
+      "owner": "Leonxlnx",
+      "repo": "taste-skill",
+      "description": "Gives your AI good taste — stops generic, boring output",
+      "maintainer": "@Leonxlnx",
+      "enabled": true
+    },
+    {
+      "source": "github:Affitor/affiliate-skills",
+      "url": "https://github.com/Affitor/affiliate-skills",
+      "owner": "Affitor",
+      "repo": "affiliate-skills",
+      "description": "Full affiliate marketing funnel: research to deploy",
+      "maintainer": "@Affitor",
+      "enabled": true
+    },
+    {
+      "source": "github:luongnv89/skills",
+      "url": "https://github.com/luongnv89/skills",
+      "owner": "luongnv89",
+      "repo": "skills",
+      "description": "Reusable skills to supercharge your AI agents",
+      "maintainer": "@luongnv89",
+      "enabled": true
+    }
+  ]
+}

--- a/scripts/preindex.ts
+++ b/scripts/preindex.ts
@@ -4,43 +4,40 @@
  * Pre-index script: clones all repos from the curated list and generates
  * index JSON files into data/skill-index/ so they ship with the npm package.
  *
+ * Reads the curated repo list from data/skill-index-resources.json.
+ *
  * Usage: bun run scripts/preindex.ts
  */
 
 import { resolve, join } from "path";
-import { mkdirSync } from "fs";
+import { mkdirSync, readFileSync } from "fs";
 import { copyFile } from "fs/promises";
 import { ingestRepo } from "../src/ingester";
 import { getIndexDir } from "../src/config";
+import type { SkillIndexResources } from "../src/utils/types";
 
 const root = resolve(import.meta.dir, "..");
 const outputDir = resolve(root, "data", "skill-index");
+const resourcesPath = resolve(root, "data", "skill-index-resources.json");
 
-// Curated repos from README — same order as the table
-const CURATED_REPOS = [
-  "github:anthropics/skills",
-  "github:obra/superpowers",
-  "github:affaan-m/everything-claude-code",
-  "github:msitarzewski/agency-agents",
-  "github:nextlevelbuilder/ui-ux-pro-max-skill",
-  "github:sickn33/antigravity-awesome-skills",
-  "github:coreyhaines31/marketingskills",
-  "github:agentskills/agentskills",
-  "github:Leonxlnx/taste-skill",
-  "github:Affitor/affiliate-skills",
-  "github:luongnv89/skills",
-];
+function loadResources(): string[] {
+  const raw = readFileSync(resourcesPath, "utf-8");
+  const data: SkillIndexResources = JSON.parse(raw);
+  return data.repos.filter((r) => r.enabled).map((r) => r.source);
+}
 
 async function main() {
+  const repos = loadResources();
+
   // Ensure output directory exists and is clean
   mkdirSync(outputDir, { recursive: true });
 
-  console.log(`Pre-indexing ${CURATED_REPOS.length} repos into ${outputDir}\n`);
+  console.log(`Pre-indexing ${repos.length} repos into ${outputDir}\n`);
 
   let succeeded = 0;
   let failed = 0;
 
-  for (const repo of CURATED_REPOS) {
+  for (const repo of repos) {
     process.stdout.write(`  ${repo} ... `);
     const result = await ingestRepo(repo);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,11 @@ import { join, resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { homedir } from "os";
 import { debug } from "./logger";
-import type { AppConfig, ProviderConfig } from "./utils/types";
+import type {
+  AppConfig,
+  ProviderConfig,
+  SkillIndexResources,
+} from "./utils/types";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -145,6 +149,16 @@ export function getBundledIndexDir(): string {
   // In built dist/: __dirname is dist/, data/ is at ../data/
   // In dev (src/): __dirname is src/, data/ is at ../data/
   return resolve(__dirname, "..", "data", "skill-index");
+}
+
+export function getSkillIndexResourcesPath(): string {
+  return resolve(__dirname, "..", "data", "skill-index-resources.json");
+}
+
+export async function loadSkillIndexResources(): Promise<SkillIndexResources> {
+  const resourcesPath = getSkillIndexResourcesPath();
+  const raw = await readFile(resourcesPath, "utf-8");
+  return JSON.parse(raw) as SkillIndexResources;
 }
 
 export function resolveProviderPath(pathTemplate: string): string {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -164,6 +164,21 @@ export interface DiscoveredSkill {
 
 // ─── Skill Index Types ───────────────────────────────────────────────────────
 
+export interface SkillIndexResource {
+  source: string;
+  url: string;
+  owner: string;
+  repo: string;
+  description: string;
+  maintainer: string;
+  enabled: boolean;
+}
+
+export interface SkillIndexResources {
+  updatedAt: string;
+  repos: SkillIndexResource[];
+}
+
 export interface IndexedSkill {
   name: string;
   description: string;


### PR DESCRIPTION
Closes #13

## Summary

- Created `data/skill-index-resources.json` as the single source of truth for curated skill repositories, replacing the hardcoded `CURATED_REPOS` array in `scripts/preindex.ts`
- Each repo entry includes `source`, `url`, `owner`, `repo`, `description`, `maintainer`, and `enabled` fields
- Updated `scripts/preindex.ts` to read from the JSON file and filter by `enabled: true`

## Approach

Extracted the hardcoded repo list into a structured JSON file with metadata from the README table. Added shared `SkillIndexResource`/`SkillIndexResources` types to `src/utils/types.ts` and a `loadSkillIndexResources()` helper to `src/config.ts` for future consumers (e.g. `asm index list`, README table generator).

## Changes

| File | Change |
|------|--------|
| `data/skill-index-resources.json` | New — curated repo list with metadata |
| `scripts/preindex.ts` | Reads from JSON instead of hardcoded array |
| `src/utils/types.ts` | Added `SkillIndexResource` and `SkillIndexResources` interfaces |
| `src/config.ts` | Added `getSkillIndexResourcesPath()` and `loadSkillIndexResources()` |

## Test Results

730 tests passed, 0 failed (all existing tests unaffected)

## Acceptance Criteria

- [x] Single source of truth: `data/skill-index-resources.json` with full metadata
- [x] `scripts/preindex.ts` reads from JSON file instead of hardcoded array
- [x] Filters by `enabled: true` to support disabling repos without removal
- [x] Shared types exported for future consumers
- [ ] `scripts/update-readme-table.ts` — deferred to follow-up (README table auto-generation)