### PR TITLE
refactor(config): reorder provider list with prioritized defaults (#95)

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -26,26 +26,28 @@ describe("getDefaultConfig", () => {
     expect(config.providers).toHaveLength(17);
   });
 
-  it("includes all 17 default providers", () => {
+  it("includes all 17 default providers in priority order", () => {
     const config = getDefaultConfig();
     const names = config.providers.map((p) => p.name);
-    expect(names).toContain("claude");
-    expect(names).toContain("codex");
-    expect(names).toContain("openclaw");
-    expect(names).toContain("agents");
-    expect(names).toContain("cursor");
-    expect(names).toContain("windsurf");
-    expect(names).toContain("cline");
-    expect(names).toContain("roocode");
-    expect(names).toContain("continue");
-    expect(names).toContain("copilot");
-    expect(names).toContain("aider");
-    expect(names).toContain("opencode");
-    expect(names).toContain("zed");
-    expect(names).toContain("augment");
-    expect(names).toContain("amp");
-    expect(names).toContain("gemini");
-    expect(names).toContain("antigravity");
+    expect(names).toEqual([
+      "claude",
+      "agents",
+      "codex",
+      "opencode",
+      "openclaw",
+      "cursor",
+      "copilot",
+      "windsurf",
+      "antigravity",
+      "gemini",
+      "cline",
+      "roocode",
+      "continue",
+      "aider",
+      "zed",
+      "augment",
+      "amp",
+    ]);
   });
 
   it("all 17 providers are enabled by default", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,25 +19,12 @@ const LOCK_PATH = join(CONFIG_DIR, ".skill-lock.json");
 const INDEX_DIR = join(CONFIG_DIR, "skill-index");
 
 const DEFAULT_PROVIDERS: ProviderConfig[] = [
+  // ── Priority providers (ordered by usage frequency) ──
   {
     name: "claude",
     label: "Claude Code",
     global: "~/.claude/skills",
     project: ".claude/skills",
-    enabled: true,
-  },
-  {
-    name: "codex",
-    label: "Codex",
-    global: "~/.codex/skills",
-    project: ".codex/skills",
-    enabled: true,
-  },
-  {
-    name: "openclaw",
-    label: "OpenClaw",
-    global: "~/.openclaw/skills",
-    project: ".openclaw/skills",
     enabled: true,
   },
   {
@@ -48,10 +35,38 @@ const DEFAULT_PROVIDERS: ProviderConfig[] = [
     enabled: true,
   },
   {
+    name: "codex",
+    label: "Codex",
+    global: "~/.codex/skills",
+    project: ".codex/skills",
+    enabled: true,
+  },
+  {
+    name: "opencode",
+    label: "OpenCode",
+    global: "~/.config/opencode/skills",
+    project: ".opencode/skills",
+    enabled: true,
+  },
+  {
+    name: "openclaw",
+    label: "OpenClaw",
+    global: "~/.openclaw/skills",
+    project: ".openclaw/skills",
+    enabled: true,
+  },
+  {
     name: "cursor",
     label: "Cursor",
     global: "~/.cursor/rules",
     project: ".cursor/rules",
+    enabled: true,
+  },
+  {
+    name: "copilot",
+    label: "GitHub Copilot",
+    global: "~/.github/instructions",
+    project: ".github/instructions",
     enabled: true,
   },
   {
@@ -61,6 +76,21 @@ const DEFAULT_PROVIDERS: ProviderConfig[] = [
     project: ".windsurf/rules",
     enabled: true,
   },
+  {
+    name: "antigravity",
+    label: "Google Antigravity",
+    global: "~/.antigravity/skills",
+    project: ".antigravity/skills",
+    enabled: true,
+  },
+  {
+    name: "gemini",
+    label: "Gemini CLI",
+    global: "~/.gemini/skills",
+    project: ".gemini/skills",
+    enabled: true,
+  },
+  // ── Remaining providers ──
   {
     name: "cline",
     label: "Cline",
@@ -83,24 +113,10 @@ const DEFAULT_PROVIDERS: ProviderConfig[] = [
     enabled: true,
   },
   {
-    name: "copilot",
-    label: "GitHub Copilot",
-    global: "~/.github/instructions",
-    project: ".github/instructions",
-    enabled: true,
-  },
-  {
     name: "aider",
     label: "Aider",
     global: "~/.aider/skills",
     project: ".aider/skills",
-    enabled: true,
-  },
-  {
-    name: "opencode",
-    label: "OpenCode",
-    global: "~/.config/opencode/skills",
-    project: ".opencode/skills",
     enabled: true,
   },
   {
@@ -122,20 +138,6 @@ const DEFAULT_PROVIDERS: ProviderConfig[] = [
     label: "Amp",
     global: "~/.amp/skills",
     project: ".amp/skills",
-    enabled: true,
-  },
-  {
-    name: "gemini",
-    label: "Gemini CLI",
-    global: "~/.gemini/skills",
-    project: ".gemini/skills",
-    enabled: true,
-  },
-  {
-    name: "antigravity",
-    label: "Google Antigravity",
-    global: "~/.antigravity/skills",
-    project: ".antigravity/skills",
     enabled: true,
   },
 ];

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -864,6 +864,32 @@ describe("resolveProvider", () => {
     expect((capturedItems[2] as { checked: boolean }).checked).toBe(false);
   });
 
+  test("interactive picker: agents provider is checked by default", async () => {
+    const agents: ProviderConfig = {
+      name: "agents",
+      label: "Agents",
+      global: "~/.agents/skills",
+      project: ".agents/skills",
+      enabled: true,
+    };
+    let capturedItems: unknown[] = [];
+    const pickerFn = mock((opts: { items: unknown[] }) => {
+      capturedItems = opts.items;
+      return Promise.resolve([1]); // select agents
+    });
+    mock.module("./utils/checkbox-picker", () => ({
+      checkboxPicker: pickerFn,
+    }));
+
+    const config = makeConfig([claude, agents, codex]);
+    await resolveProvider(config, null, true);
+
+    expect(capturedItems).toHaveLength(3);
+    expect((capturedItems[0] as { checked: boolean }).checked).toBe(false);
+    expect((capturedItems[1] as { checked: boolean }).checked).toBe(true);
+    expect((capturedItems[2] as { checked: boolean }).checked).toBe(false);
+  });
+
   test("interactive picker: all providers disabled shows picker with nothing pre-checked", async () => {
     const allDisabled: ProviderConfig[] = [
       { ...claude, enabled: false },

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -735,11 +735,11 @@ export async function resolveProvider(
     );
   }
 
-  // Interactive picker — show ALL providers, default to deselected
+  // Interactive picker — show ALL providers, "agents" checked by default
   const pickerItems = config.providers.map((p) => ({
     label: `${p.label} (${p.name})`,
     hint: p.global,
-    checked: false,
+    checked: p.name === "agents",
   }));
 
   const selectedIndices = await checkboxPicker({ items: pickerItems });


### PR DESCRIPTION
Closes #95

## Summary

Reorders the provider list displayed at step 2/8 of skill installation to prioritize the most commonly used tools and sets Agents as checked by default. This improves the installation UX by surfacing popular providers first.

## Approach

Reordered the `DEFAULT_PROVIDERS` array in `src/config.ts` to match the specified priority and updated the interactive picker in `src/installer.ts` to default-check the "agents" provider.

## Changes

| File | Change |
|------|--------|
| `src/config.ts` | Reordered `DEFAULT_PROVIDERS` array to priority order: Claude Code, Agents, Codex, OpenCode, OpenClaw, Cursor, GitHub Copilot, Windsurf, Google Antigravity, Gemini CLI, then remaining providers |
| `src/installer.ts` | Updated interactive picker to set `checked: true` for the "agents" provider |
| `src/config.test.ts` | Updated test to verify new provider order using `toEqual` with exact array |
| `src/installer.test.ts` | Added test verifying agents provider is checked by default in picker |

## Test Results

908 tests passed, 0 failed (15,547 expect() calls across 25 files)

## Acceptance Criteria

- [x] At step 2/8 of skill installation, the provider list displays in the specified priority order: Claude Code → Agents → Codex → OpenCode → OpenClaw → Cursor → GitHub Copilot → Windsurf → Google Antigravity → Gemini CLI → remaining providers
- [x] The Agents provider is checked/selected by default when the list is first displayed
- [x] All other providers remain unchecked by default
- [x] Any providers not in the priority list appear after Gemini CLI in their original relative order