### PR TITLE
feat(search): add match count and install hints (#93)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import {
   formatSkillDetail,
   formatSkillInspect,
   formatSearchResults,
+  formatAvailableSearchResults,
   formatJSON,
   ansi,
   colorEffort,
@@ -553,19 +554,18 @@ async function cmdSearch(args: ParsedArgs) {
 
   if (hasAvailable) {
     if (hasInstalled) console.error(""); // separator
-    console.error(ansi.bold(`Available skills matching "${query}":\n`));
-    for (const result of indexResults) {
-      const verifiedTag = result.skill.verified ? ansi.blue(" [verified]") : "";
-      console.error(
-        `${ansi.cyan(result.skill.name)} ${ansi.dim(`v${result.skill.version}`)}${verifiedTag} ${ansi.dim(`[${result.repo.owner}/${result.repo.repo}]`)}`,
-      );
-      for (const dl of wordWrap(result.skill.description, 80)) {
-        console.error(`  ${dl}`);
-      }
-      console.error(
-        `  ${ansi.green(`asm install ${result.skill.installUrl}`)}\n`,
-      );
-    }
+    const availableFormatted = formatAvailableSearchResults(
+      indexResults.map((r) => ({
+        name: r.skill.name,
+        version: r.skill.version,
+        description: r.skill.description,
+        verified: r.skill.verified,
+        repoLabel: `${r.repo.owner}/${r.repo.repo}`,
+        installUrl: r.skill.installUrl,
+      })),
+      query,
+    );
+    console.error(availableFormatted);
   }
 }
 

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -5,6 +5,7 @@ import {
   formatSkillInspect,
   formatGroupedTable,
   formatSearchResults,
+  formatAvailableSearchResults,
   shortenPath,
   colorProvider,
   colorEffort,
@@ -15,6 +16,7 @@ import {
   HIGH_RISK_TOOLS,
   MEDIUM_RISK_TOOLS,
 } from "./formatter";
+import type { AvailableSkillResult } from "./formatter";
 import type { SkillInfo } from "./utils/types";
 
 function makeSkill(overrides: Partial<SkillInfo> = {}): SkillInfo {
@@ -931,5 +933,137 @@ describe("formatSkillDetail with allowedTools", () => {
     const skill = makeSkill({ compatibility: "" });
     const output = await formatSkillDetail(skill);
     expect(output).not.toContain("Compatibility:");
+  });
+});
+
+// ─── formatAvailableSearchResults ──────────────────────────────────────────
+
+function makeAvailableResult(
+  overrides: Partial<AvailableSkillResult> = {},
+): AvailableSkillResult {
+  return {
+    name: "scientific-critical-thinking",
+    version: "1.0.0",
+    description: "A skill for scientific critical thinking",
+    verified: false,
+    repoLabel: "K-Dense-AI/claude-scientific-skills",
+    installUrl:
+      "github:K-Dense-AI/claude-scientific-skills:scientific-critical-thinking",
+    ...overrides,
+  };
+}
+
+describe("formatAvailableSearchResults", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("returns empty string for empty array", () => {
+    expect(formatAvailableSearchResults([], "test")).toBe("");
+  });
+
+  test("shows total count header with singular form", () => {
+    const output = formatAvailableSearchResults(
+      [makeAvailableResult()],
+      "scientific",
+    );
+    expect(output).toContain('Found 1 available skill matching "scientific"');
+  });
+
+  test("shows total count header with plural form", () => {
+    const output = formatAvailableSearchResults(
+      [
+        makeAvailableResult({ name: "skill-a" }),
+        makeAvailableResult({ name: "skill-b" }),
+        makeAvailableResult({ name: "skill-c" }),
+      ],
+      "test",
+    );
+    expect(output).toContain('Found 3 available skills matching "test"');
+  });
+
+  test("shows install command hint before each skill", () => {
+    const output = formatAvailableSearchResults(
+      [makeAvailableResult()],
+      "scientific",
+    );
+    expect(output).toContain("To install:");
+    expect(output).toContain(
+      "asm install github:K-Dense-AI/claude-scientific-skills:scientific-critical-thinking",
+    );
+  });
+
+  test("install hint appears before skill name line", () => {
+    const output = formatAvailableSearchResults(
+      [makeAvailableResult()],
+      "scientific",
+    );
+    const lines = output.split("\n");
+    const installIdx = lines.findIndex((l) => l.includes("To install:"));
+    const nameIdx = lines.findIndex(
+      (l) =>
+        l.includes("scientific-critical-thinking") &&
+        !l.includes("To install:"),
+    );
+    expect(installIdx).toBeGreaterThan(-1);
+    expect(nameIdx).toBeGreaterThan(-1);
+    expect(installIdx).toBeLessThan(nameIdx);
+  });
+
+  test("shows skill name, version, and repo label", () => {
+    const output = formatAvailableSearchResults(
+      [makeAvailableResult()],
+      "scientific",
+    );
+    expect(output).toContain("scientific-critical-thinking");
+    expect(output).toContain("v1.0.0");
+    expect(output).toContain("[K-Dense-AI/claude-scientific-skills]");
+  });
+
+  test("shows verified tag when verified", () => {
+    const output = formatAvailableSearchResults(
+      [makeAvailableResult({ verified: true })],
+      "scientific",
+    );
+    expect(output).toContain("[verified]");
+  });
+
+  test("does not show verified tag when not verified", () => {
+    const output = formatAvailableSearchResults(
+      [makeAvailableResult({ verified: false })],
+      "scientific",
+    );
+    expect(output).not.toContain("[verified]");
+  });
+
+  test("shows description text", () => {
+    const output = formatAvailableSearchResults(
+      [makeAvailableResult({ description: "My custom description" })],
+      "scientific",
+    );
+    expect(output).toContain("My custom description");
+  });
+
+  test("shows install hint for each skill in multi-result", () => {
+    const results = [
+      makeAvailableResult({
+        name: "skill-alpha",
+        installUrl: "github:owner/repo:skill-alpha",
+      }),
+      makeAvailableResult({
+        name: "skill-beta",
+        installUrl: "github:owner/repo:skill-beta",
+      }),
+    ];
+    const output = formatAvailableSearchResults(results, "skill");
+    const installLines = output
+      .split("\n")
+      .filter((l) => l.includes("To install:"));
+    expect(installLines.length).toBe(2);
+    expect(output).toContain("asm install github:owner/repo:skill-alpha");
+    expect(output).toContain("asm install github:owner/repo:skill-beta");
   });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -365,6 +365,54 @@ export function formatSearchResults(
   return lines.join("\n");
 }
 
+// ─── Available (index) search result formatter ──────────────────────────────
+
+export interface AvailableSkillResult {
+  name: string;
+  version: string;
+  description: string;
+  verified?: boolean;
+  repoLabel: string;
+  installUrl: string;
+}
+
+export function formatAvailableSearchResults(
+  results: AvailableSkillResult[],
+  query: string,
+): string {
+  if (results.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = [];
+
+  // Summary header with total count
+  lines.push(
+    ansi.dim(
+      `Found ${results.length} available skill${results.length === 1 ? "" : "s"} matching "${query}"`,
+    ) + "\n",
+  );
+
+  for (const result of results) {
+    // Install command hint
+    lines.push(
+      `  ${ansi.dim("To install:")} ${ansi.green(`asm install ${result.installUrl}`)}`,
+    );
+    // Skill name + version + verified badge + repo
+    const verifiedTag = result.verified ? ansi.blue(" [verified]") : "";
+    lines.push(
+      `  ${ansi.cyan(result.name)} ${ansi.dim(`v${result.version}`)}${verifiedTag} ${ansi.dim(`[${result.repoLabel}]`)}`,
+    );
+    // Description
+    for (const dl of wordWrap(result.description, 76)) {
+      lines.push(`    ${dl}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
 // ─── Allowed-tools risk coloring ────────────────────────────────────────────
 
 export const HIGH_RISK_TOOLS = new Set([


### PR DESCRIPTION
Closes #93

## Summary

Enhances the `asm search` command output to display a total count of matched available skills and a prominent "To install:" hint above each available skill, making it easier for users to discover and install skills.

## Approach

Added a new `formatAvailableSearchResults` formatter function that produces structured output with a count header and install command hints. Updated `cmdSearch` in the CLI to delegate available-skills rendering to this formatter instead of inline formatting.

## Changes

| File | Change |
|------|--------|
| `src/formatter.ts` | Added `AvailableSkillResult` interface and `formatAvailableSearchResults` function |
| `src/cli.ts` | Updated `cmdSearch` to use `formatAvailableSearchResults` for available skills output |
| `src/formatter.test.ts` | Added 10 tests covering count header, install hints, verified tags, and multi-result output |

## Test Results

918 tests passed across 25 files (0 failures)

## Acceptance Criteria

- [x] When `asm search <query>` finds available skills, display: 'Found X available skills matching "<query>"'
- [x] For each available skill shown, add a line prefixed with 'To install:' showing the full install command
- [x] The install hint uses the correct GitHub source format: `asm install github:owner/repo:path`
- [x] Match existing output formatting and ANSI color conventions used in the rest of the CLI
- [x] Install hints appear immediately above the skill description/metadata for clear association