### PR TITLE
fix: handle Windows backslash path separators in skill name extraction

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1076,7 +1076,7 @@ async function inspectSkillForInstall(
   const metadata = await validateSkill(skillDir);
   const warnings = await scanForWarnings(skillDir);
 
-  const dirName = skillDir === tempDir ? null : skillDir.split("/").pop();
+  const dirName = skillDir === tempDir ? null : skillDir.split(/[/\\]/).pop();
   const rawName = skillNameOverride || dirName || source.repo;
   const skillName = sanitizeName(rawName);
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -261,7 +261,7 @@ export function sanitizeName(name: string): string {
 }
 
 export function getInstallNameFromPath(relPath: string): string {
-  const parts = relPath.split("/").filter(Boolean);
+  const parts = relPath.split(/[/\\]/).filter(Boolean);
   const rawName = parts.length > 0 ? parts[parts.length - 1] : relPath;
   return sanitizeName(rawName);
 }
@@ -395,7 +395,7 @@ export async function validateSkill(tempDir: string): Promise<{
   }
 
   const fm = parseFrontmatter(content);
-  const dirName = tempDir.split("/").pop() || "unknown";
+  const dirName = tempDir.split(/[/\\]/).pop() || "unknown";
 
   const name = fm.name || dirName;
   const version = resolveVersion(fm);


### PR DESCRIPTION
## Summary

Fixes #110

On Windows, filesystem paths use backslashes (`\`) rather than forward slashes. Three locations in the codebase hardcoded `.split('/')` to extract the leaf skill name from a path. On Windows, this split does nothing — the full string (e.g. `skills\docx`) is passed unchanged to the skill name validator, which rejects backslashes with `Invalid skill name: contains unsafe characters (path separator)`.

## Changes

- `src/installer.ts` — `getInstallNameFromPath`: `split('/')` → `split(/[/\\]/)`
- `src/installer.ts` — `installSkill` (tempDir extraction): `split('/')` → `split(/[/\\]/)`
- `src/cli.ts` — `inspectSkillForInstall` (skillDir extraction): `split('/')` → `split(/[/\\]/)`

The regex `split(/[/\\]/)` matches both separators and is a no-op on Linux/macOS since backslashes never appear in POSIX paths.

## Verification

Built from TypeScript source on Windows and ran:
```
asm install github:anthropics/skills --all --yes
```

All 18 skills installed successfully with zero errors. Previously this crashed at Step 7/8 on every skill.
