### PR TITLE
feat: remember user tool selection for faster repeat installs

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -5,6 +5,7 @@ import {
   getConfigPath,
   loadConfig,
   saveConfig,
+  saveSelectedTools,
 } from "./config";
 import { setVerbose } from "./logger";
 import { homedir } from "os";
@@ -255,5 +256,74 @@ describe("config verbose output", () => {
       .map((c: unknown[]) => c[0] as string)
       .join("\n");
     expect(output).not.toContain("[verbose]");
+  });
+});
+
+describe("selectedTools preference", () => {
+  const configPath = getConfigPath();
+  let originalContent: string | null = null;
+
+  beforeEach(async () => {
+    try {
+      originalContent = await readFile(configPath, "utf-8");
+    } catch {
+      originalContent = null;
+    }
+  });
+
+  afterEach(async () => {
+    if (originalContent !== null) {
+      await mkdir(dirname(configPath), { recursive: true });
+      await writeFile(configPath, originalContent, "utf-8");
+    } else {
+      try {
+        await rm(configPath);
+      } catch {}
+    }
+  });
+
+  it("default config has no selectedTools", () => {
+    const config = getDefaultConfig();
+    expect(config.preferences.selectedTools).toBeUndefined();
+  });
+
+  it("saveSelectedTools persists tool names to config", async () => {
+    await saveSelectedTools(["claude", "codex"]);
+    const config = await loadConfig();
+    expect(config.preferences.selectedTools).toEqual(["claude", "codex"]);
+  });
+
+  it("saveSelectedTools overwrites previous selection", async () => {
+    await saveSelectedTools(["claude", "codex"]);
+    await saveSelectedTools(["agents"]);
+    const config = await loadConfig();
+    expect(config.preferences.selectedTools).toEqual(["agents"]);
+  });
+
+  it("loadConfig preserves selectedTools from saved config", async () => {
+    const config = await loadConfig();
+    config.preferences.selectedTools = ["opencode", "cursor"];
+    await saveConfig(config);
+
+    const reloaded = await loadConfig();
+    expect(reloaded.preferences.selectedTools).toEqual(["opencode", "cursor"]);
+  });
+
+  it("mergeWithDefaults preserves selectedTools from saved config", async () => {
+    // Write a partial config with selectedTools
+    await mkdir(dirname(configPath), { recursive: true });
+    const partial = {
+      version: 1,
+      providers: [],
+      preferences: {
+        defaultScope: "both",
+        defaultSort: "name",
+        selectedTools: ["claude", "agents"],
+      },
+    };
+    await writeFile(configPath, JSON.stringify(partial), "utf-8");
+
+    const config = await loadConfig();
+    expect(config.preferences.selectedTools).toEqual(["claude", "agents"]);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -214,6 +214,7 @@ function mergeWithDefaults(config: Partial<AppConfig>): AppConfig {
         config.preferences?.defaultScope ?? defaults.preferences.defaultScope,
       defaultSort:
         config.preferences?.defaultSort ?? defaults.preferences.defaultSort,
+      selectedTools: config.preferences?.selectedTools,
     },
   };
 }
@@ -256,4 +257,10 @@ export async function loadConfig(): Promise<AppConfig> {
 export async function saveConfig(config: AppConfig): Promise<void> {
   await mkdir(CONFIG_DIR, { recursive: true });
   await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8");
+}
+
+export async function saveSelectedTools(toolNames: string[]): Promise<void> {
+  const config = await loadConfig();
+  config.preferences.selectedTools = toolNames;
+  await saveConfig(config);
 }

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -801,6 +801,10 @@ describe("resolveProvider", () => {
     mock.module("./utils/checkbox-picker", () => ({
       checkboxPicker: pickerMock,
     }));
+    const saveMock = mock(() => Promise.resolve());
+    mock.module("./config", () => ({
+      saveSelectedTools: saveMock,
+    }));
 
     const config = makeConfig([claude, codex]);
     const result = await resolveProvider(config, null, true);
@@ -821,6 +825,10 @@ describe("resolveProvider", () => {
     const pickerFn = mock(() => Promise.resolve([0, 2]));
     mock.module("./utils/checkbox-picker", () => ({
       checkboxPicker: pickerFn,
+    }));
+    const saveMock = mock(() => Promise.resolve());
+    mock.module("./config", () => ({
+      saveSelectedTools: saveMock,
     }));
 
     const config = makeConfig([claude, codex, agents]);
@@ -845,26 +853,7 @@ describe("resolveProvider", () => {
     );
   });
 
-  test("interactive picker: all items default to deselected", async () => {
-    let capturedItems: unknown[] = [];
-    const pickerFn = mock((opts: { items: unknown[] }) => {
-      capturedItems = opts.items;
-      return Promise.resolve([0]);
-    });
-    mock.module("./utils/checkbox-picker", () => ({
-      checkboxPicker: pickerFn,
-    }));
-
-    const config = makeConfig([claude, codex, disabledProvider]);
-    await resolveProvider(config, null, true);
-
-    expect(capturedItems).toHaveLength(3);
-    expect((capturedItems[0] as { checked: boolean }).checked).toBe(false);
-    expect((capturedItems[1] as { checked: boolean }).checked).toBe(false);
-    expect((capturedItems[2] as { checked: boolean }).checked).toBe(false);
-  });
-
-  test("interactive picker: agents provider is checked by default", async () => {
+  test("interactive picker: no saved tools defaults agents to checked", async () => {
     const agents: ProviderConfig = {
       name: "agents",
       label: "Agents",
@@ -880,6 +869,10 @@ describe("resolveProvider", () => {
     mock.module("./utils/checkbox-picker", () => ({
       checkboxPicker: pickerFn,
     }));
+    const saveMock = mock(() => Promise.resolve());
+    mock.module("./config", () => ({
+      saveSelectedTools: saveMock,
+    }));
 
     const config = makeConfig([claude, agents, codex]);
     await resolveProvider(config, null, true);
@@ -887,6 +880,137 @@ describe("resolveProvider", () => {
     expect(capturedItems).toHaveLength(3);
     expect((capturedItems[0] as { checked: boolean }).checked).toBe(false);
     expect((capturedItems[1] as { checked: boolean }).checked).toBe(true);
+    expect((capturedItems[2] as { checked: boolean }).checked).toBe(false);
+  });
+
+  test("interactive picker: saved tools override default checked state", async () => {
+    let capturedItems: unknown[] = [];
+    const pickerFn = mock((opts: { items: unknown[] }) => {
+      capturedItems = opts.items;
+      return Promise.resolve([0, 1]); // select claude and codex
+    });
+    mock.module("./utils/checkbox-picker", () => ({
+      checkboxPicker: pickerFn,
+    }));
+    const saveMock = mock(() => Promise.resolve());
+    mock.module("./config", () => ({
+      saveSelectedTools: saveMock,
+    }));
+
+    const agents: ProviderConfig = {
+      name: "agents",
+      label: "Agents",
+      global: "~/.agents/skills",
+      project: ".agents/skills",
+      enabled: true,
+    };
+    const config: AppConfig = {
+      version: 1,
+      providers: [claude, codex, agents],
+      customPaths: [],
+      preferences: {
+        defaultScope: "both",
+        defaultSort: "name",
+        selectedTools: ["claude", "codex"],
+      },
+    };
+    await resolveProvider(config, null, true);
+
+    expect(capturedItems).toHaveLength(3);
+    // claude and codex pre-checked from saved selection, agents not
+    expect((capturedItems[0] as { checked: boolean }).checked).toBe(true);
+    expect((capturedItems[1] as { checked: boolean }).checked).toBe(true);
+    expect((capturedItems[2] as { checked: boolean }).checked).toBe(false);
+  });
+
+  test("interactive picker: persists selected tool names after selection", async () => {
+    let savedNames: string[] = [];
+    const pickerFn = mock(() => Promise.resolve([0, 2]));
+    mock.module("./utils/checkbox-picker", () => ({
+      checkboxPicker: pickerFn,
+    }));
+    const saveMock = mock((names: string[]) => {
+      savedNames = names;
+      return Promise.resolve();
+    });
+    mock.module("./config", () => ({
+      saveSelectedTools: saveMock,
+    }));
+
+    const agents: ProviderConfig = {
+      name: "agents",
+      label: "Agents",
+      global: "~/.agents/skills",
+      project: ".agents/skills",
+      enabled: true,
+    };
+    const config = makeConfig([claude, codex, agents]);
+    await resolveProvider(config, null, true);
+
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(savedNames).toEqual(["claude", "agents"]);
+  });
+
+  test("interactive picker: empty saved tools array falls back to agents default", async () => {
+    let capturedItems: unknown[] = [];
+    const agents: ProviderConfig = {
+      name: "agents",
+      label: "Agents",
+      global: "~/.agents/skills",
+      project: ".agents/skills",
+      enabled: true,
+    };
+    const pickerFn = mock((opts: { items: unknown[] }) => {
+      capturedItems = opts.items;
+      return Promise.resolve([1]); // select agents
+    });
+    mock.module("./utils/checkbox-picker", () => ({
+      checkboxPicker: pickerFn,
+    }));
+    const saveMock = mock(() => Promise.resolve());
+    mock.module("./config", () => ({
+      saveSelectedTools: saveMock,
+    }));
+
+    const config: AppConfig = {
+      version: 1,
+      providers: [claude, agents, codex],
+      customPaths: [],
+      preferences: {
+        defaultScope: "both",
+        defaultSort: "name",
+        selectedTools: [], // empty array — should fall back to agents default
+      },
+    };
+    await resolveProvider(config, null, true);
+
+    expect(capturedItems).toHaveLength(3);
+    // Falls back to agents default
+    expect((capturedItems[0] as { checked: boolean }).checked).toBe(false);
+    expect((capturedItems[1] as { checked: boolean }).checked).toBe(true);
+    expect((capturedItems[2] as { checked: boolean }).checked).toBe(false);
+  });
+
+  test("interactive picker: all items default to deselected when no agents and no saved", async () => {
+    let capturedItems: unknown[] = [];
+    const pickerFn = mock((opts: { items: unknown[] }) => {
+      capturedItems = opts.items;
+      return Promise.resolve([0]);
+    });
+    mock.module("./utils/checkbox-picker", () => ({
+      checkboxPicker: pickerFn,
+    }));
+    const saveMock = mock(() => Promise.resolve());
+    mock.module("./config", () => ({
+      saveSelectedTools: saveMock,
+    }));
+
+    const config = makeConfig([claude, codex, disabledProvider]);
+    await resolveProvider(config, null, true);
+
+    expect(capturedItems).toHaveLength(3);
+    expect((capturedItems[0] as { checked: boolean }).checked).toBe(false);
+    expect((capturedItems[1] as { checked: boolean }).checked).toBe(false);
     expect((capturedItems[2] as { checked: boolean }).checked).toBe(false);
   });
 
@@ -903,6 +1027,10 @@ describe("resolveProvider", () => {
     mock.module("./utils/checkbox-picker", () => ({
       checkboxPicker: pickerFn,
     }));
+    const saveMock = mock(() => Promise.resolve());
+    mock.module("./config", () => ({
+      saveSelectedTools: saveMock,
+    }));
 
     const config = makeConfig(allDisabled);
     const result = await resolveProvider(config, null, true);
@@ -910,6 +1038,23 @@ describe("resolveProvider", () => {
     expect(capturedItems).toHaveLength(2);
     expect((capturedItems[0] as { checked: boolean }).checked).toBe(false);
     expect((capturedItems[1] as { checked: boolean }).checked).toBe(false);
+  });
+
+  test("explicit --tool flag does not trigger save or use saved tools", async () => {
+    const config: AppConfig = {
+      version: 1,
+      providers: [claude, codex],
+      customPaths: [],
+      preferences: {
+        defaultScope: "both",
+        defaultSort: "name",
+        selectedTools: ["codex"],
+      },
+    };
+    // Explicit provider flag — should not touch saved tools, no picker shown
+    const result = await resolveProvider(config, "claude", false);
+    expect(result.provider.name).toBe("claude");
+    expect(result.allProviders).toBeNull();
   });
 });
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -735,11 +735,15 @@ export async function resolveProvider(
     );
   }
 
-  // Interactive picker — show ALL providers, "agents" checked by default
+  // Interactive picker — show ALL providers, pre-check saved selections or "agents"
+  const savedTools = config.preferences.selectedTools;
+  const hasSavedTools = savedTools && savedTools.length > 0;
+  const savedSet = hasSavedTools ? new Set(savedTools) : null;
+
   const pickerItems = config.providers.map((p) => ({
     label: `${p.label} (${p.name})`,
     hint: p.global,
-    checked: p.name === "agents",
+    checked: savedSet ? savedSet.has(p.name) : p.name === "agents",
   }));
 
   const selectedIndices = await checkboxPicker({ items: pickerItems });
@@ -749,6 +753,11 @@ export async function resolveProvider(
   }
 
   const selectedProviders = selectedIndices.map((i) => config.providers[i]);
+
+  // Persist selected tool names for next time
+  const selectedNames = selectedProviders.map((p) => p.name);
+  const { saveSelectedTools } = await import("./config");
+  await saveSelectedTools(selectedNames);
 
   if (selectedProviders.length === 1) {
     return { provider: selectedProviders[0], allProviders: null };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -134,6 +134,7 @@ export interface CustomPathConfig {
 export interface UserPreferences {
   defaultScope: Scope;
   defaultSort: SortBy;
+  selectedTools?: string[];
 }
 
 export interface AppConfig {


### PR DESCRIPTION
## Summary
- Adds `selectedTools` field to `UserPreferences` config to persist the user's interactive tool selection across runs
- After the checkbox picker confirms, the selected provider names are saved to the ASM config file via a new `saveSelectedTools()` helper
- On subsequent interactive prompts, saved selections are loaded as pre-checked defaults; if no saved preference exists, the existing "agents" default is preserved
- Explicit `--tool` / `-p` CLI flag continues to override any saved selection

Closes #123

## Test plan
- [x] New config tests: `saveSelectedTools` persists and overwrites, `loadConfig` round-trips `selectedTools`, `mergeWithDefaults` preserves the field
- [x] New installer tests: saved tools override default checked state, empty saved array falls back to agents, selection is persisted after picker confirms, explicit flag bypasses saved tools
- [x] Updated existing interactive picker tests to mock `saveSelectedTools`
- [x] Full test suite passes (896 tests, 0 failures)