### PR TITLE
feat(scanner): add plugin marketplace skill discovery (#80)

### DIFF
--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -490,7 +490,9 @@ describe("scanPluginMarketplaces", () => {
   });
 
   it("returns empty array when marketplaces dir does not exist", async () => {
-    const skills = await scanPluginMarketplaces("/tmp/nonexistent-marketplaces-xyz");
+    const skills = await scanPluginMarketplaces(
+      "/tmp/nonexistent-marketplaces-xyz",
+    );
     expect(skills).toEqual([]);
   });
 
@@ -548,7 +550,14 @@ describe("scanPluginMarketplaces", () => {
     await writeFile(join(skillA, "SKILL.md"), "---\nname: Skill A\n---\n");
 
     // Marketplace B with nested plugin layout
-    const skillB = join(tempDir, "marketplace-b", "plugins", "plugin-b", "skills", "skill-b");
+    const skillB = join(
+      tempDir,
+      "marketplace-b",
+      "plugins",
+      "plugin-b",
+      "skills",
+      "skill-b",
+    );
     await mkdir(skillB, { recursive: true });
     await writeFile(join(skillB, "SKILL.md"), "---\nname: Skill B\n---\n");
 
@@ -574,7 +583,12 @@ describe("scanPluginMarketplaces", () => {
 
   it("is included in scanAllSkills for global scope", async () => {
     // Create a fake marketplace structure in tempDir and point scanner at it
-    const skillDir = join(tempDir, "test-marketplace", "skills", "plugin-skill");
+    const skillDir = join(
+      tempDir,
+      "test-marketplace",
+      "skills",
+      "plugin-skill",
+    );
     await mkdir(skillDir, { recursive: true });
     await writeFile(
       join(skillDir, "SKILL.md"),

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -581,8 +581,8 @@ describe("scanPluginMarketplaces", () => {
     expect(skills).toHaveLength(0);
   });
 
-  it("is included in scanAllSkills for global scope", async () => {
-    // Create a fake marketplace structure in tempDir and point scanner at it
+  it("scanPluginMarketplaces returns correct metadata for a skill", async () => {
+    // Verify the function itself returns the right fields for a basic skill
     const skillDir = join(
       tempDir,
       "test-marketplace",
@@ -595,7 +595,6 @@ describe("scanPluginMarketplaces", () => {
       "---\nname: Plugin Skill\nversion: 0.1.0\n---\n",
     );
 
-    // Use empty providers to isolate; manually call scanPluginMarketplaces
     const skills = await scanPluginMarketplaces(tempDir);
     const found = skills.find((s) => s.name === "Plugin Skill");
     expect(found).toBeDefined();
@@ -603,16 +602,69 @@ describe("scanPluginMarketplaces", () => {
     expect(found!.provider).toBe("plugin");
   });
 
-  it("is excluded from project-only scope in scanAllSkills", async () => {
+  it("scanAllSkills includes plugin skills for global scope via pluginBaseDir", async () => {
+    // Verify the scanAllSkills integration path with an injected plugin base dir
+    const skillDir = join(
+      tempDir,
+      "injected-marketplace",
+      "skills",
+      "injected-skill",
+    );
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      "---\nname: Injected Skill\nversion: 1.0.0\n---\n",
+    );
+
+    const config = { ...getDefaultConfig(), providers: [], customPaths: [] };
+    const skills = await scanAllSkills(config, "global", tempDir);
+    const found = skills.find((s) => s.name === "Injected Skill");
+    expect(found).toBeDefined();
+    expect(found!.provider).toBe("plugin");
+    expect(found!.marketplace).toBe("injected-marketplace");
+    expect(found!.scope).toBe("global");
+  });
+
+  it("scanAllSkills excludes plugin skills for project-only scope", async () => {
     // Plugin skills are always global; they should not appear in project-scope scans
     const config = {
       ...getDefaultConfig(),
       providers: [],
       customPaths: [],
     };
-    // Project scope scan with no providers should yield 0 plugin marketplace skills
-    const skills = await scanAllSkills(config, "project");
+    // pluginBaseDir is passed but scope=project means plugin scan is skipped entirely
+    const skills = await scanAllSkills(config, "project", tempDir);
     const pluginSkills = skills.filter((s) => s.provider === "plugin");
     expect(pluginSkills).toHaveLength(0);
+  });
+
+  it("scanAllSkills deduplicates skills that appear in both provider and plugin paths", async () => {
+    // Skill installed in both a regular provider path and the plugin marketplace
+    // Only one copy should appear in the result
+    const skillDir = join(tempDir, "mkt", "skills", "shared-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      "---\nname: Shared Skill\nversion: 1.0.0\n---\n",
+    );
+
+    // scanPluginMarketplaces sees it via tempDir
+    const pluginSkills = await scanPluginMarketplaces(tempDir);
+    expect(pluginSkills).toHaveLength(1);
+
+    // Simulate a provider result with the same realPath
+    const duplicate = { ...pluginSkills[0], provider: "claude" };
+    const providerSkills = [duplicate];
+
+    // Manually check dedup logic: realPath from providerSkills should block plugin entry
+    const seenRealPaths = new Set(providerSkills.map((s) => s.realPath));
+    const merged = [...providerSkills];
+    for (const ps of pluginSkills) {
+      if (!seenRealPaths.has(ps.realPath)) {
+        merged.push(ps);
+      }
+    }
+    expect(merged).toHaveLength(1);
+    expect(merged[0].provider).toBe("claude"); // provider entry wins
   });
 });

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -729,7 +729,11 @@ describe("scanPluginMarketplaces", () => {
     const skills = await scanPluginMarketplaces(tempDir);
     expect(skills).toHaveLength(3);
     expect(skills.every((s) => s.marketplace === "my-mkt")).toBe(true);
-    expect(skills.map((s) => s.name).sort()).toEqual(["alpha", "beta", "gamma"]);
+    expect(skills.map((s) => s.name).sort()).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
   });
 
   it("falls back to dirName when SKILL.md has no name field", async () => {
@@ -781,7 +785,10 @@ describe("scanPluginMarketplaces", () => {
   it("sets isSymlink=false and symlinkTarget=null for all marketplace skills", async () => {
     const skillDir = join(tempDir, "mkt", "skills", "plain-skill");
     await mkdir(skillDir, { recursive: true });
-    await writeFile(join(skillDir, "SKILL.md"), "---\nname: Plain Skill\n---\n");
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      "---\nname: Plain Skill\n---\n",
+    );
 
     const skills = await scanPluginMarketplaces(tempDir);
     expect(skills).toHaveLength(1);
@@ -798,12 +805,7 @@ describe("scanPluginMarketplaces", () => {
   });
 
   it("scanAllSkills includes plugin skills for both scope", async () => {
-    const skillDir = join(
-      tempDir,
-      "mkt",
-      "skills",
-      "both-scope-skill",
-    );
+    const skillDir = join(tempDir, "mkt", "skills", "both-scope-skill");
     await mkdir(skillDir, { recursive: true });
     await writeFile(
       join(skillDir, "SKILL.md"),

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -639,32 +639,39 @@ describe("scanPluginMarketplaces", () => {
   });
 
   it("scanAllSkills deduplicates skills that appear in both provider and plugin paths", async () => {
-    // Skill installed in both a regular provider path and the plugin marketplace
-    // Only one copy should appear in the result
-    const skillDir = join(tempDir, "mkt", "skills", "shared-skill");
-    await mkdir(skillDir, { recursive: true });
+    // Layout: pluginDir/mkt/skills/shared-skill/SKILL.md
+    // - scanPluginMarketplaces(pluginDir) finds it as marketplace "mkt"
+    // - a customPath pointing at pluginDir/mkt/skills also scans into
+    //   shared-skill/ and resolves the same realPath
+    // Both should resolve to the same realPath, so scanAllSkills must emit only one entry.
+    const pluginDir = join(tempDir, "plugin-base");
+    const skillsParent = join(pluginDir, "mkt", "skills");
+    const sharedSkillDir = join(skillsParent, "shared-skill");
+    await mkdir(sharedSkillDir, { recursive: true });
     await writeFile(
-      join(skillDir, "SKILL.md"),
+      join(sharedSkillDir, "SKILL.md"),
       "---\nname: Shared Skill\nversion: 1.0.0\n---\n",
     );
 
-    // scanPluginMarketplaces sees it via tempDir
-    const pluginSkills = await scanPluginMarketplaces(tempDir);
-    expect(pluginSkills).toHaveLength(1);
+    // customPaths entry that scans skillsParent — scanDirectory finds shared-skill inside it
+    const config = {
+      ...getDefaultConfig(),
+      providers: [],
+      customPaths: [
+        {
+          path: skillsParent,
+          label: "Custom",
+          scope: "global" as const,
+        },
+      ],
+    };
 
-    // Simulate a provider result with the same realPath
-    const duplicate = { ...pluginSkills[0], provider: "claude" };
-    const providerSkills = [duplicate];
+    const skills = await scanAllSkills(config, "global", pluginDir);
 
-    // Manually check dedup logic: realPath from providerSkills should block plugin entry
-    const seenRealPaths = new Set(providerSkills.map((s) => s.realPath));
-    const merged = [...providerSkills];
-    for (const ps of pluginSkills) {
-      if (!seenRealPaths.has(ps.realPath)) {
-        merged.push(ps);
-      }
-    }
-    expect(merged).toHaveLength(1);
-    expect(merged[0].provider).toBe("claude"); // provider entry wins
+    // Exactly one entry for the shared skill — no duplicates
+    const shared = skills.filter((s) => s.name === "Shared Skill");
+    expect(shared).toHaveLength(1);
+    // Provider (customPaths) entry wins — processed before plugin results
+    expect(shared[0].provider).not.toBe("plugin");
   });
 });

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, spyOn } from "bun:test";
-import { mkdtemp, writeFile, mkdir, rm, symlink } from "fs/promises";
+import { mkdtemp, writeFile, mkdir, rm, symlink, realpath } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
 import {
@@ -673,5 +673,167 @@ describe("scanPluginMarketplaces", () => {
     expect(shared).toHaveLength(1);
     // Provider (customPaths) entry wins — processed before plugin results
     expect(shared[0].provider).not.toBe("plugin");
+  });
+
+  // ── findSkillDirs safety ─────────────────────────────────────────────────
+
+  it("skips symlinked directories inside a marketplace (cycle-safety fix)", async () => {
+    // A symlink inside the marketplace dir must not be followed, even if it
+    // points to a directory that contains a SKILL.md — this prevents infinite
+    // recursion from symlink cycles created by malformed plugin installers.
+    const realSkillDir = join(tempDir, "real-skill");
+    await mkdir(realSkillDir, { recursive: true });
+    await writeFile(
+      join(realSkillDir, "SKILL.md"),
+      "---\nname: Real Skill\n---\n",
+    );
+
+    const marketplaceDir = join(tempDir, "mkt");
+    await mkdir(marketplaceDir, { recursive: true });
+
+    // Symlink inside the marketplace pointing at the real skill dir
+    const symlinkPath = join(marketplaceDir, "linked-skill");
+    await symlink(realSkillDir, symlinkPath);
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    // The symlinked entry is skipped — result must be empty
+    expect(skills).toHaveLength(0);
+  });
+
+  it("skips non-directory entries at the marketplace level", async () => {
+    // Files sitting directly in the marketplaces dir must not cause errors
+    const marketplacesDir = tempDir;
+    await writeFile(join(marketplacesDir, "not-a-dir.txt"), "stray file");
+
+    // Also add a real marketplace so we know the scan ran
+    const skillDir = join(marketplacesDir, "real-mkt", "skills", "skill-a");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "---\nname: Skill A\n---\n");
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].marketplace).toBe("real-mkt");
+  });
+
+  it("discovers multiple skills in the same marketplace", async () => {
+    const mkt = join(tempDir, "my-mkt", "skills");
+    for (const name of ["alpha", "beta", "gamma"]) {
+      const d = join(mkt, name);
+      await mkdir(d, { recursive: true });
+      await writeFile(
+        join(d, "SKILL.md"),
+        `---\nname: ${name}\nversion: 0.1.0\n---\n`,
+      );
+    }
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(3);
+    expect(skills.every((s) => s.marketplace === "my-mkt")).toBe(true);
+    expect(skills.map((s) => s.name).sort()).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("falls back to dirName when SKILL.md has no name field", async () => {
+    const skillDir = join(tempDir, "mkt", "skills", "my-unnamed-skill");
+    await mkdir(skillDir, { recursive: true });
+    // Frontmatter omits 'name' entirely
+    await writeFile(join(skillDir, "SKILL.md"), "---\nversion: 1.0.0\n---\n");
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe("my-unnamed-skill");
+    expect(skills[0].dirName).toBe("my-unnamed-skill");
+  });
+
+  it("parses rich frontmatter fields from SKILL.md", async () => {
+    const skillDir = join(tempDir, "mkt", "skills", "rich-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: Rich Skill",
+        "version: 3.1.4",
+        "description: Does many things",
+        "metadata:",
+        "  creator: Test Author",
+        "license: MIT",
+        "compatibility: Claude 3+",
+        "effort: medium",
+        "allowed-tools: Bash, Read",
+        "---",
+        "Body content",
+      ].join("\n"),
+    );
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(1);
+    const s = skills[0];
+    expect(s.version).toBe("3.1.4");
+    expect(s.description).toBe("Does many things");
+    expect(s.creator).toBe("Test Author");
+    expect(s.license).toBe("MIT");
+    expect(s.compatibility).toBe("Claude 3+");
+    expect(s.effort).toBe("medium");
+    expect(s.allowedTools).toContain("Bash");
+    expect(s.allowedTools).toContain("Read");
+  });
+
+  it("sets isSymlink=false and symlinkTarget=null for all marketplace skills", async () => {
+    const skillDir = join(tempDir, "mkt", "skills", "plain-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "---\nname: Plain Skill\n---\n");
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].isSymlink).toBe(false);
+    expect(skills[0].symlinkTarget).toBeNull();
+  });
+
+  it("returns empty array for an empty marketplace directory", async () => {
+    // Marketplace dir exists but has no skill subdirectories at any depth
+    await mkdir(join(tempDir, "empty-mkt"), { recursive: true });
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(0);
+  });
+
+  it("scanAllSkills includes plugin skills for both scope", async () => {
+    const skillDir = join(
+      tempDir,
+      "mkt",
+      "skills",
+      "both-scope-skill",
+    );
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      "---\nname: Both Scope Skill\nversion: 1.0.0\n---\n",
+    );
+
+    const config = { ...getDefaultConfig(), providers: [], customPaths: [] };
+    const skills = await scanAllSkills(config, "both", tempDir);
+    const found = skills.find((s) => s.name === "Both Scope Skill");
+    expect(found).toBeDefined();
+    expect(found!.provider).toBe("plugin");
+    expect(found!.scope).toBe("global");
+  });
+
+  it("path and originalPath are set correctly for a marketplace skill", async () => {
+    const skillDir = join(tempDir, "mkt", "skills", "path-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "---\nname: Path Skill\n---\n");
+
+    // On macOS /tmp is a symlink to /private/tmp — resolve via realpath
+    const canonicalSkillDir = await realpath(skillDir);
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(1);
+    const s = skills[0];
+    // originalPath is the raw path as walked (not resolved)
+    expect(s.originalPath).toBe(skillDir);
+    // realPath is the canonical filesystem path (resolves /tmp symlinks on macOS)
+    expect(s.realPath).toBe(canonicalSkillDir);
+    // path uses resolve() which normalises but does not follow OS-level symlinks
+    expect(s.path).toBe(skillDir);
   });
 });

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -6,6 +6,7 @@ import {
   searchSkills,
   sortSkills,
   scanAllSkills,
+  scanPluginMarketplaces,
   compareSemver,
   countFiles,
 } from "./scanner";
@@ -472,5 +473,132 @@ describe("scanAllSkills", () => {
     expect(found).toBeDefined();
     expect(found!.provider).toBe("custom");
     expect(found!.providerLabel).toBe("My Custom");
+  });
+});
+
+// ─── scanPluginMarketplaces ──────────────────────────────────────────────────
+
+describe("scanPluginMarketplaces", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "scanner-plugins-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when marketplaces dir does not exist", async () => {
+    const skills = await scanPluginMarketplaces("/tmp/nonexistent-marketplaces-xyz");
+    expect(skills).toEqual([]);
+  });
+
+  it("discovers user-installed marketplace skills (flat skills/ layout)", async () => {
+    // ~/.claude/plugins/marketplaces/my-marketplace/skills/my-skill/SKILL.md
+    const skillDir = join(tempDir, "my-marketplace", "skills", "my-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      "---\nname: My Skill\nversion: 1.2.0\ndescription: A user-installed skill\n---\nBody",
+    );
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(1);
+    const skill = skills[0];
+    expect(skill.name).toBe("My Skill");
+    expect(skill.version).toBe("1.2.0");
+    expect(skill.marketplace).toBe("my-marketplace");
+    expect(skill.provider).toBe("plugin");
+    expect(skill.providerLabel).toBe("Plugin (my-marketplace)");
+    expect(skill.scope).toBe("global");
+    expect(skill.location).toBe("global-plugin-my-marketplace");
+    expect(skill.dirName).toBe("my-skill");
+  });
+
+  it("discovers official bundled plugin skills (plugins/.../skills/ layout)", async () => {
+    // ~/.claude/plugins/marketplaces/claude-plugins-official/plugins/my-plugin/skills/my-skill/SKILL.md
+    const skillDir = join(
+      tempDir,
+      "claude-plugins-official",
+      "plugins",
+      "my-plugin",
+      "skills",
+      "my-skill",
+    );
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      "---\nname: Bundled Skill\nversion: 2.0.0\ndescription: An official bundled skill\n---\nBody",
+    );
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(1);
+    const skill = skills[0];
+    expect(skill.name).toBe("Bundled Skill");
+    expect(skill.marketplace).toBe("claude-plugins-official");
+    expect(skill.provider).toBe("plugin");
+    expect(skill.dirName).toBe("my-skill");
+  });
+
+  it("discovers skills from multiple marketplaces", async () => {
+    // Marketplace A with flat layout
+    const skillA = join(tempDir, "marketplace-a", "skills", "skill-a");
+    await mkdir(skillA, { recursive: true });
+    await writeFile(join(skillA, "SKILL.md"), "---\nname: Skill A\n---\n");
+
+    // Marketplace B with nested plugin layout
+    const skillB = join(tempDir, "marketplace-b", "plugins", "plugin-b", "skills", "skill-b");
+    await mkdir(skillB, { recursive: true });
+    await writeFile(join(skillB, "SKILL.md"), "---\nname: Skill B\n---\n");
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(2);
+
+    const marketplaces = skills.map((s) => s.marketplace).sort();
+    expect(marketplaces).toEqual(["marketplace-a", "marketplace-b"]);
+
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toEqual(["Skill A", "Skill B"]);
+  });
+
+  it("skips directories without SKILL.md", async () => {
+    // A directory that is not a skill (no SKILL.md at any depth)
+    const notASkill = join(tempDir, "some-marketplace", "just-a-dir");
+    await mkdir(notASkill, { recursive: true });
+    await writeFile(join(notASkill, "README.md"), "Not a skill");
+
+    const skills = await scanPluginMarketplaces(tempDir);
+    expect(skills).toHaveLength(0);
+  });
+
+  it("is included in scanAllSkills for global scope", async () => {
+    // Create a fake marketplace structure in tempDir and point scanner at it
+    const skillDir = join(tempDir, "test-marketplace", "skills", "plugin-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      "---\nname: Plugin Skill\nversion: 0.1.0\n---\n",
+    );
+
+    // Use empty providers to isolate; manually call scanPluginMarketplaces
+    const skills = await scanPluginMarketplaces(tempDir);
+    const found = skills.find((s) => s.name === "Plugin Skill");
+    expect(found).toBeDefined();
+    expect(found!.marketplace).toBe("test-marketplace");
+    expect(found!.provider).toBe("plugin");
+  });
+
+  it("is excluded from project-only scope in scanAllSkills", async () => {
+    // Plugin skills are always global; they should not appear in project-scope scans
+    const config = {
+      ...getDefaultConfig(),
+      providers: [],
+      customPaths: [],
+    };
+    // Project scope scan with no providers should yield 0 plugin marketplace skills
+    const skills = await scanAllSkills(config, "project");
+    const pluginSkills = skills.filter((s) => s.provider === "plugin");
+    expect(pluginSkills).toHaveLength(0);
   });
 });

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -323,15 +323,24 @@ export async function scanPluginMarketplaces(
 export async function scanAllSkills(
   config: AppConfig,
   scope: Scope,
+  pluginBaseDir?: string,
 ): Promise<SkillInfo[]> {
   const locations = buildScanLocations(config, scope);
-  const results = await Promise.all(locations.map(scanDirectory));
-  const skills = results.flat();
+  const [providerResults, pluginSkills] = await Promise.all([
+    Promise.all(locations.map(scanDirectory)),
+    scope === "global" || scope === "both"
+      ? scanPluginMarketplaces(pluginBaseDir)
+      : Promise.resolve([] as SkillInfo[]),
+  ]);
+  const skills = providerResults.flat();
 
-  // Include plugin marketplace skills for global and both scopes
-  if (scope === "global" || scope === "both") {
-    const pluginSkills = await scanPluginMarketplaces();
-    skills.push(...pluginSkills);
+  // Deduplicate: skip plugin skills whose realPath already appears in provider results
+  const seenRealPaths = new Set(skills.map((s) => s.realPath));
+  for (const ps of pluginSkills) {
+    if (!seenRealPaths.has(ps.realPath)) {
+      skills.push(ps);
+      seenRealPaths.add(ps.realPath);
+    }
   }
 
   return skills;

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -198,10 +198,13 @@ async function findSkillDirs(dir: string): Promise<string[]> {
 
     let entryStat;
     try {
-      entryStat = await stat(entryPath);
+      entryStat = await lstat(entryPath);
     } catch {
       continue;
     }
+
+    // Skip symlinks to avoid cycles from malformed or malicious marketplaces
+    if (entryStat.isSymbolicLink()) continue;
 
     if (entryStat.isDirectory()) {
       const skillMdPath = join(entryPath, "SKILL.md");

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -6,7 +6,8 @@ import {
   readFile,
   realpath,
 } from "fs/promises";
-import { join, resolve } from "path";
+import { join, resolve, basename } from "path";
+import { homedir } from "os";
 import {
   parseFrontmatter,
   resolveVersion,
@@ -15,6 +16,13 @@ import {
 import { resolveProviderPath } from "./config";
 import { debug } from "./logger";
 import type { SkillInfo, Scope, SortBy, AppConfig } from "./utils/types";
+
+const PLUGIN_MARKETPLACES_DIR = join(
+  homedir(),
+  ".claude",
+  "plugins",
+  "marketplaces",
+);
 
 interface ScanLocation {
   dir: string;
@@ -170,13 +178,163 @@ async function scanDirectory(loc: ScanLocation): Promise<SkillInfo[]> {
   return skills;
 }
 
+/**
+ * Recursively find all SKILL.md files under a directory, returning their
+ * parent directory paths. Handles variable nesting depths used by different
+ * plugin marketplaces.
+ */
+async function findSkillDirs(dir: string): Promise<string[]> {
+  const skillDirs: string[] = [];
+
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return skillDirs;
+  }
+
+  for (const entry of entries) {
+    const entryPath = join(dir, entry);
+
+    let entryStat;
+    try {
+      entryStat = await stat(entryPath);
+    } catch {
+      continue;
+    }
+
+    if (entryStat.isDirectory()) {
+      const skillMdPath = join(entryPath, "SKILL.md");
+      try {
+        await stat(skillMdPath);
+        skillDirs.push(entryPath);
+      } catch {
+        // No SKILL.md here — recurse deeper
+        const nested = await findSkillDirs(entryPath);
+        skillDirs.push(...nested);
+      }
+    }
+  }
+
+  return skillDirs;
+}
+
+/**
+ * Scan Claude plugin marketplaces under ~/.claude/plugins/marketplaces/.
+ *
+ * Marketplaces use variable-depth layouts:
+ *   - User-installed: {marketplace}/skills/{skill}/SKILL.md
+ *   - Official bundled: {marketplace}/plugins/{plugin}/skills/{skill}/SKILL.md
+ *
+ * Skills are attributed to their marketplace name (the directory directly
+ * under ~/.claude/plugins/marketplaces/).
+ */
+export async function scanPluginMarketplaces(
+  baseDir?: string,
+): Promise<SkillInfo[]> {
+  const marketplacesDir = baseDir ?? PLUGIN_MARKETPLACES_DIR;
+  const skills: SkillInfo[] = [];
+
+  debug(`scan: checking plugin marketplaces at ${marketplacesDir}`);
+
+  let marketplaces: string[];
+  try {
+    marketplaces = await readdir(marketplacesDir);
+  } catch {
+    debug(`scan: plugin marketplaces dir not found, skipping`);
+    return skills;
+  }
+
+  for (const marketplace of marketplaces) {
+    const marketplacePath = join(marketplacesDir, marketplace);
+
+    let mStat;
+    try {
+      mStat = await stat(marketplacePath);
+    } catch {
+      continue;
+    }
+    if (!mStat.isDirectory()) continue;
+
+    debug(`scan: scanning marketplace "${marketplace}"`);
+
+    const skillDirs = await findSkillDirs(marketplacePath);
+
+    for (const skillDir of skillDirs) {
+      const skillMdPath = join(skillDir, "SKILL.md");
+      let content: string;
+      try {
+        content = await readFile(skillMdPath, "utf-8");
+      } catch {
+        continue;
+      }
+
+      const fm = parseFrontmatter(content);
+      const entry = basename(skillDir);
+
+      let isSymlink = false;
+      let symlinkTarget: string | null = null;
+      try {
+        const lstats = await lstat(skillDir);
+        if (lstats.isSymbolicLink()) {
+          isSymlink = true;
+          symlinkTarget = await readlink(skillDir);
+        }
+      } catch {
+        // not a symlink
+      }
+
+      const resolvedPath = resolve(skillDir);
+      let resolvedRealPath: string;
+      try {
+        resolvedRealPath = await realpath(skillDir);
+      } catch {
+        resolvedRealPath = resolvedPath;
+      }
+
+      skills.push({
+        name: fm.name || entry,
+        version: resolveVersion(fm),
+        description: (fm.description || "").replace(/\s*\n\s*/g, " ").trim(),
+        creator: fm["metadata.creator"] || "",
+        license: (fm.license || "").trim(),
+        compatibility: (fm.compatibility || "").trim(),
+        allowedTools: resolveAllowedTools(fm),
+        effort: fm.effort || fm["metadata.effort"] || undefined,
+        dirName: entry,
+        path: resolvedPath,
+        originalPath: skillDir,
+        location: `global-plugin-${marketplace}`,
+        scope: "global",
+        provider: "plugin",
+        providerLabel: `Plugin (${marketplace})`,
+        isSymlink,
+        symlinkTarget,
+        realPath: resolvedRealPath,
+        marketplace,
+      });
+    }
+  }
+
+  debug(`scan: found ${skills.length} plugin marketplace skill(s)`);
+  return skills;
+}
+
 export async function scanAllSkills(
   config: AppConfig,
   scope: Scope,
 ): Promise<SkillInfo[]> {
   const locations = buildScanLocations(config, scope);
   const results = await Promise.all(locations.map(scanDirectory));
-  return results.flat();
+  const skills = results.flat();
+
+  // Include plugin marketplace skills for global and both scopes
+  if (scope === "global" || scope === "both") {
+    const pluginSkills = await scanPluginMarketplaces();
+    skills.push(...pluginSkills);
+  }
+
+  return skills;
 }
 
 export function searchSkills(skills: SkillInfo[], query: string): SkillInfo[] {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -275,18 +275,8 @@ export async function scanPluginMarketplaces(
       const fm = parseFrontmatter(content);
       const entry = basename(skillDir);
 
-      let isSymlink = false;
-      let symlinkTarget: string | null = null;
-      try {
-        const lstats = await lstat(skillDir);
-        if (lstats.isSymbolicLink()) {
-          isSymlink = true;
-          symlinkTarget = await readlink(skillDir);
-        }
-      } catch {
-        // not a symlink
-      }
-
+      // findSkillDirs() skips symlinks, so marketplace skill dirs are always
+      // real directories — isSymlink is always false here.
       const resolvedPath = resolve(skillDir);
       let resolvedRealPath: string;
       try {
@@ -311,8 +301,8 @@ export async function scanPluginMarketplaces(
         scope: "global",
         provider: "plugin",
         providerLabel: `Plugin (${marketplace})`,
-        isSymlink,
-        symlinkTarget,
+        isSymlink: false,
+        symlinkTarget: null,
         realPath: resolvedRealPath,
         marketplace,
       });

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,6 +26,8 @@ export interface SkillInfo {
   fileCount?: number;
   effort?: string;
   warnings?: SkillWarning[];
+  /** Marketplace name when skill was installed via Claude plugin marketplace */
+  marketplace?: string;
 }
 
 // ─── Lock File Types ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #80

## Summary

- Adds `scanPluginMarketplaces()` in `scanner.ts` that recursively discovers skills installed via the Claude plugin marketplace
- Integrates into `scanAllSkills()` for global and both scopes
- Plugin-installed skills are visually distinguished by `provider: "plugin"` and `providerLabel: "Plugin ({marketplace-name})"`

## Approach

Claude's plugin marketplace installs skills under `~/.claude/plugins/marketplaces/` with two known layout patterns:
- **User-installed:** `{marketplace}/skills/{skill}/SKILL.md`
- **Official bundled:** `{marketplace}/plugins/{plugin}/skills/{skill}/SKILL.md`

Rather than hard-coding path patterns, the implementation walks directories recursively until it finds a `SKILL.md` file, which cleanly handles both layouts and any future depth variations.

## Changes

| File | Change |
|------|--------|
| `src/scanner.ts` | Add `findSkillDirs()` recursive helper, `scanPluginMarketplaces()` (exported), integrate into `scanAllSkills()` |
| `src/utils/types.ts` | Add optional `marketplace?: string` field to `SkillInfo` |
| `src/scanner.test.ts` | Add 7 tests for both marketplace path layouts, multi-marketplace discovery, and scope filtering |

## Test Results

44 scanner tests pass (37 existing + 7 new), 0 failures.

Note: pre-existing failures in `publisher.test.ts` and `cli.test.ts` are unrelated to this change (verified on main branch before branching).

## Acceptance Criteria

- [x] ASM scans `~/.claude/plugins/marketplaces/` directories to discover plugin-installed skills
- [x] Plugin-installed skills appear in `asm list` output, distinguished from traditionally installed skills (`provider: "plugin"`, `providerLabel: "Plugin ({marketplace})"`)
- [x] `asm info {skill}` works for plugin-installed skills and shows the marketplace source (`location: "global-plugin-{marketplace}"` and `marketplace` field)
- [x] Both user-installed marketplace skills and official bundled plugins are detected (recursive finder handles variable nesting depths)
- [ ] ASM correctly reads Claude's local config to determine which plugins are enabled vs disabled — `~/.claude/settings.local.json` has no `pluginSettings` key; flagged as future enhancement