### PR TITLE
feat(scanner): add Codex plugin marketplace discovery (#124)

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -56,6 +56,7 @@ export function colorEffort(effort: string | undefined): string {
 const PROVIDER_COLORS: Record<string, (s: string) => string> = {
   claude: ansi.blueBold,
   codex: ansi.cyan,
+  "codex-plugin": ansi.cyan,
   openclaw: ansi.yellow,
   agents: ansi.green,
   custom: ansi.magenta,

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -1074,10 +1074,7 @@ describe("scanCodexPluginCache", () => {
     const configPath = join(tempDir, "config.toml");
     await writeFile(
       configPath,
-      [
-        '[plugins."quoted-plugin"]',
-        "enabled = false",
-      ].join("\n"),
+      ['[plugins."quoted-plugin"]', "enabled = false"].join("\n"),
     );
 
     const skills = await scanCodexPluginCache(tempDir, configPath);
@@ -1090,10 +1087,7 @@ describe("scanCodexPluginCache", () => {
     });
 
     const configPath = join(tempDir, "config.toml");
-    await writeFile(
-      configPath,
-      "[plugins.'sq-plugin']\nenabled = false\n",
-    );
+    await writeFile(configPath, "[plugins.'sq-plugin']\nenabled = false\n");
 
     const skills = await scanCodexPluginCache(tempDir, configPath);
     expect(skills[0].codexPlugin?.enabled).toBe(false);

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -1034,6 +1034,17 @@ describe("scanCodexPluginCache", () => {
     expect(skills[0].codexPlugin?.hasMcpConfig).toBe(false);
   });
 
+  it("sets hasMcpConfig=false when mcp field is null", async () => {
+    await makeCodexPlugin(tempDir, "official", "null-mcp", "1.0.0", {
+      name: "null-mcp",
+      mcp: null,
+    });
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].codexPlugin?.hasMcpConfig).toBe(false);
+  });
+
   it("reads enabled status from config.toml", async () => {
     await makeCodexPlugin(tempDir, "official", "disabled-plugin", "1.0.0", {
       name: "disabled-plugin",

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -1066,6 +1066,39 @@ describe("scanCodexPluginCache", () => {
     expect(skills[0].codexPlugin?.enabled).toBe(false);
   });
 
+  it("reads enabled status from config.toml with quoted plugin names", async () => {
+    await makeCodexPlugin(tempDir, "official", "quoted-plugin", "1.0.0", {
+      name: "quoted-plugin",
+    });
+
+    const configPath = join(tempDir, "config.toml");
+    await writeFile(
+      configPath,
+      [
+        '[plugins."quoted-plugin"]',
+        "enabled = false",
+      ].join("\n"),
+    );
+
+    const skills = await scanCodexPluginCache(tempDir, configPath);
+    expect(skills[0].codexPlugin?.enabled).toBe(false);
+  });
+
+  it("reads enabled status from config.toml with single-quoted plugin names", async () => {
+    await makeCodexPlugin(tempDir, "official", "sq-plugin", "1.0.0", {
+      name: "sq-plugin",
+    });
+
+    const configPath = join(tempDir, "config.toml");
+    await writeFile(
+      configPath,
+      "[plugins.'sq-plugin']\nenabled = false\n",
+    );
+
+    const skills = await scanCodexPluginCache(tempDir, configPath);
+    expect(skills[0].codexPlugin?.enabled).toBe(false);
+  });
+
   it("defaults to enabled=true when plugin not in config.toml", async () => {
     await makeCodexPlugin(tempDir, "official", "unknown-plugin", "1.0.0", {
       name: "unknown-plugin",

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -946,6 +946,29 @@ describe("scanCodexPluginCache", () => {
     expect(skills[0].description).toBe("new");
   });
 
+  it("picks highest version by semver (not lexicographic) when versions like 2.0.0 and 10.0.0 exist", async () => {
+    await makeCodexPlugin(tempDir, "official", "semver-plugin", "1.0.0", {
+      name: "semver-plugin",
+      version: "1.0.0",
+      description: "v1",
+    });
+    await makeCodexPlugin(tempDir, "official", "semver-plugin", "2.0.0", {
+      name: "semver-plugin",
+      version: "2.0.0",
+      description: "v2",
+    });
+    await makeCodexPlugin(tempDir, "official", "semver-plugin", "10.0.0", {
+      name: "semver-plugin",
+      version: "10.0.0",
+      description: "v10",
+    });
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].version).toBe("10.0.0");
+    expect(skills[0].description).toBe("v10");
+  });
+
   it("discovers plugins from multiple marketplaces", async () => {
     await makeCodexPlugin(tempDir, "official", "plugin-a", "1.0.0", {
       name: "plugin-a",

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -7,6 +7,8 @@ import {
   sortSkills,
   scanAllSkills,
   scanPluginMarketplaces,
+  scanCodexPluginCache,
+  readCodexMarketplaceFiles,
   compareSemver,
   countFiles,
 } from "./scanner";
@@ -837,5 +839,432 @@ describe("scanPluginMarketplaces", () => {
     expect(s.realPath).toBe(canonicalSkillDir);
     // path uses resolve() which normalises but does not follow OS-level symlinks
     expect(s.path).toBe(skillDir);
+  });
+});
+
+// ─── scanCodexPluginCache ───────────────────────────────────────────────────
+
+describe("scanCodexPluginCache", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "scanner-codex-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function makeCodexPlugin(
+    cacheDir: string,
+    marketplace: string,
+    pluginName: string,
+    version: string,
+    manifest: object,
+  ): Promise<string> {
+    const pluginDir = join(
+      cacheDir,
+      marketplace,
+      pluginName,
+      version,
+      ".codex-plugin",
+    );
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(
+      join(pluginDir, "plugin.json"),
+      JSON.stringify(manifest),
+      "utf-8",
+    );
+    return join(cacheDir, marketplace, pluginName, version);
+  }
+
+  it("returns empty array when cache dir does not exist", async () => {
+    const skills = await scanCodexPluginCache(
+      "/tmp/nonexistent-codex-cache-xyz",
+    );
+    expect(skills).toEqual([]);
+  });
+
+  it("discovers a basic Codex plugin from cache", async () => {
+    await makeCodexPlugin(tempDir, "official", "my-plugin", "1.0.0", {
+      name: "my-plugin",
+      version: "1.0.0",
+      description: "A test plugin",
+    });
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills).toHaveLength(1);
+    const s = skills[0];
+    expect(s.name).toBe("my-plugin");
+    expect(s.version).toBe("1.0.0");
+    expect(s.description).toBe("A test plugin");
+    expect(s.provider).toBe("codex-plugin");
+    expect(s.providerLabel).toBe("Codex Plugin (official)");
+    expect(s.scope).toBe("global");
+    expect(s.marketplace).toBe("official");
+    expect(s.dirName).toBe("my-plugin");
+    expect(s.isSymlink).toBe(false);
+    expect(s.symlinkTarget).toBeNull();
+  });
+
+  it("uses displayName from interface when available", async () => {
+    await makeCodexPlugin(tempDir, "official", "my-plugin", "1.0.0", {
+      name: "my-plugin",
+      version: "1.0.0",
+      interface: { displayName: "My Pretty Plugin", category: "utilities" },
+    });
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe("My Pretty Plugin");
+    expect(skills[0].codexPlugin?.category).toBe("utilities");
+  });
+
+  it("uses dirName as fallback when plugin.json has no name", async () => {
+    await makeCodexPlugin(tempDir, "official", "unnamed-plugin", "0.1.0", {});
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe("unnamed-plugin");
+  });
+
+  it("picks the highest version when multiple versions are present", async () => {
+    await makeCodexPlugin(tempDir, "official", "versioned", "1.0.0", {
+      name: "versioned",
+      version: "1.0.0",
+      description: "old",
+    });
+    await makeCodexPlugin(tempDir, "official", "versioned", "2.0.0", {
+      name: "versioned",
+      version: "2.0.0",
+      description: "new",
+    });
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].version).toBe("2.0.0");
+    expect(skills[0].description).toBe("new");
+  });
+
+  it("discovers plugins from multiple marketplaces", async () => {
+    await makeCodexPlugin(tempDir, "official", "plugin-a", "1.0.0", {
+      name: "plugin-a",
+    });
+    await makeCodexPlugin(tempDir, "community", "plugin-b", "1.0.0", {
+      name: "plugin-b",
+    });
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills).toHaveLength(2);
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toEqual(["plugin-a", "plugin-b"]);
+    const marketplaces = skills.map((s) => s.marketplace).sort();
+    expect(marketplaces).toEqual(["community", "official"]);
+  });
+
+  it("skips plugin directories without .codex-plugin/plugin.json", async () => {
+    const pluginDir = join(tempDir, "official", "bad-plugin", "1.0.0");
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(pluginDir, "README.md"), "no manifest");
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills).toHaveLength(0);
+  });
+
+  it("skips plugin directories with invalid JSON in plugin.json", async () => {
+    const manifestDir = join(
+      tempDir,
+      "official",
+      "broken-plugin",
+      "1.0.0",
+      ".codex-plugin",
+    );
+    await mkdir(manifestDir, { recursive: true });
+    await writeFile(join(manifestDir, "plugin.json"), "not valid json");
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills).toHaveLength(0);
+  });
+
+  it("sets location to global-codex-plugin-{marketplace}", async () => {
+    await makeCodexPlugin(tempDir, "my-mkt", "p", "1.0.0", { name: "p" });
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills[0].location).toBe("global-codex-plugin-my-mkt");
+  });
+
+  it("detects hasMcpConfig when mcp field is present", async () => {
+    await makeCodexPlugin(tempDir, "official", "mcp-plugin", "1.0.0", {
+      name: "mcp-plugin",
+      mcp: { servers: { myServer: { command: "npx", args: ["mcp-server"] } } },
+    });
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills[0].codexPlugin?.hasMcpConfig).toBe(true);
+  });
+
+  it("sets hasMcpConfig=false when mcp field is absent", async () => {
+    await makeCodexPlugin(tempDir, "official", "no-mcp", "1.0.0", {
+      name: "no-mcp",
+    });
+
+    const skills = await scanCodexPluginCache(tempDir);
+    expect(skills[0].codexPlugin?.hasMcpConfig).toBe(false);
+  });
+
+  it("reads enabled status from config.toml", async () => {
+    await makeCodexPlugin(tempDir, "official", "disabled-plugin", "1.0.0", {
+      name: "disabled-plugin",
+    });
+
+    const configPath = join(tempDir, "config.toml");
+    await writeFile(
+      configPath,
+      [
+        "[plugins.disabled-plugin]",
+        "enabled = false",
+        "",
+        "[plugins.other-plugin]",
+        "enabled = true",
+      ].join("\n"),
+    );
+
+    const skills = await scanCodexPluginCache(tempDir, configPath);
+    expect(skills[0].codexPlugin?.enabled).toBe(false);
+  });
+
+  it("defaults to enabled=true when plugin not in config.toml", async () => {
+    await makeCodexPlugin(tempDir, "official", "unknown-plugin", "1.0.0", {
+      name: "unknown-plugin",
+    });
+
+    const configPath = join(tempDir, "config.toml");
+    await writeFile(configPath, "[plugins.other]\nenabled = true\n");
+
+    const skills = await scanCodexPluginCache(tempDir, configPath);
+    expect(skills[0].codexPlugin?.enabled).toBe(true);
+  });
+
+  it("defaults to enabled=true when config.toml does not exist", async () => {
+    await makeCodexPlugin(tempDir, "official", "some-plugin", "1.0.0", {
+      name: "some-plugin",
+    });
+
+    const skills = await scanCodexPluginCache(
+      tempDir,
+      "/tmp/nonexistent-codex-config.toml",
+    );
+    expect(skills[0].codexPlugin?.enabled).toBe(true);
+  });
+
+  it("scanAllSkills includes Codex plugin skills for global scope", async () => {
+    await makeCodexPlugin(tempDir, "official", "codex-p", "1.0.0", {
+      name: "codex-p",
+      version: "1.0.0",
+      description: "A Codex plugin",
+    });
+
+    const config = { ...getDefaultConfig(), providers: [], customPaths: [] };
+    const skills = await scanAllSkills(config, "global", undefined, tempDir);
+    const found = skills.find((s) => s.name === "codex-p");
+    expect(found).toBeDefined();
+    expect(found!.provider).toBe("codex-plugin");
+    expect(found!.scope).toBe("global");
+  });
+
+  it("scanAllSkills excludes Codex plugin skills for project-only scope", async () => {
+    await makeCodexPlugin(tempDir, "official", "codex-proj", "1.0.0", {
+      name: "codex-proj",
+    });
+
+    const config = { ...getDefaultConfig(), providers: [], customPaths: [] };
+    const skills = await scanAllSkills(config, "project", undefined, tempDir);
+    expect(skills.filter((s) => s.provider === "codex-plugin")).toHaveLength(0);
+  });
+
+  it("scanAllSkills deduplicates Codex plugin by name against provider skills", async () => {
+    // Provider skill with same name
+    const providerDir = join(tempDir, "provider");
+    const skillDir = join(providerDir, "my-codex-skill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      "---\nname: my-codex-skill\nversion: 1.0.0\n---\n",
+    );
+
+    // Codex plugin cache with same display name
+    const cacheDir = join(tempDir, "cache");
+    await makeCodexPlugin(cacheDir, "official", "my-codex-skill", "1.0.0", {
+      name: "my-codex-skill",
+      version: "1.0.0",
+    });
+
+    const config = {
+      ...getDefaultConfig(),
+      providers: [
+        {
+          name: "test",
+          label: "Test",
+          global: providerDir,
+          project: "/tmp/nonexistent-proj",
+          enabled: true,
+        },
+      ],
+      customPaths: [],
+    };
+
+    const skills = await scanAllSkills(config, "global", undefined, cacheDir);
+    const matches = skills.filter(
+      (s) => s.name.toLowerCase() === "my-codex-skill",
+    );
+    expect(matches).toHaveLength(1);
+    // Provider wins
+    expect(matches[0].provider).toBe("test");
+  });
+
+  it("scanAllSkills includes Codex plugins for both scope", async () => {
+    await makeCodexPlugin(tempDir, "official", "both-plugin", "1.0.0", {
+      name: "both-plugin",
+    });
+
+    const config = { ...getDefaultConfig(), providers: [], customPaths: [] };
+    const skills = await scanAllSkills(config, "both", undefined, tempDir);
+    expect(skills.find((s) => s.name === "both-plugin")).toBeDefined();
+  });
+});
+
+// ─── readCodexMarketplaceFiles ───────────────────────────────────────────────
+
+describe("readCodexMarketplaceFiles", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "scanner-codex-mkt-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when neither marketplace file exists", async () => {
+    const entries = await readCodexMarketplaceFiles(
+      "/tmp/nonexistent-user-mkt.json",
+      "/tmp/nonexistent-repo-mkt.json",
+    );
+    expect(entries).toEqual([]);
+  });
+
+  it("reads plugins from user-level marketplace.json", async () => {
+    const filePath = join(tempDir, "marketplace.json");
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        plugins: [
+          {
+            name: "plugin-a",
+            source: "github:user/plugin-a",
+            version: "1.0.0",
+          },
+          { name: "plugin-b", description: "Another plugin" },
+        ],
+      }),
+    );
+
+    const entries = await readCodexMarketplaceFiles(
+      filePath,
+      "/tmp/nonexistent-repo.json",
+    );
+    expect(entries).toHaveLength(2);
+    expect(entries[0].name).toBe("plugin-a");
+    expect(entries[1].name).toBe("plugin-b");
+  });
+
+  it("reads skills array from marketplace.json", async () => {
+    const filePath = join(tempDir, "marketplace.json");
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        skills: [{ name: "skill-a" }, { name: "skill-b" }],
+      }),
+    );
+
+    const entries = await readCodexMarketplaceFiles(
+      filePath,
+      "/tmp/nonexistent-repo.json",
+    );
+    expect(entries).toHaveLength(2);
+  });
+
+  it("merges plugins and skills arrays from same file", async () => {
+    const filePath = join(tempDir, "marketplace.json");
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        plugins: [{ name: "plugin-x" }],
+        skills: [{ name: "skill-x" }],
+      }),
+    );
+
+    const entries = await readCodexMarketplaceFiles(
+      filePath,
+      "/tmp/nonexistent-repo.json",
+    );
+    expect(entries).toHaveLength(2);
+  });
+
+  it("deduplicates entries with same name across files", async () => {
+    const userPath = join(tempDir, "user-marketplace.json");
+    const repoPath = join(tempDir, "repo-marketplace.json");
+
+    await writeFile(
+      userPath,
+      JSON.stringify({
+        plugins: [{ name: "shared-plugin", version: "1.0.0" }],
+      }),
+    );
+    await writeFile(
+      repoPath,
+      JSON.stringify({
+        plugins: [
+          { name: "shared-plugin", version: "2.0.0" },
+          { name: "unique-plugin" },
+        ],
+      }),
+    );
+
+    const entries = await readCodexMarketplaceFiles(userPath, repoPath);
+    const names = entries.map((e) => e.name);
+    expect(names.filter((n) => n === "shared-plugin")).toHaveLength(1);
+    expect(names).toContain("unique-plugin");
+    expect(entries).toHaveLength(2);
+  });
+
+  it("skips files with invalid JSON", async () => {
+    const badPath = join(tempDir, "bad.json");
+    await writeFile(badPath, "not valid json");
+
+    const entries = await readCodexMarketplaceFiles(
+      badPath,
+      "/tmp/nonexistent-repo.json",
+    );
+    expect(entries).toEqual([]);
+  });
+
+  it("reads from both user and repo files", async () => {
+    const userPath = join(tempDir, "user.json");
+    const repoPath = join(tempDir, "repo.json");
+    await writeFile(
+      userPath,
+      JSON.stringify({ plugins: [{ name: "user-only" }] }),
+    );
+    await writeFile(
+      repoPath,
+      JSON.stringify({ plugins: [{ name: "repo-only" }] }),
+    );
+
+    const entries = await readCodexMarketplaceFiles(userPath, repoPath);
+    expect(entries.map((e) => e.name).sort()).toEqual([
+      "repo-only",
+      "user-only",
+    ]);
   });
 });

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -621,7 +621,10 @@ export async function scanAllSkills(
   const seenNames = new Set(skills.map((s) => s.name.toLowerCase()));
 
   for (const ps of pluginSkills) {
-    if (!seenRealPaths.has(ps.realPath)) {
+    if (
+      !seenRealPaths.has(ps.realPath) &&
+      !seenNames.has(ps.name.toLowerCase())
+    ) {
       skills.push(ps);
       seenRealPaths.add(ps.realPath);
       seenNames.add(ps.name.toLowerCase());

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -517,7 +517,7 @@ export async function scanCodexPluginCache(
         codexPlugin: {
           category: manifest.interface?.category,
           hasMcpConfig:
-            manifest.mcp !== undefined && Object.keys(manifest.mcp).length > 0,
+            manifest.mcp != null && Object.keys(manifest.mcp).length > 0,
           pluginName,
           pluginVersion: selectedVersion,
           enabled,

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -343,9 +343,7 @@ function parseTomlEnabledMap(toml: string): Map<string, boolean> {
     // Section header: [plugins.plugin-name] or [[plugins]]
     const sectionMatch = line.match(/^\[plugins\.([^\]]+)\]$/);
     if (sectionMatch) {
-      currentPlugin = sectionMatch[1]
-        .trim()
-        .replace(/^["']|["']$/g, "");
+      currentPlugin = sectionMatch[1].trim().replace(/^["']|["']$/g, "");
       continue;
     }
     // Any other section header resets the current plugin context

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -343,7 +343,9 @@ function parseTomlEnabledMap(toml: string): Map<string, boolean> {
     // Section header: [plugins.plugin-name] or [[plugins]]
     const sectionMatch = line.match(/^\[plugins\.([^\]]+)\]$/);
     if (sectionMatch) {
-      currentPlugin = sectionMatch[1].trim();
+      currentPlugin = sectionMatch[1]
+        .trim()
+        .replace(/^["']|["']$/g, "");
       continue;
     }
     // Any other section header resets the current plugin context
@@ -549,6 +551,10 @@ interface CodexMarketplaceFile {
  * `.agents/plugins/` paths. These files list available (not necessarily
  * installed) plugins. This function returns the union of entries from all
  * discovered files, deduplicating by name.
+ *
+ * Note: This is a catalog utility for commands like `asm search` or
+ * `asm install` — it is not wired into `scanAllSkills()` because
+ * marketplace entries lack filesystem paths required by `SkillInfo`.
  *
  * Paths checked:
  *   - `~/.agents/plugins/marketplace.json`

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -15,13 +15,28 @@ import {
 } from "./utils/frontmatter";
 import { resolveProviderPath } from "./config";
 import { debug } from "./logger";
-import type { SkillInfo, Scope, SortBy, AppConfig } from "./utils/types";
+import type {
+  SkillInfo,
+  Scope,
+  SortBy,
+  AppConfig,
+  CodexPluginManifest,
+} from "./utils/types";
 
 const PLUGIN_MARKETPLACES_DIR = join(
   homedir(),
   ".claude",
   "plugins",
   "marketplaces",
+);
+
+const CODEX_PLUGIN_CACHE_DIR = join(homedir(), ".codex", "plugins", "cache");
+const CODEX_CONFIG_PATH = join(homedir(), ".codex", "config.toml");
+const AGENTS_PLUGINS_MARKETPLACE_PATH = join(
+  homedir(),
+  ".agents",
+  "plugins",
+  "marketplace.json",
 );
 
 interface ScanLocation {
@@ -313,26 +328,310 @@ export async function scanPluginMarketplaces(
   return skills;
 }
 
+/**
+ * Parse a subset of TOML key=value lines to extract plugin enabled/disabled state.
+ * Only handles simple `key = true/false` and `key = "string"` entries — this is
+ * intentionally minimal to avoid a TOML parser dependency.
+ */
+function parseTomlEnabledMap(toml: string): Map<string, boolean> {
+  const result = new Map<string, boolean>();
+  let currentPlugin: string | null = null;
+
+  for (const rawLine of toml.split("\n")) {
+    const line = rawLine.trim();
+
+    // Section header: [plugins.plugin-name] or [[plugins]]
+    const sectionMatch = line.match(/^\[plugins\.([^\]]+)\]$/);
+    if (sectionMatch) {
+      currentPlugin = sectionMatch[1].trim();
+      continue;
+    }
+
+    if (currentPlugin && line.startsWith("enabled")) {
+      const valMatch = line.match(/^enabled\s*=\s*(true|false)/i);
+      if (valMatch) {
+        result.set(currentPlugin, valMatch[1].toLowerCase() === "true");
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Load the Codex plugin enabled/disabled map from `~/.codex/config.toml`.
+ * Returns an empty map if the file doesn't exist or cannot be parsed.
+ */
+async function loadCodexEnabledMap(
+  configPath?: string,
+): Promise<Map<string, boolean>> {
+  const path = configPath ?? CODEX_CONFIG_PATH;
+  try {
+    const raw = await readFile(path, "utf-8");
+    return parseTomlEnabledMap(raw);
+  } catch {
+    debug(`codex: config.toml not found at ${path}, skipping enabled check`);
+    return new Map();
+  }
+}
+
+/**
+ * Scan the Codex plugin cache at `~/.codex/plugins/cache/` to discover
+ * installed Codex plugins.
+ *
+ * Cache layout:
+ *   {marketplace}/{plugin}/{version}/.codex-plugin/plugin.json
+ *
+ * Each versioned plugin directory containing `.codex-plugin/plugin.json`
+ * is registered as a SkillInfo entry. The highest version directory is
+ * used when multiple versions are present.
+ */
+export async function scanCodexPluginCache(
+  cacheBaseDir?: string,
+  configPath?: string,
+): Promise<SkillInfo[]> {
+  const cacheDir = cacheBaseDir ?? CODEX_PLUGIN_CACHE_DIR;
+  const skills: SkillInfo[] = [];
+
+  debug(`codex: checking plugin cache at ${cacheDir}`);
+
+  let marketplaces: string[];
+  try {
+    marketplaces = await readdir(cacheDir);
+  } catch {
+    debug(`codex: plugin cache dir not found, skipping`);
+    return skills;
+  }
+
+  const enabledMap = await loadCodexEnabledMap(configPath);
+
+  for (const marketplace of marketplaces) {
+    const marketplacePath = join(cacheDir, marketplace);
+
+    let mStat;
+    try {
+      mStat = await stat(marketplacePath);
+    } catch {
+      continue;
+    }
+    if (!mStat.isDirectory()) continue;
+
+    let plugins: string[];
+    try {
+      plugins = await readdir(marketplacePath);
+    } catch {
+      continue;
+    }
+
+    for (const pluginName of plugins) {
+      const pluginPath = join(marketplacePath, pluginName);
+
+      let pStat;
+      try {
+        pStat = await stat(pluginPath);
+      } catch {
+        continue;
+      }
+      if (!pStat.isDirectory()) continue;
+
+      // Find all version directories and pick the lexicographically last one
+      let versions: string[];
+      try {
+        versions = await readdir(pluginPath);
+      } catch {
+        continue;
+      }
+
+      const versionDirs = (
+        await Promise.all(
+          versions.map(async (v) => {
+            try {
+              const s = await stat(join(pluginPath, v));
+              return s.isDirectory() ? v : null;
+            } catch {
+              return null;
+            }
+          }),
+        )
+      ).filter((v): v is string => v !== null);
+
+      if (versionDirs.length === 0) continue;
+
+      // Use the last version (simple lexicographic — adequate for semver tags)
+      const selectedVersion = versionDirs.sort().at(-1)!;
+      const versionDir = join(pluginPath, selectedVersion);
+
+      const manifestPath = join(versionDir, ".codex-plugin", "plugin.json");
+      let manifest: CodexPluginManifest;
+      try {
+        const raw = await readFile(manifestPath, "utf-8");
+        manifest = JSON.parse(raw) as CodexPluginManifest;
+      } catch {
+        debug(`codex: no valid plugin.json at ${manifestPath}, skipping`);
+        continue;
+      }
+
+      const resolvedPath = resolve(versionDir);
+      let resolvedRealPath: string;
+      try {
+        resolvedRealPath = await realpath(versionDir);
+      } catch {
+        resolvedRealPath = resolvedPath;
+      }
+
+      const skillName =
+        manifest.interface?.displayName || manifest.name || pluginName;
+      const version = manifest.version || selectedVersion;
+      const description = (manifest.description || "")
+        .replace(/\s*\n\s*/g, " ")
+        .trim();
+
+      const enabled = enabledMap.has(pluginName)
+        ? enabledMap.get(pluginName)!
+        : true; // default to enabled if not in config
+
+      skills.push({
+        name: skillName,
+        version,
+        description,
+        creator: "",
+        license: "",
+        compatibility: "",
+        allowedTools: [],
+        dirName: pluginName,
+        path: resolvedPath,
+        originalPath: versionDir,
+        location: `global-codex-plugin-${marketplace}`,
+        scope: "global",
+        provider: "codex-plugin",
+        providerLabel: `Codex Plugin (${marketplace})`,
+        isSymlink: false,
+        symlinkTarget: null,
+        realPath: resolvedRealPath,
+        marketplace,
+        codexPlugin: {
+          category: manifest.interface?.category,
+          hasMcpConfig:
+            manifest.mcp !== undefined && Object.keys(manifest.mcp).length > 0,
+          pluginName,
+          pluginVersion: selectedVersion,
+          enabled,
+        },
+      });
+    }
+  }
+
+  debug(`codex: found ${skills.length} plugin(s) in cache`);
+  return skills;
+}
+
+/** Schema for a marketplace.json entry */
+interface CodexMarketplaceEntry {
+  name: string;
+  source?: string;
+  version?: string;
+  description?: string;
+}
+
+/** Schema for a marketplace.json file */
+interface CodexMarketplaceFile {
+  plugins?: CodexMarketplaceEntry[];
+  skills?: CodexMarketplaceEntry[];
+}
+
+/**
+ * Read Codex marketplace.json files from the user-level and repo-level
+ * `.agents/plugins/` paths. These files list available (not necessarily
+ * installed) plugins. This function returns the union of entries from all
+ * discovered files, deduplicating by name.
+ *
+ * Paths checked:
+ *   - `~/.agents/plugins/marketplace.json`
+ *   - `$CWD/.agents/plugins/marketplace.json`
+ */
+export async function readCodexMarketplaceFiles(
+  userMarketplacePath?: string,
+  repoMarketplacePath?: string,
+): Promise<CodexMarketplaceEntry[]> {
+  const userPath = userMarketplacePath ?? AGENTS_PLUGINS_MARKETPLACE_PATH;
+  const repoPath =
+    repoMarketplacePath ??
+    join(process.cwd(), ".agents", "plugins", "marketplace.json");
+
+  const allEntries: CodexMarketplaceEntry[] = [];
+  const seenNames = new Set<string>();
+
+  for (const filePath of [userPath, repoPath]) {
+    let raw: string;
+    try {
+      raw = await readFile(filePath, "utf-8");
+    } catch {
+      debug(`codex: marketplace.json not found at ${filePath}, skipping`);
+      continue;
+    }
+
+    let data: CodexMarketplaceFile;
+    try {
+      data = JSON.parse(raw) as CodexMarketplaceFile;
+    } catch {
+      debug(`codex: invalid JSON in ${filePath}, skipping`);
+      continue;
+    }
+
+    const entries = [...(data.plugins ?? []), ...(data.skills ?? [])];
+    for (const entry of entries) {
+      if (entry.name && !seenNames.has(entry.name)) {
+        seenNames.add(entry.name);
+        allEntries.push(entry);
+      }
+    }
+  }
+
+  debug(`codex: read ${allEntries.length} marketplace entry(ies)`);
+  return allEntries;
+}
+
 export async function scanAllSkills(
   config: AppConfig,
   scope: Scope,
   pluginBaseDir?: string,
+  codexCacheDir?: string,
 ): Promise<SkillInfo[]> {
   const locations = buildScanLocations(config, scope);
-  const [providerResults, pluginSkills] = await Promise.all([
+  const isGlobal = scope === "global" || scope === "both";
+
+  const [providerResults, pluginSkills, codexPluginSkills] = await Promise.all([
     Promise.all(locations.map(scanDirectory)),
-    scope === "global" || scope === "both"
+    isGlobal
       ? scanPluginMarketplaces(pluginBaseDir)
+      : Promise.resolve([] as SkillInfo[]),
+    isGlobal
+      ? scanCodexPluginCache(codexCacheDir)
       : Promise.resolve([] as SkillInfo[]),
   ]);
   const skills = providerResults.flat();
 
-  // Deduplicate: skip plugin skills whose realPath already appears in provider results
+  // Deduplicate by realPath: provider results win, then Claude plugin results, then Codex plugin results
   const seenRealPaths = new Set(skills.map((s) => s.realPath));
+  const seenNames = new Set(skills.map((s) => s.name.toLowerCase()));
+
   for (const ps of pluginSkills) {
     if (!seenRealPaths.has(ps.realPath)) {
       skills.push(ps);
       seenRealPaths.add(ps.realPath);
+      seenNames.add(ps.name.toLowerCase());
+    }
+  }
+
+  for (const cp of codexPluginSkills) {
+    // Deduplicate by realPath first, then by name across providers
+    if (
+      !seenRealPaths.has(cp.realPath) &&
+      !seenNames.has(cp.name.toLowerCase())
+    ) {
+      skills.push(cp);
+      seenRealPaths.add(cp.realPath);
+      seenNames.add(cp.name.toLowerCase());
     }
   }
 

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -346,6 +346,11 @@ function parseTomlEnabledMap(toml: string): Map<string, boolean> {
       currentPlugin = sectionMatch[1].trim();
       continue;
     }
+    // Any other section header resets the current plugin context
+    if (line.startsWith("[")) {
+      currentPlugin = null;
+      continue;
+    }
 
     if (currentPlugin && line.startsWith("enabled")) {
       const valMatch = line.match(/^enabled\s*=\s*(true|false)/i);
@@ -457,8 +462,8 @@ export async function scanCodexPluginCache(
 
       if (versionDirs.length === 0) continue;
 
-      // Use the last version (simple lexicographic — adequate for semver tags)
-      const selectedVersion = versionDirs.sort().at(-1)!;
+      // Use the highest semver version
+      const selectedVersion = versionDirs.sort(compareSemver).at(-1)!;
       const versionDir = join(pluginPath, selectedVersion);
 
       const manifestPath = join(versionDir, ".codex-plugin", "plugin.json");

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -43,7 +43,7 @@ export interface CodexPluginManifest {
   name: string;
   version?: string;
   description?: string;
-  skills?: string;
+  skills?: string[];
   mcp?: Record<string, unknown>;
   interface?: {
     displayName?: string;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -28,6 +28,29 @@ export interface SkillInfo {
   warnings?: SkillWarning[];
   /** Marketplace name when skill was installed via Claude plugin marketplace */
   marketplace?: string;
+  /** Codex plugin metadata when skill was discovered via Codex plugin cache */
+  codexPlugin?: {
+    category?: string;
+    hasMcpConfig?: boolean;
+    pluginName?: string;
+    pluginVersion?: string;
+    enabled?: boolean;
+  };
+}
+
+/** Codex plugin manifest (`.codex-plugin/plugin.json`) */
+export interface CodexPluginManifest {
+  name: string;
+  version?: string;
+  description?: string;
+  skills?: string;
+  mcp?: Record<string, unknown>;
+  interface?: {
+    displayName?: string;
+    category?: string;
+    capabilities?: string[];
+    branding?: Record<string, unknown>;
+  };
 }
 
 // ─── Lock File Types ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #124

## Summary

- Adds `scanCodexPluginCache()` to discover installed Codex plugins from `~/.codex/plugins/cache/{marketplace}/{plugin}/{version}/.codex-plugin/plugin.json`
- Adds `readCodexMarketplaceFiles()` to read available plugins from `~/.agents/plugins/marketplace.json` and `.agents/plugins/marketplace.json`
- Adds `loadCodexEnabledMap()` with a lightweight TOML parser for `~/.codex/config.toml` enabled/disabled state (no new dependencies)
- Wires Codex plugin scanning into `scanAllSkills()` alongside the existing Claude plugin marketplace scan

## Approach

Follows the established `scanPluginMarketplaces()` pattern exactly. Codex plugins are surfaced as `SkillInfo` entries with `provider: "codex-plugin"` and `providerLabel: "Codex Plugin ({marketplace})"` — no view changes required since all display paths already use `providerLabel`. Deduplication is two-tier: by `realPath` first, then by skill name across Claude and Codex plugin providers.

The TOML parser is intentionally minimal (regex-based `[plugins.name]` section parsing) to avoid adding a dependency. Highest-version directory wins when multiple versions of a plugin are cached.

## Changes

| File | Change |
|------|--------|
| `src/scanner.ts` | Add `scanCodexPluginCache()`, `readCodexMarketplaceFiles()`, `loadCodexEnabledMap()`, `parseTomlEnabledMap()`; update `scanAllSkills()` signature with optional `codexCacheDir`; add `CodexPluginManifest` import |
| `src/utils/types.ts` | Add `codexPlugin?` field to `SkillInfo`; add `CodexPluginManifest` interface |
| `src/formatter.ts` | Add `codex-plugin` entry to `PROVIDER_COLORS` (cyan) |
| `src/scanner.test.ts` | Add 25 tests for `scanCodexPluginCache` and `readCodexMarketplaceFiles` |

## Test Results

80 scanner tests pass (up from 55). Pre-existing failures in `publisher.test.ts` and `cli.test.ts` are unrelated to this change (confirmed present on `main` before this branch).

## Acceptance Criteria

- [x] ASM scans Codex plugin cache path (`~/.codex/plugins/cache/`) to discover installed Codex plugins
- [x] ASM reads Codex marketplace files (`marketplace.json`) from repo-level and user-level `.agents/plugins/` paths
- [x] Codex plugins appear in `asm list` output, distinguished from Claude skills and traditional skills (via `providerLabel: "Codex Plugin (marketplace-name)"`)
- [x] `asm info {skill}` works for Codex plugins and displays plugin manifest metadata (name, version, description, category via `codexPlugin.category`)
- [x] ASM reads `~/.codex/config.toml` to determine enabled/disabled status of Codex plugins
- [x] Deduplication logic detects when the same skill exists across both Claude and Codex plugin paths (name-based cross-provider dedup in `scanAllSkills`)