### PR TITLE
feat(cli): add skill quality evaluator (#119)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1409,6 +1409,14 @@ describe("isCLIMode: newer commands", () => {
   test("index → CLI mode", () => {
     expect(check("index")).toBe(true);
   });
+
+  test("eval → CLI mode", () => {
+    expect(check("eval")).toBe(true);
+  });
+
+  test("doctor → CLI mode", () => {
+    expect(check("doctor")).toBe(true);
+  });
 });
 
 // ─── CLI integration: per-command --help (new commands) ─────────────────────
@@ -1464,6 +1472,101 @@ describe("CLI integration: per-command --help (new commands)", () => {
     expect(stdout).toContain("search");
     expect(stdout).toContain("list");
     expect(stdout).toContain("remove");
+  });
+
+  test("eval --help shows eval usage", async () => {
+    const { stdout, exitCode } = await runCLI("eval", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("asm eval");
+    expect(stdout).toContain("--fix");
+    expect(stdout).toContain("--dry-run");
+    expect(stdout).toContain("--json");
+  });
+});
+
+// ─── CLI integration: eval ─────────────────────────────────────────────────
+
+describe("CLI integration: eval", () => {
+  async function makeTempSkill(
+    body: string,
+  ): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+    const dir = await mkdtemp(join(tmpdir(), "eval-cli-"));
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "SKILL.md"), body, "utf-8");
+    return {
+      dir,
+      cleanup: async () => rm(dir, { recursive: true, force: true }),
+    };
+  }
+
+  test("eval missing path exits with code 2", async () => {
+    const { exitCode, stderr } = await runCLI("eval");
+    expect(exitCode).toBe(2);
+    expect(stderr).toMatch(/Missing required argument/i);
+  });
+
+  test("eval --json emits a parseable report", async () => {
+    const { dir, cleanup } = await makeTempSkill(
+      "---\nname: eval-cli\ndescription: Evaluate a thing when asked.\n---\n\n# eval-cli\n\n## When to Use\n\n- Something\n\n## Instructions\n\n1. Do the thing\n",
+    );
+    try {
+      const { stdout, exitCode } = await runCLI("eval", dir, "--json");
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toHaveProperty("overallScore");
+      expect(parsed).toHaveProperty("categories");
+      expect(Array.isArray(parsed.categories)).toBe(true);
+      expect(parsed.categories.length).toBe(7);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --machine emits v1 envelope", async () => {
+    const { dir, cleanup } = await makeTempSkill(
+      "---\nname: eval-machine\ndescription: Evaluate when asked.\n---\n\nbody\n",
+    );
+    try {
+      const { stdout, exitCode } = await runCLI("eval", dir, "--machine");
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.version).toBe(1);
+      expect(parsed.command).toBe("eval");
+      expect(parsed.status).toBe("ok");
+      expect(parsed.data.overall_score).toBeGreaterThanOrEqual(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --fix --dry-run does not modify SKILL.md", async () => {
+    const original =
+      "---\nname: dry-run-cli\ndescription: Do a thing when asked.\n---\n\nbody\n";
+    const { dir, cleanup } = await makeTempSkill(original);
+    try {
+      const { exitCode } = await runCLI("eval", dir, "--fix", "--dry-run");
+      expect(exitCode).toBe(0);
+      const after = await readFile(join(dir, "SKILL.md"), "utf-8");
+      expect(after).toBe(original);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --fix creates .bak and modifies SKILL.md", async () => {
+    const original =
+      "---\nname: fix-cli\ndescription: Do a thing when asked.\n---\n\nbody\n";
+    const { dir, cleanup } = await makeTempSkill(original);
+    try {
+      const { exitCode } = await runCLI("eval", dir, "--fix");
+      expect(exitCode).toBe(0);
+      const after = await readFile(join(dir, "SKILL.md"), "utf-8");
+      expect(after).toContain("version: 0.1.0");
+      const backup = await readFile(join(dir, "SKILL.md.bak"), "utf-8");
+      expect(backup).toBe(original);
+    } finally {
+      await cleanup();
+    }
   });
 });
 
@@ -2101,7 +2204,9 @@ metadata:
       "claude",
     );
     expect(exitCode).toBe(2);
-    expect(stderr).toContain("--name cannot be used when linking multiple paths");
+    expect(stderr).toContain(
+      "--name cannot be used when linking multiple paths",
+    );
   });
 
   test("link multiple explicit paths one invalid continues and reports failure --json", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,6 +99,15 @@ import {
 } from "./updater";
 import { runAllChecks, formatDoctorReport, formatDoctorJSON } from "./doctor";
 import {
+  evaluateSkill,
+  applyFix,
+  detectGitAuthor,
+  formatReport,
+  formatReportJSON,
+  formatFixPreview,
+  buildEvalMachineData,
+} from "./evaluator";
+import {
   formatMachineOutput,
   formatMachineError,
   ErrorCodes,
@@ -196,6 +205,7 @@ interface ParsedArgs {
     dryRun: boolean;
     machine: boolean;
     noCache: boolean;
+    fix: boolean;
   };
 }
 
@@ -230,6 +240,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       dryRun: false,
       machine: false,
       noCache: false,
+      fix: false,
     },
   };
 
@@ -311,6 +322,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.flags.path = args[i] || null;
     } else if (arg === "--dry-run") {
       result.flags.dryRun = true;
+    } else if (arg === "--fix") {
+      result.flags.fix = true;
     } else if (arg === "--machine") {
       result.flags.machine = true;
     } else if (arg === "--no-cache") {
@@ -375,6 +388,7 @@ ${ansi.bold("Commands:")}
   outdated               Show which installed skills have newer versions
   update [name...]       Update outdated skills with security re-audit
   publish [path]         Validate, audit, and submit a skill to the registry
+  eval <skill-path>      Evaluate a skill against best practices and score it
   bundle                 Manage skill bundles (create, install, list, show, remove)
   index                  Manage skill index (ingest, search, list)
   doctor                 Run environment health checks and diagnostics
@@ -1685,7 +1699,10 @@ async function cmdInstall(args: ParsedArgs) {
 
         const selected = top[choice - 1];
         resolutionSource = "registry";
-        const selectedRepoPath = selected.repository.replace("https://github.com/", "");
+        const selectedRepoPath = selected.repository.replace(
+          "https://github.com/",
+          "",
+        );
         sourceStr = selected.skill_path
           ? `github:${selectedRepoPath}#${selected.commit}:${selected.skill_path}`
           : `github:${selectedRepoPath}#${selected.commit}`;
@@ -2598,6 +2615,149 @@ async function cmdDoctor(args: ParsedArgs) {
   }
 }
 
+// ─── Eval ───────────────────────────────────────────────────────────────────
+
+function printEvalHelp() {
+  console.log(`${ansi.bold("Usage:")} asm eval <skill-path> [options]
+
+Evaluate a skill's SKILL.md against best practices and produce a scored quality
+report. Categories: structure, description quality, prompt engineering, context
+efficiency, safety, testability, and naming conventions.
+
+${ansi.bold("Arguments:")}
+  skill-path           Path to a skill directory (must contain SKILL.md)
+
+${ansi.bold("Options:")}
+  --fix                Apply deterministic auto-fixes to SKILL.md (creates .bak)
+  --dry-run            With --fix, preview the diff without writing
+  --json               Output report as JSON
+  --machine            Output in stable machine-readable v1 envelope format
+  --no-color           Disable ANSI colors
+  -V, --verbose        Show debug output
+
+${ansi.bold("Examples:")}
+  asm eval ./my-skill                  ${ansi.dim("Score the skill")}
+  asm eval ./my-skill --json           ${ansi.dim("Output report as JSON")}
+  asm eval ./my-skill --fix            ${ansi.dim("Auto-fix deterministic frontmatter issues")}
+  asm eval ./my-skill --fix --dry-run  ${ansi.dim("Preview fixes as diff")}
+  asm eval ./my-skill --machine        ${ansi.dim("Machine-readable v1 envelope output")}`);
+}
+
+async function cmdEval(args: ParsedArgs) {
+  if (args.flags.help) {
+    printEvalHelp();
+    return;
+  }
+
+  const restoreConsole = args.flags.machine
+    ? redirectConsoleToStderr()
+    : undefined;
+  const startTime = performance.now();
+
+  // Path is the first positional (carried as `subcommand` by parseArgs).
+  const skillPath = args.subcommand;
+  if (!skillPath) {
+    if (args.flags.machine) {
+      restoreConsole?.();
+      console.log(
+        formatMachineError(
+          "eval",
+          ErrorCodes.INVALID_ARGUMENT,
+          "Missing required argument: <skill-path>",
+          startTime,
+        ),
+      );
+      process.exit(2);
+    }
+    error("Missing required argument: <skill-path>");
+    console.error(`Run "asm eval --help" for usage.`);
+    process.exit(2);
+  }
+
+  try {
+    if (args.flags.fix) {
+      const gitAuthor = await detectGitAuthor();
+      const fix = await applyFix(skillPath, {
+        dryRun: args.flags.dryRun,
+        gitAuthor,
+      });
+
+      if (args.flags.machine) {
+        restoreConsole?.();
+        console.log(
+          formatMachineOutput(
+            "eval",
+            buildEvalMachineData(fix.report, fix),
+            startTime,
+          ),
+        );
+        return;
+      }
+
+      if (args.flags.json) {
+        console.log(
+          JSON.stringify(
+            {
+              report: fix.report,
+              fix: {
+                dryRun: fix.dryRun,
+                applied: fix.applied,
+                skipped: fix.skipped,
+                backupPath: fix.backupPath,
+                diff: fix.diff,
+              },
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+
+      console.log(formatReport(fix.report));
+      console.log("");
+      console.log(formatFixPreview(fix));
+      return;
+    }
+
+    const report = await evaluateSkill(skillPath);
+
+    if (args.flags.machine) {
+      restoreConsole?.();
+      console.log(
+        formatMachineOutput(
+          "eval",
+          buildEvalMachineData(report, null),
+          startTime,
+        ),
+      );
+      return;
+    }
+
+    if (args.flags.json) {
+      console.log(formatReportJSON(report));
+      return;
+    }
+
+    console.log(formatReport(report));
+  } catch (err: any) {
+    if (args.flags.machine) {
+      restoreConsole?.();
+      console.log(
+        formatMachineError(
+          "eval",
+          ErrorCodes.SKILL_NOT_FOUND,
+          err?.message ?? String(err),
+          startTime,
+        ),
+      );
+      process.exit(1);
+    }
+    error(err?.message ?? String(err));
+    process.exit(1);
+  }
+}
+
 // ─── Link ───────────────────────────────────────────────────────────────────
 
 function printLinkHelp() {
@@ -2785,7 +2945,9 @@ async function cmdLink(args: ParsedArgs) {
           const msg = err instanceof Error ? err.message : String(err);
           allFailures.push({ name: sourcePath, error: msg });
           if (!args.flags.json) {
-            console.error(ansi.red(`  Failed to process "${sourcePath}": ${msg}`));
+            console.error(
+              ansi.red(`  Failed to process "${sourcePath}": ${msg}`),
+            );
           }
           continue;
         }
@@ -2817,7 +2979,9 @@ async function cmdLink(args: ParsedArgs) {
             const msg = err instanceof Error ? err.message : String(err);
             allFailures.push({ name: skill.name, error: msg });
             if (!args.flags.json) {
-              console.error(ansi.red(`  Failed to link "${skill.name}": ${msg}`));
+              console.error(
+                ansi.red(`  Failed to link "${skill.name}": ${msg}`),
+              );
             }
           }
         }
@@ -2835,11 +2999,15 @@ async function cmdLink(args: ParsedArgs) {
     } else {
       if (allFailures.length > 0) {
         console.error(
-          ansi.yellow(`\n${allResults.length} linked, ${allFailures.length} failed.`),
+          ansi.yellow(
+            `\n${allResults.length} linked, ${allFailures.length} failed.`,
+          ),
         );
       } else {
         console.error(
-          ansi.green(`\nDone! Linked ${allResults.length} skill(s) successfully.`),
+          ansi.green(
+            `\nDone! Linked ${allResults.length} skill(s) successfully.`,
+          ),
         );
       }
     }
@@ -4163,6 +4331,9 @@ export async function runCLI(argv: string[]): Promise<void> {
     case "doctor":
       await cmdDoctor(args);
       break;
+    case "eval":
+      await cmdEval(args);
+      break;
     default:
       error(`Unknown command: "${args.command}"`);
       console.error(`Run "asm --help" for usage.`);
@@ -4195,6 +4366,8 @@ export function isCLIMode(argv: string[]): boolean {
     "publish",
     "outdated",
     "update",
+    "doctor",
+    "eval",
   ];
   const first = args[0];
 

--- a/src/evaluator.test.ts
+++ b/src/evaluator.test.ts
@@ -1,0 +1,495 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import {
+  buildFixPlan,
+  evaluateSkillContent,
+  evaluateSkill,
+  applyFix,
+  splitSkillMd,
+  unifiedDiff,
+  formatReport,
+  formatReportJSON,
+  formatFixPreview,
+  buildEvalMachineData,
+} from "./evaluator";
+import { mkdtemp, rm, readFile, writeFile, access } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+
+let tempDir: string;
+
+function skillDir(name = "sample-skill") {
+  return join(tempDir, name);
+}
+
+async function writeSkillMd(
+  dir: string,
+  content: string,
+  fileName = "SKILL.md",
+): Promise<string> {
+  const { mkdir } = await import("fs/promises");
+  await mkdir(dir, { recursive: true });
+  const p = join(dir, fileName);
+  await writeFile(p, content, "utf-8");
+  return p;
+}
+
+const HIGH_QUALITY_SKILL = `---
+name: code-review
+description: Review pull request diffs for code smells, style issues, and safety problems before merging.
+version: 1.0.0
+license: MIT
+creator: Test Author
+compatibility: Claude Code
+allowed-tools: Read Grep
+effort: medium
+---
+
+# Code review
+
+## When to Use
+
+- When the user asks to "review this PR" or "check the diff"
+- Before merging any change larger than 10 lines
+
+## Prerequisites
+
+- A git repository with the target branch checked out
+- Read access to the files being reviewed
+
+## Instructions
+
+1. Run \`git diff main...HEAD\` to list files
+2. Read each file and check for common smells
+3. Emit a markdown report summarising findings
+
+## Example
+
+\`\`\`bash
+$ asm eval ./code-review
+Overall score: 95/100
+\`\`\`
+
+## Acceptance Criteria
+
+- Produces a markdown report with sections per file
+- Flags any use of \`eval()\` or \`exec\` as dangerous
+- Does not modify the working tree
+
+## Edge cases
+
+- Empty diffs: emit a short "no changes" note
+- Binary files: skip and mention the filename in the report
+
+## Safety
+
+See \`references/safety.md\` for error handling rules.
+Always confirm before writing. Never run destructive commands without a dry-run.
+`;
+
+const POOR_SKILL = `---
+name: BadName
+description: foo
+---
+
+short
+`;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "eval-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("splitSkillMd", () => {
+  it("splits frontmatter and body", () => {
+    const r = splitSkillMd("---\nname: x\n---\nhello world\n");
+    expect(r.rawFrontmatter).toBe("name: x");
+    expect(r.body.trim()).toBe("hello world");
+  });
+
+  it("handles no frontmatter", () => {
+    const r = splitSkillMd("just markdown\n");
+    expect(r.rawFrontmatter).toBeNull();
+    expect(r.body).toContain("just markdown");
+  });
+
+  it("handles unclosed frontmatter", () => {
+    const r = splitSkillMd("---\nkey: value\nmore\n");
+    expect(r.rawFrontmatter).not.toBeNull();
+  });
+});
+
+describe("evaluateSkillContent", () => {
+  it("scores a high-quality skill highly", () => {
+    const report = evaluateSkillContent({
+      content: HIGH_QUALITY_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+    });
+    expect(report.overallScore).toBeGreaterThan(70);
+    expect(report.grade).not.toBe("F");
+    expect(report.categories).toHaveLength(7);
+  });
+
+  it("returns 7 categories with the expected ids", () => {
+    const report = evaluateSkillContent({
+      content: HIGH_QUALITY_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+    });
+    const ids = report.categories.map((c) => c.id).sort();
+    expect(ids).toEqual(
+      [
+        "context-efficiency",
+        "description",
+        "naming",
+        "prompt-engineering",
+        "safety",
+        "structure",
+        "testability",
+      ].sort(),
+    );
+  });
+
+  it("scores a poor skill lower than a good one", () => {
+    const good = evaluateSkillContent({
+      content: HIGH_QUALITY_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+    });
+    const poor = evaluateSkillContent({
+      content: POOR_SKILL,
+      skillPath: "/virtual/bad",
+      skillMdPath: "/virtual/bad/SKILL.md",
+    });
+    expect(poor.overallScore).toBeLessThan(good.overallScore);
+  });
+
+  it("detects missing frontmatter fields", () => {
+    const report = evaluateSkillContent({
+      content: "---\nname: test\n---\nbody\n",
+      skillPath: "/virtual/test",
+      skillMdPath: "/virtual/test/SKILL.md",
+    });
+    const structure = report.categories.find((c) => c.id === "structure")!;
+    expect(structure.findings.some((f) => /description/i.test(f))).toBe(true);
+  });
+
+  it("penalises very short descriptions", () => {
+    const report = evaluateSkillContent({
+      content: "---\nname: a\ndescription: foo\n---\nbody\n",
+      skillPath: "/virtual/a",
+      skillMdPath: "/virtual/a/SKILL.md",
+    });
+    const desc = report.categories.find((c) => c.id === "description")!;
+    expect(desc.score).toBeLessThan(5);
+  });
+
+  it("rewards action-verb + trigger phrasing in descriptions", () => {
+    const report = evaluateSkillContent({
+      content:
+        "---\nname: x\ndescription: Generate release notes when shipping a new version of the package.\n---\nbody text with content here\n",
+      skillPath: "/virtual/x",
+      skillMdPath: "/virtual/x/SKILL.md",
+    });
+    const desc = report.categories.find((c) => c.id === "description")!;
+    expect(desc.score).toBeGreaterThanOrEqual(7);
+  });
+
+  it("flags non-kebab-case names", () => {
+    const report = evaluateSkillContent({
+      content:
+        "---\nname: BadName\ndescription: Something that does work.\n---\nbody\n",
+      skillPath: "/virtual/BadName",
+      skillMdPath: "/virtual/BadName/SKILL.md",
+    });
+    const naming = report.categories.find((c) => c.id === "naming")!;
+    expect(
+      naming.findings.some((f) => /not lowercase kebab-case/.test(f)),
+    ).toBe(true);
+  });
+
+  it("produces up to 3 top suggestions", () => {
+    const report = evaluateSkillContent({
+      content: POOR_SKILL,
+      skillPath: "/virtual/bad",
+      skillMdPath: "/virtual/bad/SKILL.md",
+    });
+    expect(report.topSuggestions.length).toBeGreaterThan(0);
+    expect(report.topSuggestions.length).toBeLessThanOrEqual(3);
+  });
+
+  it("scores in the 0..100 range", () => {
+    const report = evaluateSkillContent({
+      content: POOR_SKILL,
+      skillPath: "/virtual/bad",
+      skillMdPath: "/virtual/bad/SKILL.md",
+    });
+    expect(report.overallScore).toBeGreaterThanOrEqual(0);
+    expect(report.overallScore).toBeLessThanOrEqual(100);
+  });
+
+  it("awards naming bonus when directory matches frontmatter name", () => {
+    const matchDir = evaluateSkillContent({
+      content:
+        "---\nname: my-skill\ndescription: Generate something when asked.\n---\n# hi\n\n## When to Use\n- thing\n",
+      skillPath: "/virtual/my-skill",
+      skillMdPath: "/virtual/my-skill/SKILL.md",
+    });
+    const mismatchDir = evaluateSkillContent({
+      content:
+        "---\nname: my-skill\ndescription: Generate something when asked.\n---\n# hi\n\n## When to Use\n- thing\n",
+      skillPath: "/virtual/other-dir",
+      skillMdPath: "/virtual/other-dir/SKILL.md",
+    });
+    const matchScore = matchDir.categories.find(
+      (c) => c.id === "naming",
+    )!.score;
+    const mismatchScore = mismatchDir.categories.find(
+      (c) => c.id === "naming",
+    )!.score;
+    expect(matchScore).toBeGreaterThanOrEqual(mismatchScore);
+  });
+});
+
+describe("evaluateSkill (filesystem)", () => {
+  it("reads SKILL.md from a directory", async () => {
+    const dir = skillDir("ok");
+    await writeSkillMd(dir, HIGH_QUALITY_SKILL);
+    const report = await evaluateSkill(dir);
+    expect(report.skillPath).toBe(dir);
+    expect(report.overallScore).toBeGreaterThan(60);
+  });
+
+  it("accepts a direct SKILL.md file path", async () => {
+    const dir = skillDir("ok2");
+    const p = await writeSkillMd(dir, HIGH_QUALITY_SKILL);
+    const report = await evaluateSkill(p);
+    expect(report.skillMdPath).toBe(p);
+  });
+
+  it("throws when path does not exist", async () => {
+    await expect(evaluateSkill(join(tempDir, "missing"))).rejects.toThrow(
+      /does not exist/i,
+    );
+  });
+
+  it("throws when SKILL.md is missing", async () => {
+    const { mkdir } = await import("fs/promises");
+    await mkdir(join(tempDir, "empty"), { recursive: true });
+    await expect(evaluateSkill(join(tempDir, "empty"))).rejects.toThrow(
+      /SKILL\.md/,
+    );
+  });
+});
+
+describe("buildFixPlan", () => {
+  it("adds missing version when absent", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\n---\n\nbody here\n",
+    );
+    expect(plan.newContent).toContain("version: 0.1.0");
+    expect(plan.applied.some((a) => a.id === "add-missing-version")).toBe(true);
+  });
+
+  it("does not touch version when already set", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\nversion: 2.0.0\n---\n\nbody\n",
+    );
+    expect(plan.newContent).not.toContain("version: 0.1.0");
+    expect(plan.applied.some((a) => a.id === "add-missing-version")).toBe(
+      false,
+    );
+  });
+
+  it("adds creator from gitAuthor option when absent", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\n---\n\nbody\n",
+      { gitAuthor: "Jane Doe" },
+    );
+    expect(plan.newContent).toContain("creator: Jane Doe");
+    expect(plan.applied.some((a) => a.id === "add-missing-creator")).toBe(true);
+  });
+
+  it("skips creator when no gitAuthor is provided", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\n---\n\nbody\n",
+    );
+    expect(plan.skipped.some((s) => s.id === "add-missing-creator")).toBe(true);
+  });
+
+  it("infers effort from line count when missing", () => {
+    const longBody = Array.from({ length: 30 }, (_, i) => `line ${i}`).join(
+      "\n",
+    );
+    const plan = buildFixPlan(
+      `---\nname: x\ndescription: do a thing\n---\n\n${longBody}\n`,
+    );
+    expect(plan.newContent).toMatch(/effort: (low|medium|high|max)/);
+    expect(plan.applied.some((a) => a.id === "infer-missing-effort")).toBe(
+      true,
+    );
+  });
+
+  it("normalises CRLF to LF", () => {
+    const plan = buildFixPlan(
+      "---\r\nname: x\r\ndescription: do a thing\r\n---\r\n\r\nbody\r\n",
+    );
+    expect(plan.newContent).not.toContain("\r");
+    expect(plan.applied.some((a) => a.id === "normalise-line-endings")).toBe(
+      true,
+    );
+  });
+
+  it("strips trailing whitespace", () => {
+    const plan = buildFixPlan(
+      "---\nname: x   \ndescription: do a thing  \n---\n\nbody   \n",
+    );
+    expect(plan.applied.some((a) => a.id === "strip-trailing-whitespace")).toBe(
+      true,
+    );
+    expect(plan.newContent).not.toMatch(/[ \t]+\n/);
+  });
+
+  it("reorders frontmatter keys to canonical order", () => {
+    const plan = buildFixPlan(
+      "---\ncreator: Alice\nname: x\nversion: 0.1.0\ndescription: do a thing\n---\n\nbody\n",
+    );
+    expect(plan.applied.some((a) => a.id === "reorder-frontmatter")).toBe(true);
+    const nameIdx = plan.newContent.indexOf("name:");
+    const descIdx = plan.newContent.indexOf("description:");
+    const creatorIdx = plan.newContent.indexOf("creator:");
+    expect(nameIdx).toBeLessThan(descIdx);
+    expect(descIdx).toBeLessThan(creatorIdx);
+  });
+
+  it("leaves description alone (content-level fix)", () => {
+    const plan = buildFixPlan("---\nname: x\n---\n\nbody\n");
+    expect(plan.skipped.some((s) => s.id === "missing-description")).toBe(true);
+  });
+
+  it("skips when there is no frontmatter", () => {
+    const plan = buildFixPlan("# hi\njust markdown\n");
+    expect(plan.skipped.some((s) => s.id === "missing-frontmatter")).toBe(true);
+  });
+});
+
+describe("unifiedDiff", () => {
+  it("returns empty string when contents match", () => {
+    expect(unifiedDiff("abc\n", "abc\n")).toBe("");
+  });
+
+  it("includes +/- lines on change", () => {
+    const d = unifiedDiff("a\nb\nc\n", "a\nX\nc\n");
+    expect(d).toContain("-b");
+    expect(d).toContain("+X");
+  });
+});
+
+describe("applyFix", () => {
+  it("dry-run does NOT modify the file", async () => {
+    const dir = skillDir("dry");
+    const original = "---\nname: dry\ndescription: does a thing\n---\n\nbody\n";
+    await writeSkillMd(dir, original);
+    const r = await applyFix(dir, { dryRun: true, gitAuthor: "Alice" });
+    expect(r.dryRun).toBe(true);
+    const after = await readFile(join(dir, "SKILL.md"), "utf-8");
+    expect(after).toBe(original);
+    expect(r.backupPath).toBeNull();
+    expect(r.applied.length).toBeGreaterThan(0);
+    expect(r.diff).not.toBe("");
+  });
+
+  it("writing applies changes and creates .bak backup", async () => {
+    const dir = skillDir("wet");
+    const original = "---\nname: wet\ndescription: does a thing\n---\n\nbody\n";
+    await writeSkillMd(dir, original);
+    const r = await applyFix(dir, { dryRun: false, gitAuthor: "Alice" });
+    expect(r.dryRun).toBe(false);
+    expect(r.backupPath).toBe(join(dir, "SKILL.md.bak"));
+    const after = await readFile(join(dir, "SKILL.md"), "utf-8");
+    expect(after).toContain("version: 0.1.0");
+    expect(after).toContain("creator: Alice");
+    const backup = await readFile(r.backupPath!, "utf-8");
+    expect(backup).toBe(original);
+  });
+
+  it("is idempotent when nothing needs fixing", async () => {
+    const dir = skillDir("clean");
+    await writeSkillMd(dir, HIGH_QUALITY_SKILL);
+    const r = await applyFix(dir, { dryRun: false, gitAuthor: "Ignored" });
+    expect(r.applied).toEqual([]);
+    expect(r.backupPath).toBeNull();
+    // No changes → .bak should not be created
+    await expect(access(join(dir, "SKILL.md.bak"))).rejects.toThrow();
+  });
+
+  it("report is consistent with the post-fix content", async () => {
+    const dir = skillDir("cons");
+    await writeSkillMd(
+      dir,
+      "---\nname: cons\ndescription: does a specific thing when asked.\n---\n\n# cons\n\nSome body text with enough content to pass basic checks.\n",
+    );
+    const r = await applyFix(dir, { dryRun: false, gitAuthor: "Bob" });
+    expect(r.report.frontmatter.version).toBe("0.1.0");
+    expect(r.report.frontmatter.creator).toBe("Bob");
+  });
+});
+
+describe("formatters", () => {
+  it("formatReport contains key sections", () => {
+    const report = evaluateSkillContent({
+      content: HIGH_QUALITY_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+    });
+    const text = formatReport(report);
+    expect(text).toContain("Overall score:");
+    expect(text).toContain("Categories:");
+    expect(text).toContain("Structure & completeness");
+  });
+
+  it("formatReportJSON returns parseable JSON", () => {
+    const report = evaluateSkillContent({
+      content: HIGH_QUALITY_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+    });
+    const parsed = JSON.parse(formatReportJSON(report));
+    expect(parsed.overallScore).toBeGreaterThan(0);
+    expect(Array.isArray(parsed.categories)).toBe(true);
+  });
+
+  it("buildEvalMachineData has the expected shape", () => {
+    const report = evaluateSkillContent({
+      content: HIGH_QUALITY_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+    });
+    const data = buildEvalMachineData(report);
+    expect(data.overall_score).toBe(report.overallScore);
+    expect(data.categories.length).toBe(7);
+    expect(data.fix).toBeNull();
+  });
+
+  it("formatFixPreview summarises applied and skipped items", () => {
+    const report = evaluateSkillContent({
+      content: HIGH_QUALITY_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+    });
+    const preview = formatFixPreview({
+      report,
+      applied: [{ id: "x", description: "did the thing" }],
+      skipped: [{ id: "y", description: "skipped the other thing" }],
+      diff: "",
+      dryRun: true,
+      backupPath: null,
+      skillMdPath: "/virtual/code-review/SKILL.md",
+    });
+    expect(preview).toContain("did the thing");
+    expect(preview).toContain("skipped the other thing");
+  });
+});

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1,0 +1,1507 @@
+/**
+ * Skill quality evaluator for `asm eval <skill-path>`.
+ *
+ * Evaluates a skill's SKILL.md against skill-authoring best practices and
+ * produces a structured report with per-category scores, an overall score,
+ * and actionable improvement suggestions.
+ *
+ * Categories (7):
+ *   1. Structure & completeness   — frontmatter + markdown structure
+ *   2. Description quality        — specific trigger phrasing, action verbs
+ *   3. Prompt engineering         — progressive disclosure, degrees of freedom, examples
+ *   4. Context efficiency         — references/templates instead of inline content
+ *   5. Safety & guardrails        — error handling, prerequisites, confirmations
+ *   6. Testability                — acceptance criteria, edge cases, verifiable outputs
+ *   7. Naming & conventions       — naming conventions, imperative mood, consistent labels
+ *
+ * Also provides `--fix` / `--fix --dry-run` auto-fix for deterministic
+ * frontmatter issues (ordering, version default, creator from git, effort
+ * inference from size, trailing whitespace, CRLF normalization).
+ *
+ * Schema mapping notes (see also /docs/ARCHITECTURE.md + README "SKILL.md Format"):
+ *   - Issue wording     → codebase convention
+ *   - `author`          → `creator` (or `metadata.creator`)
+ *   - top-level `version` → `metadata.version` (preferred) with `version` fallback
+ *   - `XS/S/M/L/XL`     → `low/medium/high/max`
+ *   - `type`            → not a recognized frontmatter field; ignored by the
+ *                          evaluator so this PR does not silently invent a
+ *                          schema. Downstream issues can add it later.
+ */
+
+import { readFile, writeFile, stat, copyFile, access } from "fs/promises";
+import { join, resolve, basename, isAbsolute } from "path";
+import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface CategoryResult {
+  /** Short, stable id for the category (e.g. "structure"). */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** 0..max integer score. */
+  score: number;
+  /** Maximum attainable score for the category. Always 10 today. */
+  max: number;
+  /** Human-readable findings (positive and negative). */
+  findings: string[];
+  /** Concrete improvement suggestions a human author can act on. */
+  suggestions: string[];
+}
+
+export interface EvaluationReport {
+  /** Path to the evaluated skill directory. */
+  skillPath: string;
+  /** Path to the evaluated SKILL.md. */
+  skillMdPath: string;
+  /** ISO-8601 timestamp of evaluation. */
+  evaluatedAt: string;
+  /** Per-category results. */
+  categories: CategoryResult[];
+  /** Aggregate score in 0..100 (sum of category scores × 100 / sum of maxes). */
+  overallScore: number;
+  /** Letter grade for humans: A/B/C/D/F. */
+  grade: "A" | "B" | "C" | "D" | "F";
+  /** Top N improvement suggestions drawn from the lowest-scoring categories. */
+  topSuggestions: string[];
+  /** Parsed frontmatter (for follow-up tooling). */
+  frontmatter: Record<string, string>;
+}
+
+export interface FixPlanItem {
+  /** Short id of the fix (e.g. "add-missing-version"). */
+  id: string;
+  /** Description of what will change. */
+  description: string;
+}
+
+export interface FixResult {
+  /** Evaluator report run after the fix (or before, in dry-run). */
+  report: EvaluationReport;
+  /** Items that would be / were applied. */
+  applied: FixPlanItem[];
+  /** Items skipped because they are out of scope for auto-fix. */
+  skipped: FixPlanItem[];
+  /** Unified diff between original and fixed SKILL.md. Empty when no changes. */
+  diff: string;
+  /** Whether this was a dry run (no writes). */
+  dryRun: boolean;
+  /** Path to the `.bak` created when writing (null on dry-run or no changes). */
+  backupPath: string | null;
+  /** Path to the (possibly modified) SKILL.md. */
+  skillMdPath: string;
+}
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** Canonical frontmatter key ordering used by the auto-fixer. */
+export const CANONICAL_FIELD_ORDER = [
+  "name",
+  "description",
+  "version",
+  "license",
+  "creator",
+  "compatibility",
+  "allowed-tools",
+  "effort",
+  "tags",
+  "metadata",
+] as const;
+
+/** Words we reward as "action verbs" in descriptions. */
+const ACTION_VERBS = [
+  "add",
+  "analyze",
+  "audit",
+  "build",
+  "check",
+  "configure",
+  "convert",
+  "create",
+  "debug",
+  "deploy",
+  "detect",
+  "edit",
+  "evaluate",
+  "explain",
+  "export",
+  "extract",
+  "fetch",
+  "find",
+  "fix",
+  "format",
+  "generate",
+  "identify",
+  "improve",
+  "index",
+  "inspect",
+  "install",
+  "list",
+  "manage",
+  "migrate",
+  "optimize",
+  "parse",
+  "plan",
+  "prepare",
+  "publish",
+  "refactor",
+  "remove",
+  "rename",
+  "report",
+  "research",
+  "review",
+  "run",
+  "scaffold",
+  "scan",
+  "score",
+  "search",
+  "set",
+  "setup",
+  "show",
+  "summarize",
+  "sync",
+  "test",
+  "transform",
+  "translate",
+  "update",
+  "validate",
+  "verify",
+  "write",
+];
+
+const SAFETY_KEYWORDS = [
+  "confirm",
+  "confirmation",
+  "error",
+  "errors",
+  "fail",
+  "failure",
+  "caution",
+  "warning",
+  "prerequisite",
+  "prerequisites",
+  "requires",
+  "requirements",
+  "rollback",
+  "dry-run",
+  "dry run",
+  "safety",
+  "validate",
+  "validation",
+  "check",
+  "backup",
+];
+
+const TESTABILITY_KEYWORDS = [
+  "acceptance criteria",
+  "expected output",
+  "expected result",
+  "edge case",
+  "edge cases",
+  "test",
+  "tests",
+  "testing",
+  "verify",
+  "verification",
+  "assert",
+  "example input",
+  "example output",
+  "given",
+  "then",
+];
+
+const EFFICIENCY_KEYWORDS = [
+  "reference",
+  "references",
+  "see",
+  "template",
+  "templates",
+  "script",
+  "scripts",
+  "helper",
+  "helpers",
+  "link",
+];
+
+const PROGRESSIVE_DISCLOSURE_KEYWORDS = [
+  "when to use",
+  "quick start",
+  "overview",
+  "instructions",
+  "steps",
+  "workflow",
+  "phases",
+  "progressive",
+];
+
+// ─── Body / Frontmatter helpers ─────────────────────────────────────────────
+
+/**
+ * Split SKILL.md content into `{ frontmatter, body, rawFrontmatter }`.
+ * If no frontmatter block is present, `rawFrontmatter` is null and the entire
+ * content is returned as the body.
+ */
+export function splitSkillMd(content: string): {
+  rawFrontmatter: string | null;
+  body: string;
+} {
+  const lines = content.split("\n");
+  if (lines.length === 0 || lines[0].trim() !== "---") {
+    return { rawFrontmatter: null, body: content };
+  }
+
+  // Find the closing `---`
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      const fm = lines.slice(1, i).join("\n");
+      const body = lines.slice(i + 1).join("\n");
+      return { rawFrontmatter: fm, body };
+    }
+  }
+
+  // Unclosed frontmatter → treat entire rest as "frontmatter-ish"
+  return {
+    rawFrontmatter: lines.slice(1).join("\n"),
+    body: "",
+  };
+}
+
+function lineCount(str: string): number {
+  if (!str) return 0;
+  return str.split("\n").length;
+}
+
+function wordCount(str: string): number {
+  if (!str) return 0;
+  return str
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean).length;
+}
+
+function hasAnyHeading(body: string, min = 1): boolean {
+  const headings = body.match(/^#{1,6}\s+\S/gm) || [];
+  return headings.length >= min;
+}
+
+function containsAny(text: string, needles: string[]): string[] {
+  const lc = text.toLowerCase();
+  return needles.filter((n) => lc.includes(n));
+}
+
+function hasCodeBlock(body: string): boolean {
+  return /```[\s\S]+?```/m.test(body);
+}
+
+function hasList(body: string): boolean {
+  return /^\s*[-*]\s+\S/m.test(body) || /^\s*\d+\.\s+\S/m.test(body);
+}
+
+// ─── Category scorers ───────────────────────────────────────────────────────
+// Each scorer takes the parsed frontmatter + body and returns a 0..10 score.
+
+function scoreStructure(
+  fm: Record<string, string>,
+  body: string,
+  rawFrontmatter: string | null,
+): CategoryResult {
+  const findings: string[] = [];
+  const suggestions: string[] = [];
+  let score = 0;
+
+  // Frontmatter present?  (2 pts)
+  if (rawFrontmatter !== null) {
+    score += 2;
+    findings.push("Has YAML frontmatter block.");
+  } else {
+    findings.push("SKILL.md has no YAML frontmatter.");
+    suggestions.push(
+      "Add a YAML frontmatter block delimited by `---` with at least `name` and `description` fields.",
+    );
+  }
+
+  // Required fields (3 pts)
+  const hasName = Boolean(fm.name && fm.name.trim());
+  const hasDescription = Boolean(fm.description && fm.description.trim());
+  if (hasName) score += 1.5;
+  else {
+    findings.push("Missing required field: name.");
+    suggestions.push(
+      "Add `name:` to frontmatter (use the skill directory name).",
+    );
+  }
+  if (hasDescription) score += 1.5;
+  else {
+    findings.push("Missing required field: description.");
+    suggestions.push("Add a one-line `description:` to frontmatter.");
+  }
+
+  // Recommended fields (3 pts)
+  const version = resolveVersion(fm);
+  const versionKnown = version && version !== "0.0.0";
+  if (versionKnown) score += 1;
+  else {
+    findings.push("Missing or default version.");
+    suggestions.push(
+      "Set `metadata.version` (or top-level `version`) using semver (e.g. 0.1.0).",
+    );
+  }
+
+  const hasCreator = Boolean(fm.creator || fm["metadata.creator"]);
+  if (hasCreator) score += 1;
+  else {
+    findings.push("Missing `creator`.");
+    suggestions.push(
+      "Add a `creator` field so users know who authored and maintains the skill.",
+    );
+  }
+
+  const hasLicense = Boolean(fm.license);
+  if (hasLicense) score += 1;
+  else {
+    findings.push("Missing `license`.");
+    suggestions.push("Add a `license` field (e.g. `license: MIT`).");
+  }
+
+  // Body structure (2 pts)
+  const body20 = body.trim().length >= 20;
+  const hasHeadings = hasAnyHeading(body, 1);
+  if (body20) {
+    score += 1;
+    findings.push("Body has meaningful content.");
+  } else {
+    findings.push("Body content is too short (<20 chars of instructions).");
+    suggestions.push(
+      "Flesh out the markdown body with at least one paragraph of instructions for the agent.",
+    );
+  }
+  if (hasHeadings) {
+    score += 1;
+    findings.push("Body uses markdown headings.");
+  } else {
+    findings.push("Body has no markdown headings.");
+    suggestions.push(
+      "Add section headings (e.g. `## When to Use`, `## Instructions`) so the agent can navigate the skill quickly.",
+    );
+  }
+
+  return {
+    id: "structure",
+    name: "Structure & completeness",
+    score: Math.round(score),
+    max: 10,
+    findings,
+    suggestions,
+  };
+}
+
+function scoreDescription(
+  fm: Record<string, string>,
+  _body: string,
+): CategoryResult {
+  const findings: string[] = [];
+  const suggestions: string[] = [];
+  let score = 0;
+
+  const desc = (fm.description || "").trim();
+  if (!desc) {
+    findings.push("No description.");
+    suggestions.push(
+      "Write a one-sentence description that says specifically what the skill does and when to use it.",
+    );
+    return {
+      id: "description",
+      name: "Description quality",
+      score: 0,
+      max: 10,
+      findings,
+      suggestions,
+    };
+  }
+
+  const words = wordCount(desc);
+  findings.push(`Description is ${words} words.`);
+
+  // Length sweet spot: 8..40 words (4 pts)
+  if (words >= 8 && words <= 40) {
+    score += 4;
+  } else if (words >= 5 && words < 8) {
+    score += 2;
+    suggestions.push(
+      "Lengthen the description slightly so it names both the action and the trigger (aim for 8–20 words).",
+    );
+  } else if (words >= 41 && words <= 60) {
+    score += 2;
+    suggestions.push(
+      "Trim the description — aim for under 40 words. Move the long version to the markdown body.",
+    );
+  } else if (words > 60) {
+    score += 0;
+    suggestions.push(
+      "Description is too long. Keep it under 40 words; put detail in the body.",
+    );
+  } else {
+    score += 0;
+    suggestions.push("Description is too short. Aim for 8–20 words.");
+  }
+
+  // Starts with a lowercase imperative / action verb (3 pts)
+  const firstWord = desc
+    .split(/\s+/)[0]
+    ?.toLowerCase()
+    .replace(/[^\w-]/g, "");
+  const hasActionVerb = Boolean(
+    firstWord &&
+    (ACTION_VERBS.includes(firstWord) ||
+      ACTION_VERBS.includes(firstWord.replace(/s$/, ""))),
+  );
+  if (hasActionVerb) {
+    score += 3;
+    findings.push("Starts with an action verb.");
+  } else {
+    findings.push(
+      `Does not start with a recognized action verb (got "${firstWord ?? ""}").`,
+    );
+    suggestions.push(
+      'Start the description with an imperative action verb (e.g. "Generate...", "Analyze...", "Review...").',
+    );
+  }
+
+  // Mentions a specific trigger / "use when" / "for" (3 pts)
+  const hasTrigger =
+    /\buse when\b|\btrigger\b|\bwhen\b|\bfor\b/i.test(desc) ||
+    /\b(before|after|during)\b/i.test(desc);
+  if (hasTrigger) {
+    score += 3;
+    findings.push("Mentions a trigger or use-case signal.");
+  } else {
+    findings.push("No explicit trigger / use-case phrase.");
+    suggestions.push(
+      'Name the trigger in the description — e.g. "Use when...", "for reviewing...", "before publishing...".',
+    );
+  }
+
+  return {
+    id: "description",
+    name: "Description quality",
+    score: Math.min(10, Math.round(score)),
+    max: 10,
+    findings,
+    suggestions,
+  };
+}
+
+function scorePromptEngineering(
+  _fm: Record<string, string>,
+  body: string,
+): CategoryResult {
+  const findings: string[] = [];
+  const suggestions: string[] = [];
+  let score = 0;
+
+  // Progressive disclosure cues: section structure (3 pts)
+  const pdMatches = containsAny(body, PROGRESSIVE_DISCLOSURE_KEYWORDS);
+  if (pdMatches.length >= 2) {
+    score += 3;
+    findings.push(
+      `Progressive disclosure cues present: ${pdMatches.slice(0, 3).join(", ")}.`,
+    );
+  } else if (pdMatches.length === 1) {
+    score += 1;
+    suggestions.push(
+      'Add clearer section labels — e.g. "## When to Use" and "## Instructions" — to support progressive disclosure.',
+    );
+  } else {
+    suggestions.push(
+      'Structure the body with "## When to Use" and "## Instructions" sections so the agent reads only what it needs.',
+    );
+  }
+
+  // Lists / steps / ordered instructions (2 pts)
+  if (hasList(body)) {
+    score += 2;
+    findings.push("Uses lists or numbered steps.");
+  } else {
+    findings.push("No lists or steps detected.");
+    suggestions.push(
+      "Use bulleted or numbered steps to narrow the agent's degrees of freedom.",
+    );
+  }
+
+  // Includes examples (2 pts)
+  const hasCode = hasCodeBlock(body);
+  const mentionsExample = /\bexample\b/i.test(body);
+  if (hasCode && mentionsExample) {
+    score += 2;
+    findings.push("Includes example code block.");
+  } else if (hasCode || mentionsExample) {
+    score += 1;
+    suggestions.push(
+      'Back up examples with fenced code blocks labelled under "## Example" so the agent sees concrete input/output.',
+    );
+  } else {
+    suggestions.push(
+      'Add an "## Example" section with a fenced code block showing the desired output.',
+    );
+  }
+
+  // Minimizes degrees of freedom: imperative sentences, explicit phrasing (2 pts)
+  const imperativeHits = (
+    body.match(
+      /^\s*[-*0-9.]*\s*(Do|Use|Run|Call|Check|Validate|Return|Emit|Write|Read|Ask|Confirm|Avoid|Never|Always)\b/gim,
+    ) || []
+  ).length;
+  if (imperativeHits >= 3) {
+    score += 2;
+    findings.push(`Uses imperative voice (${imperativeHits} cues).`);
+  } else if (imperativeHits >= 1) {
+    score += 1;
+    suggestions.push(
+      "Favor imperative voice (Do / Use / Avoid / Never) to narrow the agent's choices.",
+    );
+  } else {
+    suggestions.push(
+      'Rewrite instructions in the imperative mood — e.g. "Run `git status` first" instead of "you might want to run".',
+    );
+  }
+
+  // Length sanity (1 pt) — penalize massive or tiny bodies
+  const words = wordCount(body);
+  if (words >= 80 && words <= 3000) {
+    score += 1;
+    findings.push(`Body length within healthy range (${words} words).`);
+  } else if (words < 80) {
+    findings.push(`Body is very short (${words} words).`);
+    suggestions.push(
+      "Expand the instructions; an underspecified skill gives the agent too much freedom.",
+    );
+  } else {
+    findings.push(`Body is very long (${words} words).`);
+    suggestions.push(
+      "Split large content into referenced files; keep SKILL.md focused under ~3000 words.",
+    );
+  }
+
+  return {
+    id: "prompt-engineering",
+    name: "Prompt engineering",
+    score: Math.min(10, Math.round(score)),
+    max: 10,
+    findings,
+    suggestions,
+  };
+}
+
+function scoreContextEfficiency(
+  _fm: Record<string, string>,
+  body: string,
+): CategoryResult {
+  const findings: string[] = [];
+  const suggestions: string[] = [];
+  let score = 0;
+
+  const words = wordCount(body);
+  findings.push(`Body is ${words} words.`);
+
+  // Ideal window: 120..1500 words (4 pts)
+  if (words >= 120 && words <= 1500) {
+    score += 4;
+  } else if (words >= 60 && words < 120) {
+    score += 2;
+    suggestions.push(
+      "Expand instructions slightly — too little context can push the agent to improvise.",
+    );
+  } else if (words > 1500 && words <= 3000) {
+    score += 2;
+    suggestions.push(
+      "Consider moving large sections into referenced files (e.g. `references/*.md`) and linking them instead of inlining.",
+    );
+  } else if (words > 3000) {
+    score += 0;
+    suggestions.push(
+      "Body is over 3000 words — split long content into referenced files or templates.",
+    );
+  }
+
+  // References / see / links (3 pts)
+  const refMatches = containsAny(body, EFFICIENCY_KEYWORDS);
+  if (refMatches.length >= 2) {
+    score += 3;
+    findings.push(
+      `References external files or links (${refMatches.slice(0, 3).join(", ")}).`,
+    );
+  } else if (refMatches.length === 1) {
+    score += 1;
+    suggestions.push(
+      'Link out to supporting files (e.g. "see `references/examples.md`") instead of inlining them.',
+    );
+  } else {
+    suggestions.push(
+      'Offload verbose content to referenced files and link to them ("see `./templates/x.md`").',
+    );
+  }
+
+  // No giant code blocks (2 pts)
+  const codeBlocks = body.match(/```[\s\S]+?```/g) || [];
+  const largeBlocks = codeBlocks.filter((b) => lineCount(b) > 60);
+  if (largeBlocks.length === 0) {
+    score += 2;
+    findings.push("No oversized code blocks.");
+  } else {
+    findings.push(`${largeBlocks.length} code block(s) longer than 60 lines.`);
+    suggestions.push(
+      "Move large code blocks into referenced template files; link to them from SKILL.md.",
+    );
+  }
+
+  // Explicit token/budget mention is a bonus (1 pt)
+  if (/\btoken\b|\bbudget\b|\bcontext window\b/i.test(body)) {
+    score += 1;
+    findings.push("Mentions tokens/budget/context window.");
+  }
+
+  return {
+    id: "context-efficiency",
+    name: "Context efficiency",
+    score: Math.min(10, Math.round(score)),
+    max: 10,
+    findings,
+    suggestions,
+  };
+}
+
+function scoreSafety(
+  _fm: Record<string, string>,
+  body: string,
+): CategoryResult {
+  const findings: string[] = [];
+  const suggestions: string[] = [];
+  let score = 0;
+
+  const hits = containsAny(body, SAFETY_KEYWORDS);
+  if (hits.length >= 4) {
+    score += 4;
+    findings.push(
+      `Covers multiple safety cues (${hits.slice(0, 4).join(", ")}).`,
+    );
+  } else if (hits.length >= 2) {
+    score += 2;
+    findings.push(`Mentions a few safety cues: ${hits.join(", ")}.`);
+    suggestions.push(
+      "Add explicit error-handling and confirmation steps so the agent knows how to recover from failures.",
+    );
+  } else if (hits.length === 1) {
+    score += 1;
+    suggestions.push(
+      'Expand the safety section — include prerequisites, validation steps, and what to do "on error".',
+    );
+  } else {
+    suggestions.push(
+      "Describe prerequisites, confirmation prompts, and error-handling steps to reduce blast radius.",
+    );
+  }
+
+  // Destructive action guardrails (3 pts)
+  const mentionsDestructive =
+    /\b(rm\s|delete|remove|drop|force|overwrite|destructive)\b/i.test(body);
+  const mentionsConfirm =
+    /\bconfirm\b|\bdry-?run\b|\bare you sure\b|\bbackup\b/i.test(body);
+  if (mentionsDestructive && mentionsConfirm) {
+    score += 3;
+    findings.push("Destructive actions paired with confirmation/dry-run.");
+  } else if (mentionsDestructive) {
+    findings.push(
+      "References destructive actions without explicit confirmation/dry-run.",
+    );
+    suggestions.push(
+      "Pair any destructive command with an explicit confirmation prompt, dry-run flag, or backup step.",
+    );
+  } else {
+    // No destructive actions mentioned — neutral (add half of the bucket)
+    score += 1.5;
+  }
+
+  // Prerequisites / requirements (3 pts)
+  const hasPrereq =
+    /\bprerequisit/i.test(body) ||
+    /\brequire/i.test(body) ||
+    /\bdepend/i.test(body);
+  if (hasPrereq) {
+    score += 3;
+    findings.push("Declares prerequisites or requirements.");
+  } else {
+    findings.push("No prerequisites / requirements section.");
+    suggestions.push(
+      'Add a "## Prerequisites" block listing required tools, credentials, and environment state.',
+    );
+  }
+
+  return {
+    id: "safety",
+    name: "Safety & guardrails",
+    score: Math.min(10, Math.round(score)),
+    max: 10,
+    findings,
+    suggestions,
+  };
+}
+
+function scoreTestability(
+  _fm: Record<string, string>,
+  body: string,
+): CategoryResult {
+  const findings: string[] = [];
+  const suggestions: string[] = [];
+  let score = 0;
+
+  const hits = containsAny(body, TESTABILITY_KEYWORDS);
+  if (hits.length >= 4) {
+    score += 5;
+    findings.push(
+      `Many testability cues present (${hits.slice(0, 4).join(", ")}).`,
+    );
+  } else if (hits.length >= 2) {
+    score += 3;
+    findings.push(`Some testability cues: ${hits.join(", ")}.`);
+    suggestions.push(
+      'Add an "## Acceptance Criteria" block listing verifiable outputs or checklist items.',
+    );
+  } else if (hits.length === 1) {
+    score += 1;
+    suggestions.push(
+      'Add concrete "expected output" examples so the agent can self-check.',
+    );
+  } else {
+    suggestions.push(
+      'Add a "## Acceptance Criteria" section with testable statements (e.g. "produces a JSON report with overall_score").',
+    );
+  }
+
+  // Explicit examples of expected output (3 pts)
+  if (/expected\s+(output|result|response)/i.test(body)) {
+    score += 3;
+    findings.push("Describes expected output/result.");
+  } else {
+    suggestions.push(
+      'Include an "Expected output" example so reviewers and the agent can verify correctness.',
+    );
+  }
+
+  // Edge cases / pitfalls (2 pts)
+  if (/\bedge case|gotcha|pitfall|limitation/i.test(body)) {
+    score += 2;
+    findings.push("Mentions edge cases or limitations.");
+  } else {
+    suggestions.push(
+      'Add a short "Edge cases" list to describe inputs the skill should reject or handle carefully.',
+    );
+  }
+
+  return {
+    id: "testability",
+    name: "Testability",
+    score: Math.min(10, Math.round(score)),
+    max: 10,
+    findings,
+    suggestions,
+  };
+}
+
+function scoreNaming(fm: Record<string, string>, body: string): CategoryResult {
+  const findings: string[] = [];
+  const suggestions: string[] = [];
+  let score = 0;
+
+  const name = (fm.name || "").trim();
+
+  // Kebab-case lowercase, <= 40 chars (4 pts)
+  if (name) {
+    const kebab = /^[a-z][a-z0-9-]*$/.test(name);
+    const slim = name.length <= 40;
+    if (kebab && slim) {
+      score += 4;
+      findings.push(`name "${name}" follows kebab-case convention.`);
+    } else {
+      if (!kebab) {
+        findings.push(`name "${name}" is not lowercase kebab-case.`);
+        suggestions.push(
+          `Rename to lowercase kebab-case (e.g. "${name
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-+|-+$/g, "")}").`,
+        );
+      }
+      if (!slim) {
+        findings.push(`name is ${name.length} chars; keep it <= 40.`);
+      }
+    }
+  } else {
+    suggestions.push("Add a kebab-case `name` (e.g. `my-skill`).");
+  }
+
+  // Imperative tone in top-level headings (3 pts)
+  const headings = body.match(/^#{1,6}\s+(.+)$/gm) || [];
+  if (headings.length > 0) {
+    const imperative = headings.filter((h) =>
+      /^#{1,6}\s+([A-Z][a-z]+|Use|How|When|Workflow|Instructions|Examples|Steps|Acceptance)/.test(
+        h,
+      ),
+    );
+    const ratio = imperative.length / headings.length;
+    if (ratio >= 0.5) {
+      score += 3;
+      findings.push("Most headings use action/imperative labels.");
+    } else {
+      score += 1;
+      suggestions.push(
+        "Rename body headings to action-oriented labels (e.g. `## Instructions`, `## When to Use`).",
+      );
+    }
+  }
+
+  // Consistent labels (2 pts): both `description` and `name` do not contain stray punctuation
+  const descNoise = /(?:\s\s|\bTODO\b|\bFIXME\b|\?{2,})/.test(
+    fm.description || "",
+  );
+  if (!descNoise) {
+    score += 2;
+    findings.push("Description looks clean (no TODO/FIXME/stray noise).");
+  } else {
+    suggestions.push(
+      "Clean up description — remove TODOs, FIXMEs, double spaces, or trailing punctuation.",
+    );
+  }
+
+  // Directory basename matches `name` (1 pt) — caller passes skillPath
+  // Handled later at report aggregation level, so keep this scorer stateless.
+
+  return {
+    id: "naming",
+    name: "Naming & conventions",
+    score: Math.min(10, Math.round(score)),
+    max: 10,
+    findings,
+    suggestions,
+  };
+}
+
+// ─── Report aggregator ─────────────────────────────────────────────────────
+
+/**
+ * Compute the full evaluation report for a parsed SKILL.md.
+ */
+export function evaluateSkillContent(args: {
+  content: string;
+  skillPath: string;
+  skillMdPath: string;
+}): EvaluationReport {
+  const { content, skillPath, skillMdPath } = args;
+  const fm = parseFrontmatter(content);
+  const { rawFrontmatter, body } = splitSkillMd(content);
+
+  const categories: CategoryResult[] = [
+    scoreStructure(fm, body, rawFrontmatter),
+    scoreDescription(fm, body),
+    scorePromptEngineering(fm, body),
+    scoreContextEfficiency(fm, body),
+    scoreSafety(fm, body),
+    scoreTestability(fm, body),
+    scoreNaming(fm, body),
+  ];
+
+  // Naming bonus: directory basename matches `name` frontmatter
+  if (fm.name && basename(skillPath) === fm.name) {
+    const naming = categories.find((c) => c.id === "naming")!;
+    if (naming.score < naming.max) {
+      naming.score = Math.min(naming.max, naming.score + 1);
+      naming.findings.push("Directory name matches frontmatter `name`.");
+    }
+  }
+
+  const sumScore = categories.reduce((s, c) => s + c.score, 0);
+  const sumMax = categories.reduce((s, c) => s + c.max, 0);
+  const overallScore = Math.round((sumScore / sumMax) * 100);
+
+  let grade: EvaluationReport["grade"] = "F";
+  if (overallScore >= 90) grade = "A";
+  else if (overallScore >= 80) grade = "B";
+  else if (overallScore >= 65) grade = "C";
+  else if (overallScore >= 50) grade = "D";
+
+  // Top 3 suggestions: pick from the 3 lowest-scoring categories
+  const topSuggestions: string[] = [];
+  const sortedByScore = [...categories].sort(
+    (a, b) => a.score / a.max - b.score / b.max,
+  );
+  for (const cat of sortedByScore) {
+    for (const s of cat.suggestions) {
+      if (topSuggestions.length >= 3) break;
+      if (!topSuggestions.includes(s)) topSuggestions.push(s);
+    }
+    if (topSuggestions.length >= 3) break;
+  }
+
+  return {
+    skillPath,
+    skillMdPath,
+    evaluatedAt: new Date().toISOString(),
+    categories,
+    overallScore,
+    grade,
+    topSuggestions,
+    frontmatter: fm,
+  };
+}
+
+/**
+ * Read SKILL.md from a skill directory and evaluate it.
+ * Throws if the path does not exist or SKILL.md is missing.
+ */
+export async function evaluateSkill(
+  skillPath: string,
+): Promise<EvaluationReport> {
+  const resolved = isAbsolute(skillPath) ? skillPath : resolve(skillPath);
+
+  let s;
+  try {
+    s = await stat(resolved);
+  } catch {
+    throw new Error(`Skill path does not exist: ${resolved}`);
+  }
+
+  let skillMdPath: string;
+  let content: string;
+
+  if (s.isFile()) {
+    // Accept a direct SKILL.md path
+    skillMdPath = resolved;
+    content = await readFile(skillMdPath, "utf-8");
+    return evaluateSkillContent({
+      content,
+      skillPath:
+        basename(resolved) === "SKILL.md" ? basename(resolved) : resolved,
+      skillMdPath,
+    });
+  }
+
+  if (!s.isDirectory()) {
+    throw new Error(`Skill path is not a directory or file: ${resolved}`);
+  }
+
+  skillMdPath = join(resolved, "SKILL.md");
+  try {
+    content = await readFile(skillMdPath, "utf-8");
+  } catch {
+    throw new Error(
+      `SKILL.md not found in ${resolved}. Run "asm init" to create one.`,
+    );
+  }
+
+  return evaluateSkillContent({
+    content,
+    skillPath: resolved,
+    skillMdPath,
+  });
+}
+
+// ─── Auto-fix pipeline ─────────────────────────────────────────────────────
+
+/**
+ * Compute a deterministic fix plan + new SKILL.md content for the given
+ * original content. Caller decides whether to write to disk or dry-run.
+ *
+ * Only low-risk, deterministic edits are applied:
+ *   - Add missing `version` as `0.1.0`
+ *   - Add missing `creator` from git `user.name` if available
+ *   - Infer `effort` from body line count (low/medium/high/max)
+ *   - Normalise trailing whitespace and CRLF line endings
+ *   - Ensure a blank line between `---` and body
+ *   - Reorder frontmatter keys to canonical order when all keys are simple
+ *
+ * Description-quality fixes and other subjective content are NEVER auto-fixed;
+ * they're returned in `skipped`.
+ */
+export interface BuildFixPlanOptions {
+  /** Optional git author string to use when `creator` is missing. */
+  gitAuthor?: string | null;
+}
+
+export interface BuildFixPlanResult {
+  /** Transformed SKILL.md. Same as original if nothing changed. */
+  newContent: string;
+  applied: FixPlanItem[];
+  skipped: FixPlanItem[];
+}
+
+function inferEffortFromLines(bodyLines: number): string {
+  if (bodyLines <= 20) return "low";
+  if (bodyLines <= 80) return "medium";
+  if (bodyLines <= 250) return "high";
+  return "max";
+}
+
+/**
+ * Rewrite a frontmatter block so that canonical top-level keys appear in a
+ * consistent order. The rewriter is intentionally conservative: it only touches
+ * simple `key: value` scalars. Nested blocks (e.g. `metadata:` with indented
+ * children) are preserved verbatim at their current position.
+ */
+function reorderFrontmatter(raw: string): {
+  newFrontmatter: string;
+  changed: boolean;
+} {
+  const lines = raw.split("\n");
+  type Entry = { key: string; text: string };
+  const simple: Entry[] = [];
+  const nested: Entry[] = []; // kept at end, in original relative order
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (!trimmed) {
+      // blank line — attach to previous context implicitly by ignoring it
+      i++;
+      continue;
+    }
+    const match = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (!match) {
+      // Non key-value line at top-level — bail out, treat as unsafe to reorder
+      return { newFrontmatter: raw, changed: false };
+    }
+    const key = match[1];
+    const rest = match[2];
+    if (rest === "" || rest === ">" || rest === "|") {
+      // Nested block or multiline — collect until next non-indented, non-blank line
+      const block: string[] = [line];
+      i++;
+      while (i < lines.length) {
+        const nxt = lines[i];
+        if (nxt.trim() === "") {
+          block.push(nxt);
+          i++;
+          continue;
+        }
+        if (/^\s+/.test(nxt)) {
+          block.push(nxt);
+          i++;
+        } else {
+          break;
+        }
+      }
+      nested.push({ key, text: block.join("\n") });
+    } else {
+      simple.push({ key, text: line });
+      i++;
+    }
+  }
+
+  // Sort simple entries by canonical order; unknown keys preserve original order after known.
+  const orderIndex = (k: string) => {
+    const idx = CANONICAL_FIELD_ORDER.indexOf(
+      k as (typeof CANONICAL_FIELD_ORDER)[number],
+    );
+    return idx === -1 ? CANONICAL_FIELD_ORDER.length + 1 : idx;
+  };
+  const sortedSimple = [...simple].sort((a, b) => {
+    const da = orderIndex(a.key);
+    const db = orderIndex(b.key);
+    if (da !== db) return da - db;
+    return simple.indexOf(a) - simple.indexOf(b);
+  });
+
+  const simpleChanged = sortedSimple.some((e, idx) => e !== simple[idx]);
+
+  const rebuilt = [
+    ...sortedSimple.map((e) => e.text),
+    ...nested.map((e) => e.text),
+  ].join("\n");
+  return {
+    newFrontmatter: rebuilt,
+    changed: simpleChanged,
+  };
+}
+
+/**
+ * Build the fix plan and the transformed SKILL.md content.
+ */
+export function buildFixPlan(
+  originalContent: string,
+  options: BuildFixPlanOptions = {},
+): BuildFixPlanResult {
+  const applied: FixPlanItem[] = [];
+  const skipped: FixPlanItem[] = [];
+
+  // Normalise CRLF → LF once up front
+  let working = originalContent.replace(/\r\n/g, "\n");
+  if (working !== originalContent) {
+    applied.push({
+      id: "normalise-line-endings",
+      description: "Convert CRLF line endings to LF.",
+    });
+  }
+
+  // Strip trailing whitespace on each line.
+  const lines = working.split("\n");
+  const stripped = lines.map((l) => l.replace(/[ \t]+$/g, ""));
+  if (stripped.some((l, i) => l !== lines[i])) {
+    applied.push({
+      id: "strip-trailing-whitespace",
+      description: "Strip trailing whitespace from lines.",
+    });
+  }
+  working = stripped.join("\n");
+
+  // Split + parse
+  const { rawFrontmatter, body } = splitSkillMd(working);
+  const fm = parseFrontmatter(working);
+
+  if (rawFrontmatter === null) {
+    skipped.push({
+      id: "missing-frontmatter",
+      description:
+        "SKILL.md has no frontmatter — not auto-fixable (requires author decisions).",
+    });
+    return { newContent: working, applied, skipped };
+  }
+
+  // Work on the frontmatter block as a string that we can transform.
+  let fmStr = rawFrontmatter;
+
+  // 1) Add missing `version` as 0.1.0 when neither top-level nor metadata.version is present.
+  const hasVersion = Boolean(fm.version || fm["metadata.version"]);
+  if (!hasVersion) {
+    fmStr = appendFrontmatterKey(fmStr, "version", "0.1.0");
+    applied.push({
+      id: "add-missing-version",
+      description: "Add `version: 0.1.0`.",
+    });
+  }
+
+  // 2) Add missing creator from git config user.name (if provided).
+  const hasCreator = Boolean(fm.creator || fm["metadata.creator"]);
+  if (!hasCreator) {
+    const gitAuthor = options.gitAuthor?.trim();
+    if (gitAuthor) {
+      fmStr = appendFrontmatterKey(fmStr, "creator", gitAuthor);
+      applied.push({
+        id: "add-missing-creator",
+        description: `Add \`creator: ${gitAuthor}\` from git config.`,
+      });
+    } else {
+      skipped.push({
+        id: "add-missing-creator",
+        description:
+          "Missing `creator` — no git user.name found to fill in safely.",
+      });
+    }
+  }
+
+  // 3) Infer `effort` from body line count.
+  if (!fm.effort) {
+    const inferred = inferEffortFromLines(lineCount(body));
+    fmStr = appendFrontmatterKey(fmStr, "effort", inferred);
+    applied.push({
+      id: "infer-missing-effort",
+      description: `Infer \`effort: ${inferred}\` from body size.`,
+    });
+  }
+
+  // 4) Default description? Not auto-fixable — belongs to author.
+  if (!fm.description) {
+    skipped.push({
+      id: "missing-description",
+      description:
+        "Missing `description` — content-level fix, left to the author.",
+    });
+  }
+
+  // 5) Reorder simple top-level fields to canonical order.
+  const reorder = reorderFrontmatter(fmStr);
+  if (reorder.changed) {
+    applied.push({
+      id: "reorder-frontmatter",
+      description: "Reorder frontmatter fields to canonical order.",
+    });
+    fmStr = reorder.newFrontmatter;
+  }
+
+  // Re-assemble content: ensure a single blank line between frontmatter and body.
+  const trimmedBody = body.replace(/^\n+/, "");
+  let newContent = `---\n${fmStr.replace(/^\n+|\n+$/g, "")}\n---\n\n${trimmedBody}`;
+
+  // Ensure trailing newline on file
+  if (!newContent.endsWith("\n")) newContent += "\n";
+
+  // Ensure final normalisation only reports applied.reorder/whitespace once.
+  if (newContent === originalContent.replace(/\r\n/g, "\n")) {
+    // no effective change besides possibly CRLF normalisation already recorded
+  }
+
+  return {
+    newContent,
+    applied,
+    skipped,
+  };
+}
+
+/**
+ * Append a simple `key: value` line to a frontmatter block if not already present.
+ * Values are quoted when they contain characters that would otherwise need escaping.
+ */
+function appendFrontmatterKey(
+  fmStr: string,
+  key: string,
+  value: string,
+): string {
+  const existing = new RegExp(`^${key}:\\s*`, "m");
+  if (existing.test(fmStr)) return fmStr;
+  const quoted = /[:#{}\[\],&*?|<>=!%@`"']/.test(value)
+    ? JSON.stringify(value)
+    : value;
+  const separator = fmStr.length === 0 || fmStr.endsWith("\n") ? "" : "\n";
+  return `${fmStr}${separator}${key}: ${quoted}\n`;
+}
+
+// ─── Unified diff ─────────────────────────────────────────────────────────
+
+/**
+ * Produce a minimal unified diff between two text blobs. This is intentionally
+ * naive — it does not compute the true LCS — but it is good enough for humans
+ * to eyeball what the fixer will do, and it avoids adding a dependency.
+ */
+export function unifiedDiff(
+  before: string,
+  after: string,
+  filename = "SKILL.md",
+): string {
+  if (before === after) return "";
+  const a = before.split("\n");
+  const b = after.split("\n");
+  const lines: string[] = [`--- a/${filename}`, `+++ b/${filename}`];
+
+  // Brute-force line diff: emit all of before as "-", then all of after as "+".
+  // Coalesce a leading common prefix and trailing common suffix to keep diff tight.
+  let pre = 0;
+  while (pre < a.length && pre < b.length && a[pre] === b[pre]) pre++;
+  let suf = 0;
+  while (
+    suf < a.length - pre &&
+    suf < b.length - pre &&
+    a[a.length - 1 - suf] === b[b.length - 1 - suf]
+  )
+    suf++;
+
+  const aMid = a.slice(pre, a.length - suf);
+  const bMid = b.slice(pre, b.length - suf);
+
+  // Hunk header (line numbers are 1-based)
+  const aStart = pre + 1;
+  const bStart = pre + 1;
+  lines.push(`@@ -${aStart},${aMid.length} +${bStart},${bMid.length} @@`);
+
+  // Up to 3 lines of leading context
+  const contextBefore = a.slice(Math.max(0, pre - 3), pre).map((l) => ` ${l}`);
+  const contextAfter = a
+    .slice(a.length - suf, Math.min(a.length, a.length - suf + 3))
+    .map((l) => ` ${l}`);
+
+  lines.push(...contextBefore);
+  for (const line of aMid) lines.push(`-${line}`);
+  for (const line of bMid) lines.push(`+${line}`);
+  lines.push(...contextAfter);
+
+  return lines.join("\n");
+}
+
+// ─── Apply fix to a skill path ─────────────────────────────────────────────
+
+export interface ApplyFixOptions {
+  dryRun: boolean;
+  gitAuthor?: string | null;
+}
+
+export async function applyFix(
+  skillPath: string,
+  options: ApplyFixOptions,
+): Promise<FixResult> {
+  const resolved = isAbsolute(skillPath) ? skillPath : resolve(skillPath);
+  let skillMdPath: string;
+  const s = await stat(resolved).catch(() => null);
+  if (!s) {
+    throw new Error(`Skill path does not exist: ${resolved}`);
+  }
+  if (s.isFile()) {
+    skillMdPath = resolved;
+  } else if (s.isDirectory()) {
+    skillMdPath = join(resolved, "SKILL.md");
+  } else {
+    throw new Error(`Skill path is not a directory or file: ${resolved}`);
+  }
+
+  let original: string;
+  try {
+    original = await readFile(skillMdPath, "utf-8");
+  } catch {
+    throw new Error(`SKILL.md not found at ${skillMdPath}.`);
+  }
+
+  const plan = buildFixPlan(original, { gitAuthor: options.gitAuthor });
+  const diff = unifiedDiff(original, plan.newContent);
+
+  let backupPath: string | null = null;
+  if (!options.dryRun && plan.newContent !== original) {
+    backupPath = `${skillMdPath}.bak`;
+    await copyFile(skillMdPath, backupPath);
+    await writeFile(skillMdPath, plan.newContent, "utf-8");
+  }
+
+  // Re-evaluate using the (possibly modified) content.
+  const report = evaluateSkillContent({
+    content: options.dryRun ? original : plan.newContent,
+    skillPath: resolved,
+    skillMdPath,
+  });
+
+  return {
+    report,
+    applied: plan.applied,
+    skipped: plan.skipped,
+    diff,
+    dryRun: options.dryRun,
+    backupPath,
+    skillMdPath,
+  };
+}
+
+/**
+ * Ask `git config user.name` for a default creator string. Returns null on
+ * failure / missing value.
+ */
+export async function detectGitAuthor(): Promise<string | null> {
+  try {
+    // Use Bun.spawn when available; fall back to child_process for Node tests.
+    const proc = Bun.spawn(
+      ["git", "config", "--global", "--get", "user.name"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    const code = await proc.exited;
+    if (code !== 0) return null;
+    const trimmed = stdout.trim();
+    return trimmed ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Formatters ────────────────────────────────────────────────────────────
+
+function bar(score: number, max: number, width = 20): string {
+  const filled = Math.round((score / max) * width);
+  return "█".repeat(filled) + "░".repeat(Math.max(0, width - filled));
+}
+
+/**
+ * Render a human-readable evaluation report (no ANSI — the CLI adds colour).
+ */
+export function formatReport(report: EvaluationReport): string {
+  const lines: string[] = [];
+  lines.push(`Skill evaluation: ${report.skillPath}`);
+  lines.push(`SKILL.md:         ${report.skillMdPath}`);
+  lines.push("");
+  lines.push(`Overall score:    ${report.overallScore}/100  (${report.grade})`);
+  lines.push("");
+  lines.push("Categories:");
+  for (const c of report.categories) {
+    lines.push(
+      `  ${c.name.padEnd(28)} ${String(c.score).padStart(2)}/${c.max}  ${bar(
+        c.score,
+        c.max,
+      )}`,
+    );
+  }
+  lines.push("");
+  if (report.topSuggestions.length > 0) {
+    lines.push("Top suggestions:");
+    for (const s of report.topSuggestions) {
+      lines.push(`  • ${s}`);
+    }
+  } else {
+    lines.push("No suggestions — skill looks great.");
+  }
+  return lines.join("\n");
+}
+
+export function formatReportJSON(report: EvaluationReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export function formatFixPreview(result: FixResult): string {
+  const lines: string[] = [];
+  if (result.applied.length === 0 && result.skipped.length === 0) {
+    lines.push("No fixes needed — SKILL.md is already clean.");
+    return lines.join("\n");
+  }
+  if (result.applied.length > 0) {
+    lines.push(
+      `${result.dryRun ? "Would apply" : "Applied"} ${result.applied.length} fix(es):`,
+    );
+    for (const a of result.applied) {
+      lines.push(`  • ${a.description}`);
+    }
+  }
+  if (result.skipped.length > 0) {
+    lines.push("");
+    lines.push(`Skipped ${result.skipped.length} issue(s) (not auto-fixable):`);
+    for (const s of result.skipped) {
+      lines.push(`  • ${s.description}`);
+    }
+  }
+  if (result.diff) {
+    lines.push("");
+    lines.push("Diff:");
+    lines.push(result.diff);
+  }
+  if (!result.dryRun && result.backupPath) {
+    lines.push("");
+    lines.push(`Backup: ${result.backupPath}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Machine-envelope friendly shape for `asm eval`.
+ */
+export function buildEvalMachineData(
+  report: EvaluationReport,
+  fix: FixResult | null = null,
+) {
+  return {
+    skill_path: report.skillPath,
+    skill_md_path: report.skillMdPath,
+    overall_score: report.overallScore,
+    grade: report.grade,
+    categories: report.categories.map((c) => ({
+      id: c.id,
+      name: c.name,
+      score: c.score,
+      max: c.max,
+      findings: c.findings,
+      suggestions: c.suggestions,
+    })),
+    top_suggestions: report.topSuggestions,
+    fix: fix
+      ? {
+          dry_run: fix.dryRun,
+          applied: fix.applied,
+          skipped: fix.skipped,
+          backup_path: fix.backupPath,
+          diff: fix.diff,
+        }
+      : null,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `asm eval <skill-path>` which scores a skill's `SKILL.md` against seven best-practice categories (structure, description, prompt engineering, context efficiency, safety, testability, naming & conventions) and emits a structured report with an overall 0–100 score plus the top three actionable suggestions.
- `--fix` applies deterministic frontmatter fixes (add missing version, infer effort from body size, canonical key ordering, CRLF normalisation, trailing-whitespace stripping, creator from `git config user.name`) and creates a `SKILL.md.bak` backup before writing. `--fix --dry-run` previews a unified diff without touching disk.
- Supports `--json` and `--machine` (v1 envelope) outputs for programmatic consumers, matching the shape used by `doctor`/`publish`.

## Changes

- **New module** `src/evaluator.ts` — category scorers, report aggregator, auto-fix planner, unified diff helper, formatters, machine-envelope helper.
- **New test file** `src/evaluator.test.ts` — 37 unit tests covering every category scorer, each auto-fixable item in isolation, dry-run, backup creation, idempotency, format helpers, and end-to-end `evaluateSkill`.
- **CLI wiring** `src/cli.ts` — new `--fix` flag in `ParsedArgs`, help text, `cmdEval` dispatcher, `switch` case, and `eval` added to the `commands` array in `isCLIMode`. `doctor` also added to the array (was previously relying on the fallback branch).
- **CLI integration tests** in `src/cli.test.ts` — `eval --help`, missing-path error, `--json`, `--machine`, `--fix --dry-run` non-writing behaviour, and `--fix` backup creation. `isCLIMode` tests for `eval` and `doctor`.

## Schema alignment (intentional)

The issue uses `author` / `type` / `XS/S/M/L/XL`, which don't match the existing `SKILL.md` schema described in the README and parsed by `src/utils/frontmatter.ts`. Rather than silently introduce a new schema, the evaluator maps issue terminology to existing conventions:

| Issue wording | Codebase convention |
| --- | --- |
| `author` | `creator` (or `metadata.creator`) |
| top-level `version` | `metadata.version` preferred, `version` fallback (via `resolveVersion`) |
| `XS/S/M/L/XL` | `low/medium/high/max` (README table) |
| `type` | no existing field — deferred; can be added in a follow-up |

The decision is documented in the module docstring at the top of `src/evaluator.ts`.

## Scope note

The optional "Can be integrated into `asm publish` as pre-publish quality gate (medium)" item from the issue is **deferred**. Hooking into the existing publish pipeline would widen the blast radius of this PR (existing publish tests, a behavior change for an already-shipped command). This PR ships `eval` standalone; publish integration is a clean follow-up.

## Testing

- `bun test src/evaluator.test.ts` — 37 pass, 0 fail, 70 expect() calls.
- `bun test src/cli.test.ts --test-name-pattern "eval"` — 7 new CLI integration tests pass.
- `bun run typecheck` — clean.
- `bunx prettier --check src/evaluator.ts src/evaluator.test.ts src/cli.ts src/cli.test.ts` — clean.
- `bun run build` — succeeds (run by the `pre-push` hook).
- `bun test tests/e2e/bun-e2e.test.ts` — passes (run by the `pre-push` hook).
- Manual smoke tests: ran `asm eval` against `./skills/hello-world` (scored 40/F) and `./skills/skill-index-updater` (scored higher) to confirm scoring differentiates real skills rather than being degenerate.

### Note on pre-existing test failures

Five unit tests fail locally on both `main` and this branch due to local environment state (4 `publishSkill > ...` tests that depend on git / `gh` CLI state, and 1 `CLI integration: import > import existing skills are skipped` test that collides with the user's globally-installed skills). These failures exist on `main` prior to this PR — verified via `git stash` + `bun test`. CI on `main` is green, so the CI sandbox is not affected. This PR does not add or touch any of those tests.

## Test plan

- [ ] CI passes on the branch (unit, typecheck, e2e, build)
- [ ] `asm eval ./skills/hello-world` produces a scored report
- [ ] `asm eval ./skills/hello-world --json` emits parseable JSON with 7 categories
- [ ] `asm eval <tempdir>/skill --fix --dry-run` prints a diff and does not modify `SKILL.md`
- [ ] `asm eval <tempdir>/skill --fix` creates `SKILL.md.bak` and rewrites the original
- [ ] `asm eval <bogus>` exits with code 1 and a helpful error
- [ ] `asm eval` with no path prints the usage error and exits with code 2
- [ ] `asm eval --help` prints help
- [ ] `asm eval ./skills/hello-world --machine` emits a v1 envelope with `command: "eval"`

Closes #119