### PR TITLE
feat(eval): add quality provider adapter (#156)

### DIFF
--- a/src/eval/providers/index.test.ts
+++ b/src/eval/providers/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from "bun:test";
 import { registerBuiltins } from "./index";
-import { list, __resetForTests } from "../registry";
+import { list, resolve, __resetForTests } from "../registry";
 
 describe("registerBuiltins", () => {
   beforeEach(() => {
@@ -11,10 +11,22 @@ describe("registerBuiltins", () => {
     expect(typeof registerBuiltins).toBe("function");
   });
 
-  it("registers zero providers in PR 1 (empty by design)", () => {
+  it("registers the quality provider (PR 2)", () => {
     registerBuiltins();
-    // PR 1 ships with no built-in providers wired — PR 2 adds `quality`.
-    expect(list()).toHaveLength(0);
+    // PR 2 lands `quality@1.0.0`. PR 4 will add skillgrade — bump this count
+    // when it does.
+    const providers = list();
+    expect(providers).toHaveLength(1);
+    expect(providers[0]!.id).toBe("quality");
+    expect(providers[0]!.version).toBe("1.0.0");
+    expect(providers[0]!.schemaVersion).toBe(1);
+  });
+
+  it("makes quality resolvable via semver range", () => {
+    registerBuiltins();
+    const provider = resolve("quality", "^1.0.0");
+    expect(provider.id).toBe("quality");
+    expect(provider.version).toBe("1.0.0");
   });
 
   it("does not throw when invoked", () => {

--- a/src/eval/providers/index.ts
+++ b/src/eval/providers/index.ts
@@ -5,19 +5,19 @@
  * the eval framework. Each built-in provider module exports a factory,
  * and this function calls `register()` for each one.
  *
- * PR 1 ships this as an empty function on purpose — no providers are
- * registered yet. PR 2 adds the `quality` provider import + register
- * call here; PR 4 adds `skillgrade`. Keeping the list here (rather
- * than each provider self-registering at import time) makes ordering
- * deterministic and makes it possible to run with a restricted
- * provider set in tests.
+ * PR 1 shipped this as an empty function. PR 2 (#156) adds the `quality`
+ * provider — an adapter over `src/evaluator.ts`. PR 4 will add
+ * `skillgrade`. Keeping the list here (rather than each provider
+ * self-registering at import time) makes ordering deterministic and
+ * makes it possible to run with a restricted provider set in tests.
  *
- * This file MUST NOT be imported from `src/cli.ts` in PR 1 — the
- * acceptance criteria for #155 explicitly require zero user-visible
- * behavior change. Later PRs own that wiring.
+ * This file MUST NOT be imported from `src/cli.ts` yet — PR 3 owns that
+ * wiring. Importing it here in PR 2 would register a provider at module
+ * load time and silently change `asm eval` behavior.
  */
 
 import { register } from "../registry";
+import { qualityProviderV1 } from "./quality/v1";
 
 /**
  * Register every built-in provider with the shared registry.
@@ -27,10 +27,6 @@ import { register } from "../registry";
  * `register()` throws on duplicate `(id, version)` by design.
  */
 export function registerBuiltins(): void {
-  // PR 2: register(qualityProviderV1);
+  register(qualityProviderV1);
   // PR 4: register(skillgradeProviderV1);
-  // `register` is imported but intentionally unused in PR 1 — it is the
-  // hook every subsequent PR in the Skillgrade integration series will
-  // call from inside this function.
-  void register;
 }

--- a/src/eval/providers/quality/v1/fixtures/missing-frontmatter.json
+++ b/src/eval/providers/quality/v1/fixtures/missing-frontmatter.json
@@ -1,0 +1,174 @@
+{
+  "providerId": "quality",
+  "providerVersion": "1.0.0",
+  "schemaVersion": 1,
+  "score": 21,
+  "passed": false,
+  "categories": [
+    {
+      "id": "structure",
+      "name": "Structure & completeness",
+      "score": 2,
+      "max": 10
+    },
+    {
+      "id": "description",
+      "name": "Description quality",
+      "score": 0,
+      "max": 10
+    },
+    {
+      "id": "prompt-engineering",
+      "name": "Prompt engineering",
+      "score": 0,
+      "max": 10
+    },
+    {
+      "id": "context-efficiency",
+      "name": "Context efficiency",
+      "score": 2,
+      "max": 10
+    },
+    {
+      "id": "safety",
+      "name": "Safety & guardrails",
+      "score": 3,
+      "max": 10
+    },
+    {
+      "id": "testability",
+      "name": "Testability",
+      "score": 3,
+      "max": 10
+    },
+    {
+      "id": "naming",
+      "name": "Naming & conventions",
+      "score": 5,
+      "max": 10
+    }
+  ],
+  "findings": [
+    {
+      "severity": "info",
+      "message": "Write a one-sentence description that says specifically what the skill does and when to use it."
+    },
+    {
+      "severity": "info",
+      "message": "Structure the body with \"## When to Use\" and \"## Instructions\" sections so the agent reads only what it needs."
+    },
+    {
+      "severity": "info",
+      "message": "Use bulleted or numbered steps to narrow the agent's degrees of freedom."
+    }
+  ],
+  "raw": {
+    "skillPath": "__FIXTURE__/missing-frontmatter",
+    "skillMdPath": "__FIXTURE__/missing-frontmatter/SKILL.md",
+    "categories": [
+      {
+        "id": "structure",
+        "name": "Structure & completeness",
+        "score": 2,
+        "max": 10,
+        "findings": [
+          "SKILL.md has no YAML frontmatter.",
+          "Missing required field: name.",
+          "Missing required field: description.",
+          "Missing or default version.",
+          "Missing `creator`.",
+          "Missing `license`.",
+          "Body has meaningful content.",
+          "Body uses markdown headings."
+        ],
+        "suggestions": [
+          "Add a YAML frontmatter block delimited by `---` with at least `name` and `description` fields.",
+          "Add `name:` to frontmatter (use the skill directory name).",
+          "Add a one-line `description:` to frontmatter.",
+          "Set `metadata.version` (or top-level `version`) using semver (e.g. 0.1.0).",
+          "Add a `creator` field so users know who authored and maintains the skill.",
+          "Add a `license` field (e.g. `license: MIT`)."
+        ]
+      },
+      {
+        "id": "description",
+        "name": "Description quality",
+        "score": 0,
+        "max": 10,
+        "findings": ["No description."],
+        "suggestions": [
+          "Write a one-sentence description that says specifically what the skill does and when to use it."
+        ]
+      },
+      {
+        "id": "prompt-engineering",
+        "name": "Prompt engineering",
+        "score": 0,
+        "max": 10,
+        "findings": [
+          "No lists or steps detected.",
+          "Body is very short (35 words)."
+        ],
+        "suggestions": [
+          "Structure the body with \"## When to Use\" and \"## Instructions\" sections so the agent reads only what it needs.",
+          "Use bulleted or numbered steps to narrow the agent's degrees of freedom.",
+          "Add an \"## Example\" section with a fenced code block showing the desired output.",
+          "Rewrite instructions in the imperative mood — e.g. \"Run `git status` first\" instead of \"you might want to run\".",
+          "Expand the instructions; an underspecified skill gives the agent too much freedom."
+        ]
+      },
+      {
+        "id": "context-efficiency",
+        "name": "Context efficiency",
+        "score": 2,
+        "max": 10,
+        "findings": ["Body is 35 words.", "No oversized code blocks."],
+        "suggestions": [
+          "Offload verbose content to referenced files and link to them (\"see `./templates/x.md`\")."
+        ]
+      },
+      {
+        "id": "safety",
+        "name": "Safety & guardrails",
+        "score": 3,
+        "max": 10,
+        "findings": ["No prerequisites / requirements section."],
+        "suggestions": [
+          "Expand the safety section — include prerequisites, validation steps, and what to do \"on error\".",
+          "Add a \"## Prerequisites\" block listing required tools, credentials, and environment state."
+        ]
+      },
+      {
+        "id": "testability",
+        "name": "Testability",
+        "score": 3,
+        "max": 10,
+        "findings": ["Some testability cues: test, tests."],
+        "suggestions": [
+          "Add an \"## Acceptance Criteria\" block listing verifiable outputs or checklist items.",
+          "Include an \"Expected output\" example so reviewers and the agent can verify correctness.",
+          "Add a short \"Edge cases\" list to describe inputs the skill should reject or handle carefully."
+        ]
+      },
+      {
+        "id": "naming",
+        "name": "Naming & conventions",
+        "score": 5,
+        "max": 10,
+        "findings": [
+          "Most headings use action/imperative labels.",
+          "Description looks clean (no TODO/FIXME/stray noise)."
+        ],
+        "suggestions": ["Add a kebab-case `name` (e.g. `my-skill`)."]
+      }
+    ],
+    "overallScore": 21,
+    "grade": "F",
+    "topSuggestions": [
+      "Write a one-sentence description that says specifically what the skill does and when to use it.",
+      "Structure the body with \"## When to Use\" and \"## Instructions\" sections so the agent reads only what it needs.",
+      "Use bulleted or numbered steps to narrow the agent's degrees of freedom."
+    ],
+    "frontmatter": {}
+  }
+}

--- a/src/eval/providers/quality/v1/fixtures/well-formed.json
+++ b/src/eval/providers/quality/v1/fixtures/well-formed.json
@@ -1,0 +1,172 @@
+{
+  "providerId": "quality",
+  "providerVersion": "1.0.0",
+  "schemaVersion": 1,
+  "score": 91,
+  "passed": true,
+  "categories": [
+    {
+      "id": "structure",
+      "name": "Structure & completeness",
+      "score": 10,
+      "max": 10
+    },
+    {
+      "id": "description",
+      "name": "Description quality",
+      "score": 10,
+      "max": 10
+    },
+    {
+      "id": "prompt-engineering",
+      "name": "Prompt engineering",
+      "score": 10,
+      "max": 10
+    },
+    {
+      "id": "context-efficiency",
+      "name": "Context efficiency",
+      "score": 9,
+      "max": 10
+    },
+    {
+      "id": "safety",
+      "name": "Safety & guardrails",
+      "score": 10,
+      "max": 10
+    },
+    {
+      "id": "testability",
+      "name": "Testability",
+      "score": 5,
+      "max": 10
+    },
+    {
+      "id": "naming",
+      "name": "Naming & conventions",
+      "score": 10,
+      "max": 10
+    }
+  ],
+  "findings": [
+    {
+      "severity": "info",
+      "message": "Add an \"## Acceptance Criteria\" block listing verifiable outputs or checklist items."
+    },
+    {
+      "severity": "info",
+      "message": "Include an \"Expected output\" example so reviewers and the agent can verify correctness."
+    }
+  ],
+  "raw": {
+    "skillPath": "__FIXTURE__/well-formed",
+    "skillMdPath": "__FIXTURE__/well-formed/SKILL.md",
+    "categories": [
+      {
+        "id": "structure",
+        "name": "Structure & completeness",
+        "score": 10,
+        "max": 10,
+        "findings": [
+          "Has YAML frontmatter block.",
+          "Body has meaningful content.",
+          "Body uses markdown headings."
+        ],
+        "suggestions": []
+      },
+      {
+        "id": "description",
+        "name": "Description quality",
+        "score": 10,
+        "max": 10,
+        "findings": [
+          "Description is 14 words.",
+          "Starts with an action verb.",
+          "Mentions a trigger or use-case signal."
+        ],
+        "suggestions": []
+      },
+      {
+        "id": "prompt-engineering",
+        "name": "Prompt engineering",
+        "score": 10,
+        "max": 10,
+        "findings": [
+          "Progressive disclosure cues present: when to use, instructions.",
+          "Uses lists or numbered steps.",
+          "Includes example code block.",
+          "Uses imperative voice (5 cues).",
+          "Body length within healthy range (158 words)."
+        ],
+        "suggestions": []
+      },
+      {
+        "id": "context-efficiency",
+        "name": "Context efficiency",
+        "score": 9,
+        "max": 10,
+        "findings": [
+          "Body is 158 words.",
+          "References external files or links (reference, references, see).",
+          "No oversized code blocks."
+        ],
+        "suggestions": []
+      },
+      {
+        "id": "safety",
+        "name": "Safety & guardrails",
+        "score": 10,
+        "max": 10,
+        "findings": [
+          "Covers multiple safety cues (confirm, error, prerequisite, prerequisites).",
+          "Destructive actions paired with confirmation/dry-run.",
+          "Declares prerequisites or requirements."
+        ],
+        "suggestions": []
+      },
+      {
+        "id": "testability",
+        "name": "Testability",
+        "score": 5,
+        "max": 10,
+        "findings": [
+          "Some testability cues: acceptance criteria, edge case, edge cases.",
+          "Mentions edge cases or limitations."
+        ],
+        "suggestions": [
+          "Add an \"## Acceptance Criteria\" block listing verifiable outputs or checklist items.",
+          "Include an \"Expected output\" example so reviewers and the agent can verify correctness."
+        ]
+      },
+      {
+        "id": "naming",
+        "name": "Naming & conventions",
+        "score": 10,
+        "max": 10,
+        "findings": [
+          "name \"well-formed\" follows kebab-case convention.",
+          "Most headings use action/imperative labels.",
+          "Description looks clean (no TODO/FIXME/stray noise).",
+          "Directory name matches frontmatter `name`."
+        ],
+        "suggestions": []
+      }
+    ],
+    "overallScore": 91,
+    "grade": "A",
+    "topSuggestions": [
+      "Add an \"## Acceptance Criteria\" block listing verifiable outputs or checklist items.",
+      "Include an \"Expected output\" example so reviewers and the agent can verify correctness."
+    ],
+    "frontmatter": {
+      "name": "well-formed",
+      "description": "Review pull request diffs for code smells, style issues, and safety problems before merging.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "creator": "ASM Fixtures",
+      "compatibility": "Claude Code",
+      "allowed-tools": "Read Grep",
+      "effort": "medium"
+    }
+  }
+}

--- a/src/eval/providers/quality/v1/index.test.ts
+++ b/src/eval/providers/quality/v1/index.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Snapshot tests for the quality provider adapter (PR 2, #156).
+ *
+ * Each corpus skill in `tests/fixtures/skills/` has a checked-in
+ * `EvalResult` fixture in `./fixtures/<name>.json`. We run the provider
+ * through `runProvider()` (same entry point the CLI will use in PR 3),
+ * normalize away non-deterministic fields, and assert deep equality
+ * against the fixture.
+ *
+ * Non-deterministic fields stripped before comparison:
+ *   - `startedAt`, `durationMs`  — stamped by the runner on every call.
+ *   - `raw.evaluatedAt`          — wall-clock set by `evaluateSkill()`.
+ *   - `raw.skillPath`,
+ *     `raw.skillMdPath`          — absolute paths depend on the
+ *                                   developer's checkout; fixtures store
+ *                                   a `__FIXTURE__/<name>` marker.
+ *
+ * Drift in fixtures is a review artifact — if the evaluator's scoring
+ * changes, these snapshots flag it so reviewers can decide whether the
+ * scoring change is intentional.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { join, resolve } from "path";
+import { readFile, stat, mkdtemp } from "fs/promises";
+import { tmpdir } from "os";
+import { qualityProviderV1 } from "./index";
+import { runProvider } from "../../../runner";
+import {
+  list,
+  resolve as resolveProvider,
+  __resetForTests,
+  register,
+} from "../../../registry";
+import type { EvalResult } from "../../../types";
+
+// ─── Fixture corpus ─────────────────────────────────────────────────────────
+
+const REPO_ROOT = resolve(__dirname, "../../../../..");
+const CORPUS_DIR = join(REPO_ROOT, "tests/fixtures/skills");
+const FIXTURES_DIR = join(__dirname, "fixtures");
+
+/** Every skill name under `tests/fixtures/skills/` that has a snapshot. */
+const CORPUS_SKILLS = ["well-formed", "missing-frontmatter"] as const;
+
+// ─── Normalizers ────────────────────────────────────────────────────────────
+
+/**
+ * Remove runner-stamped timing fields so snapshots stay deterministic.
+ * Returns a new object; the input is not mutated.
+ */
+function stripTimings(
+  result: EvalResult,
+): Omit<EvalResult, "startedAt" | "durationMs"> {
+  // Destructure to a new object so snapshots don't care about timing jitter.
+  const { startedAt: _s, durationMs: _d, ...stable } = result;
+  return stable;
+}
+
+/**
+ * Replace developer-specific absolute paths in `raw` with the same
+ * `__FIXTURE__/<name>` marker the generator script used. Also strips the
+ * wall-clock `evaluatedAt`. Everything else in `raw` is kept as-is so the
+ * fixture captures the full evaluator report.
+ */
+function normalizeRaw(raw: unknown, name: string): unknown {
+  if (!raw || typeof raw !== "object") return raw;
+  const report = raw as Record<string, unknown>;
+  const { evaluatedAt: _a, ...rest } = report;
+  return {
+    ...rest,
+    skillPath: `__FIXTURE__/${name}`,
+    skillMdPath: `__FIXTURE__/${name}/SKILL.md`,
+  };
+}
+
+async function loadFixture(name: string): Promise<unknown> {
+  const path = join(FIXTURES_DIR, `${name}.json`);
+  const content = await readFile(path, "utf-8");
+  return JSON.parse(content);
+}
+
+// ─── Provider shape ─────────────────────────────────────────────────────────
+
+describe("qualityProviderV1 — contract surface", () => {
+  it("has id, version, schemaVersion, description", () => {
+    expect(qualityProviderV1.id).toBe("quality");
+    expect(qualityProviderV1.version).toBe("1.0.0");
+    expect(qualityProviderV1.schemaVersion).toBe(1);
+    expect(qualityProviderV1.description.length).toBeGreaterThan(0);
+  });
+
+  it("applicable() returns ok=true for a real SKILL.md", async () => {
+    const skillPath = join(CORPUS_DIR, "well-formed");
+    const skillMdPath = join(skillPath, "SKILL.md");
+    const res = await qualityProviderV1.applicable(
+      { skillPath, skillMdPath },
+      {},
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("applicable() returns ok=false with a reason when SKILL.md is missing", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "quality-applicable-"));
+    const res = await qualityProviderV1.applicable(
+      { skillPath: tmp, skillMdPath: join(tmp, "SKILL.md") },
+      {},
+    );
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBeTruthy();
+  });
+});
+
+// ─── Snapshot tests ─────────────────────────────────────────────────────────
+
+describe("qualityProviderV1 — snapshot tests per corpus skill", () => {
+  for (const name of CORPUS_SKILLS) {
+    it(`adapter output matches checked-in fixture for ${name}`, async () => {
+      const skillPath = join(CORPUS_DIR, name);
+      const skillMdPath = join(skillPath, "SKILL.md");
+
+      // Sanity: fixture skill + snapshot JSON both exist on disk.
+      await expect(stat(skillMdPath)).resolves.toBeTruthy();
+      await expect(
+        stat(join(FIXTURES_DIR, `${name}.json`)),
+      ).resolves.toBeTruthy();
+
+      const result = await runProvider(qualityProviderV1, {
+        skillPath,
+        skillMdPath,
+      });
+
+      const stable = stripTimings(result);
+      const actual = { ...stable, raw: normalizeRaw(stable.raw, name) };
+      const expected = (await loadFixture(name)) as typeof actual;
+
+      expect(actual).toEqual(expected);
+    });
+  }
+});
+
+// ─── Registry integration ──────────────────────────────────────────────────
+
+describe("qualityProviderV1 — registry integration", () => {
+  it("resolves via registry.resolve('quality', '^1.0.0')", () => {
+    __resetForTests();
+    register(qualityProviderV1);
+    const resolved = resolveProvider("quality", "^1.0.0");
+    expect(resolved.id).toBe("quality");
+    expect(resolved.version).toBe("1.0.0");
+    expect(resolved.schemaVersion).toBe(1);
+    // Confirm it's the same object instance (no copy-on-register).
+    expect(resolved).toBe(qualityProviderV1);
+  });
+
+  it("is exactly one provider after fresh register", () => {
+    __resetForTests();
+    register(qualityProviderV1);
+    expect(list()).toHaveLength(1);
+  });
+});
+
+// ─── Mapping invariants ─────────────────────────────────────────────────────
+
+describe("qualityProviderV1 — mapping invariants", () => {
+  it("sets passed = true when grade is not F (well-formed)", async () => {
+    const skillPath = join(CORPUS_DIR, "well-formed");
+    const result = await runProvider(qualityProviderV1, {
+      skillPath,
+      skillMdPath: join(skillPath, "SKILL.md"),
+    });
+    expect(result.passed).toBe(true);
+    // score is the same integer as the underlying report.overallScore
+    const raw = result.raw as { overallScore: number; grade: string };
+    expect(result.score).toBe(raw.overallScore);
+    expect(raw.grade).not.toBe("F");
+  });
+
+  it("sets passed = false when grade is F (missing-frontmatter)", async () => {
+    const skillPath = join(CORPUS_DIR, "missing-frontmatter");
+    const result = await runProvider(qualityProviderV1, {
+      skillPath,
+      skillMdPath: join(skillPath, "SKILL.md"),
+    });
+    expect(result.passed).toBe(false);
+    const raw = result.raw as { grade: string };
+    expect(raw.grade).toBe("F");
+  });
+
+  it("maps topSuggestions to findings with severity 'info'", async () => {
+    const skillPath = join(CORPUS_DIR, "missing-frontmatter");
+    const result = await runProvider(qualityProviderV1, {
+      skillPath,
+      skillMdPath: join(skillPath, "SKILL.md"),
+    });
+    const raw = result.raw as { topSuggestions: string[] };
+    expect(result.findings).toHaveLength(raw.topSuggestions.length);
+    for (const f of result.findings) {
+      expect(f.severity).toBe("info");
+    }
+    expect(result.findings.map((f) => f.message)).toEqual(raw.topSuggestions);
+  });
+
+  it("maps evaluator categories 1:1 by id", async () => {
+    const skillPath = join(CORPUS_DIR, "well-formed");
+    const result = await runProvider(qualityProviderV1, {
+      skillPath,
+      skillMdPath: join(skillPath, "SKILL.md"),
+    });
+    const raw = result.raw as { categories: { id: string }[] };
+    expect(result.categories.map((c) => c.id)).toEqual(
+      raw.categories.map((c) => c.id),
+    );
+    // Each adapter category exposes only the contract fields.
+    for (const c of result.categories) {
+      expect(Object.keys(c).sort()).toEqual(["id", "max", "name", "score"]);
+    }
+  });
+
+  it("stamps providerId, providerVersion, schemaVersion correctly", async () => {
+    const skillPath = join(CORPUS_DIR, "well-formed");
+    const result = await runProvider(qualityProviderV1, {
+      skillPath,
+      skillMdPath: join(skillPath, "SKILL.md"),
+    });
+    expect(result.providerId).toBe("quality");
+    expect(result.providerVersion).toBe("1.0.0");
+    expect(result.schemaVersion).toBe(1);
+  });
+});

--- a/src/eval/providers/quality/v1/index.ts
+++ b/src/eval/providers/quality/v1/index.ts
@@ -1,0 +1,135 @@
+/**
+ * Quality provider — v1.
+ *
+ * Thin adapter over `src/evaluator.ts`. Proves the `EvalProvider` contract
+ * from PR 1 (#155) fits the existing static SKILL.md linter without
+ * modifying the evaluator itself. If this adapter needs ugly workarounds,
+ * the contract — not the evaluator — is what has to change.
+ *
+ * Mapping (EvaluationReport → EvalResult), per the issue body and
+ * docs/SKILLGRADE_INTEGRATION_PLAN.md §4 PR 2:
+ *
+ *   - overallScore            → score
+ *   - grade !== "F"           → passed
+ *   - categories              → categories (1:1, id/name/score/max)
+ *   - topSuggestions          → findings with severity "info"
+ *   - original report         → raw (stable per schemaVersion)
+ *
+ * Non-determinism note: the underlying `EvaluationReport` contains
+ * `evaluatedAt` (wall-clock) and the runner stamps `startedAt` /
+ * `durationMs` on the returned `EvalResult`. Snapshot tests strip these
+ * before comparing against checked-in fixtures.
+ */
+
+import { stat } from "fs/promises";
+import { evaluateSkill, type EvaluationReport } from "../../../../evaluator";
+import type {
+  ApplicableResult,
+  EvalOpts,
+  EvalProvider,
+  EvalResult,
+  Finding,
+  SkillContext,
+} from "../../../types";
+
+/** Stable provider id used by registry.resolve("quality", "^1.0.0"). */
+const PROVIDER_ID = "quality";
+
+/** Provider semver. Bump on logic/feature releases of the adapter. */
+const PROVIDER_VERSION = "1.0.0";
+
+/** Result-shape version. Bump only on structural breaks to EvalResult. */
+const SCHEMA_VERSION = 1;
+
+/**
+ * Map `topSuggestions: string[]` onto the flat `findings: Finding[]` array.
+ *
+ * Per the issue, every suggestion is surfaced as a `severity: "info"`
+ * finding. Category-level detail stays inside `raw` for callers that want
+ * the full evaluator report. Kept pure and tiny so snapshots are stable.
+ */
+function mapTopSuggestions(report: EvaluationReport): Finding[] {
+  return report.topSuggestions.map<Finding>((message) => ({
+    severity: "info",
+    message,
+  }));
+}
+
+/**
+ * Map the evaluator's `CategoryResult[]` onto the contract's `CategoryResult[]`.
+ *
+ * Both shapes share `id`, `name`, `score`, `max` — we drop the evaluator's
+ * free-form `findings: string[]` and `suggestions: string[]` intentionally.
+ * Those live in `raw` so callers can still reach them without the adapter
+ * inventing a string→Finding conversion the contract doesn't require.
+ */
+function mapCategories(report: EvaluationReport): EvalResult["categories"] {
+  return report.categories.map((c) => ({
+    id: c.id,
+    name: c.name,
+    score: c.score,
+    max: c.max,
+  }));
+}
+
+/**
+ * Quality provider v1 — wraps `evaluateSkill()` from `src/evaluator.ts`.
+ *
+ * `applicable()` is a cheap filesystem stat: if `SKILL.md` doesn't exist
+ * at `ctx.skillMdPath`, we bail with a reason the CLI can show. Everything
+ * else (frontmatter validity, body length, etc.) is the evaluator's job
+ * and shows up as findings/suggestions in the report.
+ *
+ * `run()` delegates to `evaluateSkill(ctx.skillPath)` and maps the
+ * `EvaluationReport` onto an `EvalResult`. Errors thrown by the evaluator
+ * (missing SKILL.md, unreadable path) bubble up to the runner, which
+ * wraps them into an error-shaped result with a single `severity: "error"`
+ * finding — consumers never need try/catch around `runner.runProvider()`.
+ *
+ * Note: `startedAt` / `durationMs` on the returned result are placeholders;
+ * the runner overwrites them both. This keeps the provider oblivious to
+ * timing and makes test scaffolding simpler.
+ */
+export const qualityProviderV1: EvalProvider = {
+  id: PROVIDER_ID,
+  version: PROVIDER_VERSION,
+  schemaVersion: SCHEMA_VERSION,
+  description: "Static linter for SKILL.md structure, description, and safety.",
+
+  async applicable(ctx: SkillContext): Promise<ApplicableResult> {
+    try {
+      const s = await stat(ctx.skillMdPath);
+      if (!s.isFile()) {
+        return {
+          ok: false,
+          reason: `${ctx.skillMdPath} is not a file`,
+        };
+      }
+      return { ok: true };
+    } catch {
+      return {
+        ok: false,
+        reason: `SKILL.md not found at ${ctx.skillMdPath}`,
+      };
+    }
+  },
+
+  async run(ctx: SkillContext, _opts: EvalOpts): Promise<EvalResult> {
+    const report = await evaluateSkill(ctx.skillPath);
+    return {
+      providerId: PROVIDER_ID,
+      providerVersion: PROVIDER_VERSION,
+      schemaVersion: SCHEMA_VERSION,
+      score: report.overallScore,
+      passed: report.grade !== "F",
+      categories: mapCategories(report),
+      findings: mapTopSuggestions(report),
+      raw: report,
+      // Runner stamps these — the values here are intentionally placeholder.
+      startedAt: "",
+      durationMs: 0,
+    };
+  },
+};
+
+export default qualityProviderV1;

--- a/tests/fixtures/skills/missing-frontmatter/SKILL.md
+++ b/tests/fixtures/skills/missing-frontmatter/SKILL.md
@@ -1,0 +1,5 @@
+# Missing frontmatter corpus skill
+
+This skill intentionally has no YAML frontmatter so the static linter
+fails it on structure and naming. Used as a "fail path" fixture for the
+quality provider adapter snapshot tests.

--- a/tests/fixtures/skills/well-formed/SKILL.md
+++ b/tests/fixtures/skills/well-formed/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: well-formed
+description: Review pull request diffs for code smells, style issues, and safety problems before merging.
+version: 1.0.0
+license: MIT
+creator: ASM Fixtures
+compatibility: Claude Code
+allowed-tools: Read Grep
+effort: medium
+---
+
+# Well-formed corpus skill
+
+## When to Use
+
+- When the user asks to "review this PR" or "check the diff"
+- Before merging any change larger than 10 lines
+
+## Prerequisites
+
+- A git repository with the target branch checked out
+- Read access to the files being reviewed
+
+## Instructions
+
+1. Run `git diff main...HEAD` to list files
+2. Read each file and check for common smells
+3. Emit a markdown report summarising findings
+
+## Example
+
+```bash
+$ asm eval ./well-formed
+Overall score: 95/100
+```
+
+## Acceptance Criteria
+
+- Produces a markdown report with sections per file
+- Flags any use of `eval()` or `exec` as dangerous
+- Does not modify the working tree
+
+## Edge cases
+
+- Empty diffs: emit a short "no changes" note
+- Binary files: skip and mention the filename in the report
+
+## Safety
+
+See `references/safety.md` for error handling rules.
+Always confirm before writing. Never run destructive commands without a dry-run.


### PR DESCRIPTION
Closes #156

## Summary

PR 2 of 5 from the Skillgrade integration plan. Wraps the existing static SKILL.md linter (`src/evaluator.ts`) in the `EvalProvider` contract introduced by PR 1 (#155) — **without modifying `src/evaluator.ts`**. If this adapter needed ugly workarounds, the contract would be what had to change; it didn't, so the interface from PR 1 holds.

## Approach

Thin delegation. `qualityProviderV1.run()` calls `evaluateSkill()` and maps `EvaluationReport` onto `EvalResult`. `applicable()` is a cheap `stat(skillMdPath)` — no other gating, since the evaluator surfaces every other issue as a finding.

## Mapping (EvaluationReport -> EvalResult)

| EvaluationReport | EvalResult |
|---|---|
| `overallScore` | `score` |
| `grade !== "F"` | `passed` |
| `categories` | `categories` (1:1 on `id`, `name`, `score`, `max`) |
| `topSuggestions` | `findings` with `severity: "info"` |
| original report | `raw` (stable per `schemaVersion`) |

Evaluator's free-form `findings: string[]` and `suggestions: string[]` stay in `raw` — the adapter intentionally does not invent a string→Finding conversion the issue didn't ask for.

## Changes

| File | Change |
|------|--------|
| `src/eval/providers/quality/v1/index.ts` | New — EvalProvider implementation |
| `src/eval/providers/quality/v1/fixtures/well-formed.json` | New — snapshot for pass-path corpus skill (score 91, grade A) |
| `src/eval/providers/quality/v1/fixtures/missing-frontmatter.json` | New — snapshot for fail-path corpus skill (score 21, grade F) |
| `src/eval/providers/quality/v1/index.test.ts` | New — 12 tests (contract, `applicable()`, snapshot per corpus skill, registry integration, mapping invariants) |
| `src/eval/providers/index.ts` | Registers `quality@1.0.0` via `registerBuiltins()` |
| `src/eval/providers/index.test.ts` | Updated to expect 1 registered provider (was 0 in PR 1) |
| `tests/fixtures/skills/well-formed/SKILL.md` | New corpus fixture |
| `tests/fixtures/skills/missing-frontmatter/SKILL.md` | New corpus fixture |

`src/evaluator.ts` unchanged — `git diff HEAD~1 src/evaluator.ts` returns zero lines.

## Non-determinism handling

Snapshot tests strip these before deep-equal against checked-in JSON:

- `startedAt`, `durationMs` — stamped by the runner on every call
- `raw.evaluatedAt` — wall-clock set by `evaluateSkill()`
- `raw.skillPath`, `raw.skillMdPath` — absolute paths depend on checkout; fixtures store a `__FIXTURE__/<name>` marker

Drift in fixtures is a review artifact — if evaluator scoring changes, snapshots flag it so reviewers can decide whether the change is intentional.

## Test Results

- `bun test src/eval/` — **80 pass, 0 fail** (67 existing PR 1 tests + 12 new quality provider tests + 1 existing `registerBuiltins` test)
- `bun run typecheck` — clean
- Full `bun test src/` — 1413 pass, 5 fail (pre-existing unrelated failures in `publisher.test.ts` and `cli.test.ts`, called out in the issue; not addressed here)

## Acceptance Criteria

- [x] `quality` provider registered and resolvable via `registry.resolve("quality", "^1.0.0")`
- [x] Snapshot test per corpus skill passes — adapter output matches checked-in JSON
- [x] `src/evaluator.ts` is untouched (diff confirms zero changes)
- [x] `bun test` passes (all new tests green; pre-existing unrelated failures as called out in issue)

## Boundary kept for PR 3

`src/cli.ts` does not import `providers/index.ts` or call `registerBuiltins()` — PR 3 owns that wiring. No user-visible behavior change in this PR.