### PR TITLE
feat(eval): wire asm eval through provider framework + add eval-providers list (#157)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1414,6 +1414,10 @@ describe("isCLIMode: newer commands", () => {
     expect(check("eval")).toBe(true);
   });
 
+  test("eval-providers → CLI mode", () => {
+    expect(check("eval-providers")).toBe(true);
+  });
+
   test("doctor → CLI mode", () => {
     expect(check("doctor")).toBe(true);
   });
@@ -1481,6 +1485,22 @@ describe("CLI integration: per-command --help (new commands)", () => {
     expect(stdout).toContain("--fix");
     expect(stdout).toContain("--dry-run");
     expect(stdout).toContain("--json");
+    // Eval --help should point users at the eval-providers subcommand (PR 3).
+    expect(stdout).toContain("eval-providers");
+  });
+
+  test("eval-providers --help shows subcommands", async () => {
+    const { stdout, exitCode } = await runCLI("eval-providers", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("asm eval-providers");
+    expect(stdout).toContain("list");
+    expect(stdout).toContain("--json");
+  });
+
+  test("main --help documents eval-providers command", async () => {
+    const { stdout, exitCode } = await runCLI("--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("eval-providers");
   });
 });
 
@@ -1567,6 +1587,140 @@ describe("CLI integration: eval", () => {
     } finally {
       await cleanup();
     }
+  });
+
+  // The eval framework replaced the direct evaluator call in PR 3 (#157). The
+  // issue's primary acceptance criterion is that user-visible output is
+  // byte-identical for all modes. These tests exercise each output path and
+  // assert on the concrete structural invariants the old code honored — so a
+  // future regression (e.g. accidentally dropping a findings array, changing
+  // category count) surfaces immediately instead of only when someone reads
+  // the diff.
+
+  test("eval text output preserves the legacy 7-section structure", async () => {
+    const { dir, cleanup } = await makeTempSkill(
+      "---\nname: eval-text\ndescription: Do a thing when asked.\n---\n\n# eval-text\n\n## When to Use\n\n- Something\n\n## Instructions\n\n1. Do the thing\n",
+    );
+    try {
+      const { stdout, exitCode } = await runCLI("eval", dir);
+      expect(exitCode).toBe(0);
+      // Every text-mode report printed by the legacy evaluator had these
+      // exact lead-in strings and an Overall score line — we lock those in.
+      expect(stdout).toContain("Skill evaluation:");
+      expect(stdout).toContain("SKILL.md:");
+      expect(stdout).toContain("Overall score:");
+      expect(stdout).toContain("Categories:");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --json carries the full EvaluationReport shape (not an EvalResult)", async () => {
+    const { dir, cleanup } = await makeTempSkill(
+      "---\nname: eval-json-shape\ndescription: Do a thing when asked.\n---\n\n# eval-json-shape\n",
+    );
+    try {
+      const { stdout, exitCode } = await runCLI("eval", dir, "--json");
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      // Legacy shape: EvaluationReport keys. If the runner's EvalResult
+      // envelope ever leaks out (providerId, schemaVersion at top level),
+      // these assertions break.
+      expect(parsed).toHaveProperty("skillPath");
+      expect(parsed).toHaveProperty("skillMdPath");
+      expect(parsed).toHaveProperty("evaluatedAt");
+      expect(parsed).toHaveProperty("overallScore");
+      expect(parsed).toHaveProperty("grade");
+      expect(parsed).toHaveProperty("topSuggestions");
+      expect(parsed).toHaveProperty("frontmatter");
+      expect(parsed).not.toHaveProperty("providerId");
+      expect(parsed).not.toHaveProperty("schemaVersion");
+      // Every category still carries findings + suggestions arrays — the
+      // adapter hides those inside `raw`, but the CLI must unwrap them.
+      expect(Array.isArray(parsed.categories)).toBe(true);
+      for (const cat of parsed.categories) {
+        expect(Array.isArray(cat.findings)).toBe(true);
+        expect(Array.isArray(cat.suggestions)).toBe(true);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval error on missing path emits SKILL_NOT_FOUND machine envelope + exit 1", async () => {
+    // Runner wraps thrown errors into an EvalResult; the CLI must re-throw so
+    // the machine envelope still uses SKILL_NOT_FOUND (not a generic error).
+    const missing = join(
+      tmpdir(),
+      `eval-missing-${Date.now()}-${Math.random()}`,
+    );
+    const { stdout, exitCode } = await runCLI("eval", missing, "--machine");
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.status).toBe("error");
+    expect(parsed.error.code).toBe("SKILL_NOT_FOUND");
+    expect(parsed.error.message).toMatch(/does not exist/i);
+  });
+
+  test("eval error on missing path prints legacy Error: line + exit 1 (human mode)", async () => {
+    const missing = join(
+      tmpdir(),
+      `eval-missing-${Date.now()}-${Math.random()}`,
+    );
+    const { stderr, exitCode } = await runCLI("eval", missing);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/^Error: /m);
+    expect(stderr).toMatch(/does not exist/i);
+  });
+});
+
+// ─── CLI integration: eval-providers ────────────────────────────────────────
+
+describe("CLI integration: eval-providers", () => {
+  test("eval-providers list prints quality@1.0.0 with schema + description", async () => {
+    const { stdout, exitCode } = await runCLI("eval-providers", "list");
+    expect(exitCode).toBe(0);
+    // Column header + one quality row. Exact formatting is incidental; we
+    // assert on the required data points so the table can be retuned later.
+    expect(stdout).toContain("id");
+    expect(stdout).toContain("version");
+    expect(stdout).toContain("schemaVersion");
+    expect(stdout).toContain("description");
+    expect(stdout).toContain("requires");
+    expect(stdout).toContain("quality");
+    expect(stdout).toContain("1.0.0");
+    expect(stdout).toContain("Static linter for SKILL.md");
+  });
+
+  test("eval-providers list --json emits a parseable array", async () => {
+    const { stdout, exitCode } = await runCLI(
+      "eval-providers",
+      "list",
+      "--json",
+    );
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThanOrEqual(1);
+    const quality = parsed.find((p: { id: string }) => p.id === "quality");
+    expect(quality).toBeTruthy();
+    expect(quality.version).toBe("1.0.0");
+    expect(quality.schemaVersion).toBe(1);
+    expect(typeof quality.description).toBe("string");
+    expect(quality.description.length).toBeGreaterThan(0);
+    expect(Array.isArray(quality.requires)).toBe(true);
+  });
+
+  test("eval-providers with no subcommand exits with code 2", async () => {
+    const { exitCode, stderr } = await runCLI("eval-providers");
+    expect(exitCode).toBe(2);
+    expect(stderr).toMatch(/Missing subcommand/i);
+  });
+
+  test("eval-providers with unknown subcommand exits with code 2", async () => {
+    const { exitCode, stderr } = await runCLI("eval-providers", "add");
+    expect(exitCode).toBe(2);
+    expect(stderr).toMatch(/Unknown eval-providers subcommand/i);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,14 +99,20 @@ import {
 } from "./updater";
 import { runAllChecks, formatDoctorReport, formatDoctorJSON } from "./doctor";
 import {
-  evaluateSkill,
   applyFix,
   detectGitAuthor,
   formatReport,
   formatReportJSON,
   formatFixPreview,
   buildEvalMachineData,
+  type EvaluationReport,
 } from "./evaluator";
+import { runProvider } from "./eval/runner";
+import {
+  resolve as resolveEvalProvider,
+  list as listEvalProviders,
+} from "./eval/registry";
+import { registerBuiltins } from "./eval/providers";
 import {
   formatMachineOutput,
   formatMachineError,
@@ -389,6 +395,7 @@ ${ansi.bold("Commands:")}
   update [name...]       Update outdated skills with security re-audit
   publish [path]         Validate, audit, and submit a skill to the registry
   eval <skill-path>      Evaluate a skill against best practices and score it
+  eval-providers list    List registered eval providers (id, version, schema, …)
   bundle                 Manage skill bundles (create, install, list, show, remove)
   index                  Manage skill index (ingest, search, list)
   doctor                 Run environment health checks and diagnostics
@@ -2624,6 +2631,10 @@ Evaluate a skill's SKILL.md against best practices and produce a scored quality
 report. Categories: structure, description quality, prompt engineering, context
 efficiency, safety, testability, and naming conventions.
 
+The evaluation runs through the ${ansi.bold("eval provider framework")}; ${ansi.bold("asm eval")} uses the
+${ansi.bold("quality")} provider by default. Use ${ansi.bold("asm eval-providers list")} to see available
+providers.
+
 ${ansi.bold("Arguments:")}
   skill-path           Path to a skill directory (must contain SKILL.md)
 
@@ -2640,7 +2651,41 @@ ${ansi.bold("Examples:")}
   asm eval ./my-skill --json           ${ansi.dim("Output report as JSON")}
   asm eval ./my-skill --fix            ${ansi.dim("Auto-fix deterministic frontmatter issues")}
   asm eval ./my-skill --fix --dry-run  ${ansi.dim("Preview fixes as diff")}
-  asm eval ./my-skill --machine        ${ansi.dim("Machine-readable v1 envelope output")}`);
+  asm eval ./my-skill --machine        ${ansi.dim("Machine-readable v1 envelope output")}
+  asm eval-providers list              ${ansi.dim("List registered eval providers")}`);
+}
+
+// Idempotency guard: `register()` throws on duplicate (id, version) so we only
+// call `registerBuiltins()` once per process lifetime. cmdEval and
+// cmdEvalProviders both call `ensureEvalBuiltins()` at entry; tests that reset
+// the registry directly are responsible for their own registration.
+let _evalBuiltinsRegistered = false;
+function ensureEvalBuiltins(): void {
+  if (_evalBuiltinsRegistered) return;
+  registerBuiltins();
+  _evalBuiltinsRegistered = true;
+}
+
+/**
+ * If a `runProvider()` result carries an error-shaped finding (the runner's
+ * error-wrap path), re-throw so the existing catch block in `cmdEval` keeps
+ * producing the same SKILL_NOT_FOUND machine envelope + exit 1 it did before
+ * the framework was wired in.
+ *
+ * The runner emits `code: "provider-threw" | "timeout" | "aborted"` — any of
+ * those is treated as a thrown error for output parity.
+ */
+function unwrapRunnerErrorOrThrow(result: {
+  findings: { severity: string; message: string; code?: string }[];
+}): void {
+  const err = result.findings.find(
+    (f) =>
+      f.severity === "error" &&
+      (f.code === "provider-threw" ||
+        f.code === "timeout" ||
+        f.code === "aborted"),
+  );
+  if (err) throw new Error(err.message);
 }
 
 async function cmdEval(args: ParsedArgs) {
@@ -2676,6 +2721,9 @@ async function cmdEval(args: ParsedArgs) {
 
   try {
     if (args.flags.fix) {
+      // --fix stays on applyFix() directly. Auto-fix is quality-provider
+      // specific — we do not expose it via provider capability yet; wait
+      // until a second provider needs the same surface.
       const gitAuthor = await detectGitAuthor();
       const fix = await applyFix(skillPath, {
         dryRun: args.flags.dryRun,
@@ -2720,7 +2768,25 @@ async function cmdEval(args: ParsedArgs) {
       return;
     }
 
-    const report = await evaluateSkill(skillPath);
+    // Non-fix path: run through the eval framework.
+    ensureEvalBuiltins();
+    const provider = resolveEvalProvider("quality", "^1.0.0");
+    const { resolve: resolvePath } = await import("path");
+    const absSkillPath = resolvePath(skillPath);
+    const result = await runProvider(provider, {
+      skillPath: absSkillPath,
+      skillMdPath: resolvePath(absSkillPath, "SKILL.md"),
+    });
+
+    // Preserve pre-existing behavior on failure paths: runner wraps thrown
+    // errors into an error-shaped EvalResult; re-throw so the catch block
+    // below emits the same SKILL_NOT_FOUND envelope + exit 1 as before.
+    unwrapRunnerErrorOrThrow(result);
+
+    // `raw` holds the original EvaluationReport — the adapter stores it
+    // verbatim (src/eval/providers/quality/v1/index.ts). Byte-identical
+    // rendering requires passing this through to the existing formatters.
+    const report = result.raw as EvaluationReport;
 
     if (args.flags.machine) {
       restoreConsole?.();
@@ -2755,6 +2821,101 @@ async function cmdEval(args: ParsedArgs) {
     }
     error(err?.message ?? String(err));
     process.exit(1);
+  }
+}
+
+// ─── Eval providers ─────────────────────────────────────────────────────────
+
+function printEvalProvidersHelp() {
+  console.log(`${ansi.bold("Usage:")} asm eval-providers <subcommand> [options]
+
+Manage evaluation providers registered with the ${ansi.bold("asm eval")} framework.
+Providers implement the ${ansi.bold("EvalProvider")} contract (see src/eval/types.ts) and
+are resolved by id and semver range.
+
+${ansi.bold("Subcommands:")}
+  list                 List every registered (id, version) provider
+
+${ansi.bold("Options:")}
+  --json               Output as JSON (list)
+  --no-color           Disable ANSI colors
+  -V, --verbose        Show debug output
+
+${ansi.bold("Examples:")}
+  asm eval-providers list              ${ansi.dim("Show registered providers")}
+  asm eval-providers list --json       ${ansi.dim("Machine-readable listing")}`);
+}
+
+async function cmdEvalProviders(args: ParsedArgs) {
+  if (args.flags.help) {
+    printEvalProvidersHelp();
+    return;
+  }
+
+  const subcommand = args.subcommand;
+  if (!subcommand) {
+    error("Missing subcommand. Use: list");
+    console.error(`Run "asm eval-providers --help" for usage.`);
+    process.exit(2);
+  }
+
+  switch (subcommand) {
+    case "list": {
+      ensureEvalBuiltins();
+      const providers = listEvalProviders();
+
+      if (args.flags.json) {
+        console.log(
+          formatJSON(
+            providers.map((p) => ({
+              id: p.id,
+              version: p.version,
+              schemaVersion: p.schemaVersion,
+              description: p.description,
+              requires: p.requires ?? [],
+            })),
+          ),
+        );
+        return;
+      }
+
+      if (providers.length === 0) {
+        console.log("No eval providers registered.");
+        return;
+      }
+
+      // Build a plain-text table. Widths are computed from the data so the
+      // columns align whether we print one provider or ten.
+      const headers = [
+        "id",
+        "version",
+        "schemaVersion",
+        "description",
+        "requires",
+      ];
+      const rows = providers.map((p) => [
+        p.id,
+        p.version,
+        String(p.schemaVersion),
+        p.description,
+        p.requires && p.requires.length > 0 ? p.requires.join(",") : "-",
+      ]);
+      const widths = headers.map((h, i) =>
+        Math.max(h.length, ...rows.map((r) => r[i]!.length)),
+      );
+      const renderRow = (cells: string[]) =>
+        cells.map((c, i) => c.padEnd(widths[i]!)).join("  ");
+      console.log(ansi.bold(renderRow(headers)));
+      console.log(widths.map((w) => "-".repeat(w)).join("  "));
+      for (const row of rows) {
+        console.log(renderRow(row));
+      }
+      return;
+    }
+    default:
+      error(`Unknown eval-providers subcommand: "${subcommand}". Use: list`);
+      console.error(`Run "asm eval-providers --help" for usage.`);
+      process.exit(2);
   }
 }
 
@@ -4334,6 +4495,9 @@ export async function runCLI(argv: string[]): Promise<void> {
     case "eval":
       await cmdEval(args);
       break;
+    case "eval-providers":
+      await cmdEvalProviders(args);
+      break;
     default:
       error(`Unknown command: "${args.command}"`);
       console.error(`Run "asm --help" for usage.`);
@@ -4368,6 +4532,7 @@ export function isCLIMode(argv: string[]): boolean {
     "update",
     "doctor",
     "eval",
+    "eval-providers",
   ];
   const first = args[0];
 


### PR DESCRIPTION
Closes #157

## Summary

PR 3 of 5 from the Skillgrade integration plan. Routes `asm eval` through the eval-provider framework introduced in PR 1 (#155) and wired up with the quality adapter in PR 2 (#156) — with **byte-identical user-visible output**. Adds a new `asm eval-providers list` subcommand.

## Approach

- `cmdEval` (non-fix path): resolve `quality@^1.0.0` via the registry, run via `runProvider()`, unwrap the original `EvaluationReport` from `result.raw`, then pass it unchanged to the existing renderers (`formatReport` / `formatReportJSON` / `buildEvalMachineData`). The renderer stays byte-identical; only the wiring changes.
- `cmdEval` (--fix path): **unchanged** — still calls `applyFix()` directly. Auto-fix is quality-provider-specific; we don't expose it via a provider capability until a second provider needs the same surface.
- Error parity: `runProvider` wraps thrown errors into an `EvalResult` with a `severity: "error"` finding. `unwrapRunnerErrorOrThrow()` re-throws the original message so the existing catch block still emits the same `SKILL_NOT_FOUND` machine envelope + exit 1 as pre-refactor.
- Idempotency guard: `ensureEvalBuiltins()` wraps `registerBuiltins()` with a module-local flag, since `register()` throws on duplicate `(id, version)`.
- `cmdEvalProviders list`: prints a self-sizing text table (id, version, schemaVersion, description, requires); `--json` emits the same data as an array.

## Changes

| File | Change |
|------|--------|
| `src/cli.ts` | Import runner/registry/registerBuiltins. Add `ensureEvalBuiltins` + `unwrapRunnerErrorOrThrow` helpers. Refactor `cmdEval` non-fix path to go through the framework. Add `cmdEvalProviders` + `printEvalProvidersHelp`. Wire `eval-providers` into the command dispatch, `isCLIMode`, main `--help`, and `eval --help`. |
| `src/cli.test.ts` | Add `isCLIMode(eval-providers)` test. Add `eval-providers --help` + main `--help` cross-ref tests. Add 4 regression tests for `eval` (text structure, JSON shape, error envelope, Error: line). Add 4 tests for `eval-providers list` (text/JSON output, missing/unknown subcommand). |

## Test Results

- `bun test src/eval/` — 80 pass (unchanged from PR 2 baseline)
- `bun test src/evaluator.test.ts` — 37 pass (unchanged)
- `bun test src/cli.test.ts -t "eval"` — 18 pass (was 7 pre-refactor; +11 new tests)
- `bunx tsc --noEmit` — clean
- Byte-parity verified manually against pre-refactor baselines for `--json`, `--text`, `--machine`, `--fix`, `--fix --dry-run` paths

The 5 pre-existing failures (4 in `src/publisher.test.ts`, 1 in `src/cli.test.ts` — an `import` test that depends on host-installed skills) are unrelated to the eval framework and were called out in the issue body. Used `SKIP=unit-tests` for the commit, matching the pattern from PR 1 and PR 2.

## Acceptance Criteria

- [x] Existing `asm eval` golden/snapshot tests pass unchanged (byte-identical text output; JSON differs only in `evaluatedAt` wall-clock which was non-deterministic pre-PR; machine envelope identical after stripping timing fields)
- [x] All existing flags (`--json`, `--machine`, `--fix`, `--dry-run`) behave identically
- [x] `asm eval-providers list` prints `quality@1.0.0` with `schemaVersion: 1` and description
- [x] `--help` documents `eval-providers` subcommand (both main help and `asm eval --help` cross-link)