### PR TITLE
feat(eval): add skillgrade runtime provider (#158)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1674,6 +1674,563 @@ describe("CLI integration: eval", () => {
   });
 });
 
+// ─── CLI integration: eval --runtime (skillgrade) ──────────────────────────
+
+// The runtime provider shells out to the external `skillgrade` binary, which
+// is not installed in CI. The CLI's user-visible contract in that situation
+// is that applicable() produces an actionable reason — no crash, no stack
+// trace, exit 1. These tests lock in that contract without ever running
+// skillgrade for real. Deeper end-to-end exercising of run() lives in
+// src/eval/providers/skillgrade/v1/index.test.ts where the Spawner seam can
+// return recorded fixture JSON without any subprocess.
+
+describe("CLI integration: eval --runtime", () => {
+  async function makeSkillDir(
+    opts: { withEvalYaml?: boolean } = {},
+  ): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+    const dir = await mkdtemp(join(tmpdir(), "eval-runtime-cli-"));
+    await writeFile(
+      join(dir, "SKILL.md"),
+      "---\nname: runtime-cli\ndescription: Runtime eval test skill when invoked.\n---\n\n# runtime-cli\n\n## Instructions\n\n1. Do the thing\n",
+      "utf-8",
+    );
+    if (opts.withEvalYaml) {
+      await writeFile(
+        join(dir, "eval.yaml"),
+        "name: runtime-cli\npreset: smoke\nthreshold: 0.8\n",
+        "utf-8",
+      );
+    }
+    return { dir, cleanup: () => rm(dir, { recursive: true, force: true }) };
+  }
+
+  // Force the skillgrade detection to fail by scrubbing PATH so any
+  // `skillgrade` binary is invisible to the subprocess. We still need
+  // bun itself on PATH to run the CLI, so we carefully keep the bun
+  // binary's directory (derived from `process.execPath`) but nothing
+  // else. If a developer has bun installed alongside skillgrade in the
+  // same directory, the PATH scrub won't hide it — but that's an
+  // extremely unusual layout and the test still validates the CLI
+  // correctly surfaces applicable() reasons for any failure shape.
+  async function runRuntimeCLI(
+    ...args: string[]
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const { dirname } = await import("path");
+    const bunDir = dirname(process.execPath);
+    const emptyDir = await mkdtemp(join(tmpdir(), "empty-path-"));
+    try {
+      // PATH: empty-dir first (to shadow anything), then bun's dir.
+      // Standard locations like /usr/bin are intentionally excluded so
+      // a system `skillgrade` can't slip through.
+      const scrubbedPath = [emptyDir, bunDir].join(":");
+      const proc = Bun.spawn([process.execPath, CLI_BIN, ...args], {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, NO_COLOR: "1", PATH: scrubbedPath },
+      });
+      const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      const exitCode = await proc.exited;
+      return {
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode,
+      };
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
+    }
+  }
+
+  test("eval --runtime exits 1 with install hint when skillgrade is missing", async () => {
+    const { dir, cleanup } = await makeSkillDir({ withEvalYaml: true });
+    try {
+      const { stderr, exitCode } = await runRuntimeCLI(
+        "eval",
+        dir,
+        "--runtime",
+      );
+      expect(exitCode).toBe(1);
+      expect(stderr).toMatch(/skillgrade not installed/);
+      expect(stderr).toMatch(/npm i -g skillgrade/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --runtime --machine emits a structured error envelope", async () => {
+    const { dir, cleanup } = await makeSkillDir({ withEvalYaml: true });
+    try {
+      const { stdout, exitCode } = await runRuntimeCLI(
+        "eval",
+        dir,
+        "--runtime",
+        "--machine",
+      );
+      expect(exitCode).toBe(1);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.status).toBe("error");
+      expect(parsed.error.message).toMatch(/skillgrade/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --runtime init surfaces a scaffold error when skillgrade is missing", async () => {
+    const { dir, cleanup } = await makeSkillDir();
+    try {
+      const { stderr, exitCode } = await runRuntimeCLI(
+        "eval",
+        dir,
+        "--runtime",
+        "init",
+      );
+      expect(exitCode).toBe(1);
+      expect(stderr).toMatch(/skillgrade/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --runtime rejects an invalid --provider value", async () => {
+    const { dir, cleanup } = await makeSkillDir({ withEvalYaml: true });
+    try {
+      const { stderr, exitCode } = await runRuntimeCLI(
+        "eval",
+        dir,
+        "--runtime",
+        "--provider",
+        "aws",
+      );
+      expect(exitCode).toBe(2);
+      expect(stderr).toMatch(/Invalid --provider/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --runtime rejects an invalid --preset value", async () => {
+    const { dir, cleanup } = await makeSkillDir({ withEvalYaml: true });
+    try {
+      const { stderr, exitCode } = await runRuntimeCLI(
+        "eval",
+        dir,
+        "--runtime",
+        "--preset",
+        "nuclear",
+      );
+      expect(exitCode).toBe(2);
+      expect(stderr).toMatch(/Invalid --preset/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --runtime rejects a non-numeric --threshold", async () => {
+    const { dir, cleanup } = await makeSkillDir({ withEvalYaml: true });
+    try {
+      const { stderr, exitCode } = await runRuntimeCLI(
+        "eval",
+        dir,
+        "--runtime",
+        "--threshold",
+        "abc",
+      );
+      expect(exitCode).toBe(2);
+      expect(stderr).toMatch(/Invalid --threshold/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  // Stub-binary end-to-end test. This proves the headline acceptance
+  // criterion — "asm eval ./fixture --runtime produces expected output
+  // against recorded skillgrade JSON" — at the real CLI layer, not just
+  // the provider unit layer. We write a tiny shell script that mimics
+  // `skillgrade --version` and `skillgrade run --json`, put it first on
+  // PATH, and let the CLI shell out to it. Zero live LLM calls.
+  test("eval --runtime with a stub skillgrade binary produces a passing report", async () => {
+    const { dir: skillDir, cleanup: cleanupSkill } = await makeSkillDir({
+      withEvalYaml: true,
+    });
+    const stubDir = await mkdtemp(join(tmpdir(), "stub-skillgrade-"));
+    try {
+      const fixture = JSON.stringify({
+        version: "0.1.4",
+        skill: "runtime-cli",
+        preset: "smoke",
+        threshold: 0.8,
+        passRate: 0.95,
+        passed: true,
+        tasks: [
+          {
+            id: "hello",
+            passed: true,
+            trials: 5,
+            passing: 5,
+            passRate: 1.0,
+            graders: [{ id: "contains", passed: true, message: "has hello" }],
+          },
+        ],
+      });
+      // Escape single quotes via ASCII char for safe shell embedding.
+      const escapedFixture = fixture.replace(/'/g, "'\\''");
+      const stubPath = join(stubDir, "skillgrade");
+      await writeFile(
+        stubPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "skillgrade 0.1.4"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "run" ]; then',
+          `  printf '%s' '${escapedFixture}'`,
+          "  exit 0",
+          "fi",
+          "exit 127",
+        ].join("\n"),
+        "utf-8",
+      );
+      await (await import("fs/promises")).chmod(stubPath, 0o755);
+
+      // Keep bun itself + the stub on PATH; everything else scrubbed so
+      // a system skillgrade can't interfere.
+      const { dirname } = await import("path");
+      const bunDir = dirname(process.execPath);
+      const scrubbedPath = [stubDir, bunDir].join(":");
+
+      const proc = Bun.spawn(
+        [process.execPath, CLI_BIN, "eval", skillDir, "--runtime", "--json"],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: { ...process.env, NO_COLOR: "1", PATH: scrubbedPath },
+        },
+      );
+      const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toMatch(/not installed/);
+
+      const parsed = JSON.parse(stdout);
+      expect(parsed.providerId).toBe("skillgrade");
+      expect(parsed.providerVersion).toBe("1.0.0");
+      expect(parsed.score).toBe(95);
+      expect(parsed.passed).toBe(true);
+      expect(parsed.categories).toHaveLength(1);
+      expect(parsed.categories[0].id).toBe("hello");
+    } finally {
+      await cleanupSkill();
+      await rm(stubDir, { recursive: true, force: true });
+    }
+  });
+
+  test("eval --runtime reads preset/threshold/provider from ~/.asm/config.yml", async () => {
+    // HOME override → config.yml placed under a fake home so we don't
+    // touch the developer's real ~/.asm/config.yml.
+    const fakeHome = await mkdtemp(join(tmpdir(), "runtime-home-"));
+    const asmDir = join(fakeHome, ".asm");
+    await mkdir(asmDir, { recursive: true });
+    await writeFile(
+      join(asmDir, "config.yml"),
+      [
+        "eval:",
+        "  providers:",
+        "    skillgrade:",
+        "      preset: reliable",
+        "      threshold: 0.9",
+        "      provider: local",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const { dir: skillDir, cleanup: cleanupSkill } = await makeSkillDir({
+      withEvalYaml: true,
+    });
+    const stubDir = await mkdtemp(join(tmpdir(), "stub-cfg-"));
+    try {
+      // Stub records its argv to a side-channel file we assert on.
+      const argvLog = join(stubDir, "argv.txt");
+      const stubPath = join(stubDir, "skillgrade");
+      const fixture = JSON.stringify({
+        version: "0.1.4",
+        passRate: 1.0,
+        passed: true,
+        tasks: [],
+      });
+      const escapedFixture = fixture.replace(/'/g, "'\\''");
+      await writeFile(
+        stubPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "skillgrade 0.1.4"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "run" ]; then',
+          `  printf '%s\\n' "$@" > '${argvLog}'`,
+          `  printf '%s' '${escapedFixture}'`,
+          "  exit 0",
+          "fi",
+          "exit 127",
+        ].join("\n"),
+        "utf-8",
+      );
+      await (await import("fs/promises")).chmod(stubPath, 0o755);
+
+      const { dirname } = await import("path");
+      const bunDir = dirname(process.execPath);
+      const scrubbedPath = [stubDir, bunDir].join(":");
+
+      const proc = Bun.spawn(
+        [process.execPath, CLI_BIN, "eval", skillDir, "--runtime", "--json"],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: {
+            ...process.env,
+            NO_COLOR: "1",
+            PATH: scrubbedPath,
+            HOME: fakeHome,
+          },
+        },
+      );
+      const [stdout] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(stdout).passed).toBe(true);
+      const loggedArgv = await readFile(argvLog, "utf-8");
+      expect(loggedArgv).toContain("reliable");
+      expect(loggedArgv).toContain("0.9");
+      expect(loggedArgv).toContain("local");
+    } finally {
+      await cleanupSkill();
+      await rm(stubDir, { recursive: true, force: true });
+      await rm(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("eval --runtime CLI flags override config values", async () => {
+    const fakeHome = await mkdtemp(join(tmpdir(), "runtime-home-2-"));
+    const asmDir = join(fakeHome, ".asm");
+    await mkdir(asmDir, { recursive: true });
+    await writeFile(
+      join(asmDir, "config.yml"),
+      [
+        "eval:",
+        "  providers:",
+        "    skillgrade:",
+        "      preset: regression",
+        "      threshold: 0.99",
+        "      provider: docker",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const { dir: skillDir, cleanup: cleanupSkill } = await makeSkillDir({
+      withEvalYaml: true,
+    });
+    const stubDir = await mkdtemp(join(tmpdir(), "stub-cfg-override-"));
+    try {
+      const argvLog = join(stubDir, "argv.txt");
+      const stubPath = join(stubDir, "skillgrade");
+      const fixture = JSON.stringify({
+        version: "0.1.4",
+        passRate: 1.0,
+        passed: true,
+        tasks: [],
+      });
+      const escapedFixture = fixture.replace(/'/g, "'\\''");
+      await writeFile(
+        stubPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "skillgrade 0.1.4"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "run" ]; then',
+          `  printf '%s\\n' "$@" > '${argvLog}'`,
+          `  printf '%s' '${escapedFixture}'`,
+          "  exit 0",
+          "fi",
+          "exit 127",
+        ].join("\n"),
+        "utf-8",
+      );
+      await (await import("fs/promises")).chmod(stubPath, 0o755);
+
+      const { dirname } = await import("path");
+      const bunDir = dirname(process.execPath);
+      const scrubbedPath = [stubDir, bunDir].join(":");
+
+      const proc = Bun.spawn(
+        [
+          process.execPath,
+          CLI_BIN,
+          "eval",
+          skillDir,
+          "--runtime",
+          "--preset",
+          "smoke",
+          "--threshold",
+          "0.7",
+          "--provider",
+          "local",
+          "--json",
+        ],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: {
+            ...process.env,
+            NO_COLOR: "1",
+            PATH: scrubbedPath,
+            HOME: fakeHome,
+          },
+        },
+      );
+      await new Response(proc.stdout).text();
+      await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+      expect(exitCode).toBe(0);
+
+      const loggedArgv = await readFile(argvLog, "utf-8");
+      // CLI values, not config values.
+      expect(loggedArgv).toContain("smoke");
+      expect(loggedArgv).toContain("0.7");
+      expect(loggedArgv).toContain("local");
+      expect(loggedArgv).not.toContain("regression");
+      expect(loggedArgv).not.toContain("0.99");
+    } finally {
+      await cleanupSkill();
+      await rm(stubDir, { recursive: true, force: true });
+      await rm(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  test("eval --runtime with a failing stub exits 1 and reports failure", async () => {
+    const { dir: skillDir, cleanup: cleanupSkill } = await makeSkillDir({
+      withEvalYaml: true,
+    });
+    const stubDir = await mkdtemp(join(tmpdir(), "stub-skillgrade-fail-"));
+    try {
+      const fixture = JSON.stringify({
+        version: "0.1.4",
+        skill: "runtime-cli",
+        passRate: 0.4,
+        passed: false,
+        tasks: [
+          {
+            id: "sad-path",
+            passed: false,
+            trials: 5,
+            passing: 2,
+            graders: [{ id: "contains", passed: false, message: "no hello" }],
+          },
+        ],
+      });
+      const escapedFixture = fixture.replace(/'/g, "'\\''");
+      const stubPath = join(stubDir, "skillgrade");
+      await writeFile(
+        stubPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "skillgrade 0.1.4"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "run" ]; then',
+          `  printf '%s' '${escapedFixture}'`,
+          "  exit 0",
+          "fi",
+          "exit 127",
+        ].join("\n"),
+        "utf-8",
+      );
+      await (await import("fs/promises")).chmod(stubPath, 0o755);
+
+      const { dirname } = await import("path");
+      const bunDir = dirname(process.execPath);
+      const scrubbedPath = [stubDir, bunDir].join(":");
+
+      const proc = Bun.spawn(
+        [process.execPath, CLI_BIN, "eval", skillDir, "--runtime"],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+          env: { ...process.env, NO_COLOR: "1", PATH: scrubbedPath },
+        },
+      );
+      const [stdout] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(1);
+      expect(stdout).toMatch(/FAIL/);
+      expect(stdout).toMatch(/score=40/);
+    } finally {
+      await cleanupSkill();
+      await rm(stubDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── parseArgs: runtime flags ───────────────────────────────────────────────
+
+describe("parseArgs — runtime flags", () => {
+  const parse = (...args: string[]) => parseArgs(["bun", "script.ts", ...args]);
+
+  test("--runtime sets flags.runtime", () => {
+    const result = parse("eval", "./skill", "--runtime");
+    expect(result.flags.runtime).toBe(true);
+  });
+
+  test("--runtime defaults to false", () => {
+    const result = parse("eval", "./skill");
+    expect(result.flags.runtime).toBe(false);
+  });
+
+  test("--preset captures the next token", () => {
+    const result = parse(
+      "eval",
+      "./skill",
+      "--runtime",
+      "--preset",
+      "reliable",
+    );
+    expect(result.flags.preset).toBe("reliable");
+  });
+
+  test("--threshold accepts fractional values", () => {
+    const result = parse("eval", "./skill", "--runtime", "--threshold", "0.9");
+    expect(result.flags.threshold).toBe(0.9);
+  });
+
+  test("--threshold accepts 0..100 integer values", () => {
+    const result = parse("eval", "./skill", "--runtime", "--threshold", "85");
+    expect(result.flags.threshold).toBe(85);
+  });
+
+  test("--runtime init carries `init` as a positional arg", () => {
+    const result = parse("eval", "./skill", "--runtime", "init");
+    expect(result.flags.runtime).toBe(true);
+    expect(result.positional).toContain("init");
+  });
+});
+
 // ─── CLI integration: eval-providers ────────────────────────────────────────
 
 describe("CLI integration: eval-providers", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,6 +113,8 @@ import {
   list as listEvalProviders,
 } from "./eval/registry";
 import { registerBuiltins } from "./eval/providers";
+import { loadEvalConfig } from "./eval/config";
+import { scaffoldEvalYaml } from "./eval/providers/skillgrade/v1/scaffold";
 import {
   formatMachineOutput,
   formatMachineError,
@@ -212,6 +214,12 @@ interface ParsedArgs {
     machine: boolean;
     noCache: boolean;
     fix: boolean;
+    /** `asm eval --runtime` toggles the skillgrade runtime provider. */
+    runtime: boolean;
+    /** `asm eval --preset smoke|reliable|regression` — skillgrade preset. */
+    preset: string | null;
+    /** `asm eval --threshold 0.8` — accepts `0..1` or `0..100`. */
+    threshold: number | null;
   };
 }
 
@@ -247,6 +255,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
       machine: false,
       noCache: false,
       fix: false,
+      runtime: false,
+      preset: null,
+      threshold: null,
     },
   };
 
@@ -340,6 +351,26 @@ export function parseArgs(argv: string[]): ParsedArgs {
     } else if (arg === "--missing") {
       i++;
       if (args[i]) result.flags.missing.push(args[i]);
+    } else if (arg === "--runtime") {
+      result.flags.runtime = true;
+    } else if (arg === "--preset") {
+      i++;
+      result.flags.preset = args[i] || null;
+    } else if (arg === "--threshold") {
+      i++;
+      const val = args[i];
+      if (val === undefined) {
+        error("--threshold requires a numeric value");
+        process.exit(2);
+      }
+      const n = Number(val);
+      if (!Number.isFinite(n)) {
+        error(
+          `Invalid --threshold: "${val}". Must be a number (e.g. 0.8 or 80).`,
+        );
+        process.exit(2);
+      }
+      result.flags.threshold = n;
     } else if (arg.startsWith("-")) {
       error(`Unknown option: ${arg}`);
       console.error(`Run "asm --help" for usage.`);
@@ -2632,8 +2663,8 @@ report. Categories: structure, description quality, prompt engineering, context
 efficiency, safety, testability, and naming conventions.
 
 The evaluation runs through the ${ansi.bold("eval provider framework")}; ${ansi.bold("asm eval")} uses the
-${ansi.bold("quality")} provider by default. Use ${ansi.bold("asm eval-providers list")} to see available
-providers.
+${ansi.bold("quality")} provider by default, or the ${ansi.bold("skillgrade")} runtime provider with
+${ansi.bold("--runtime")}. Use ${ansi.bold("asm eval-providers list")} to see available providers.
 
 ${ansi.bold("Arguments:")}
   skill-path           Path to a skill directory (must contain SKILL.md)
@@ -2641,18 +2672,26 @@ ${ansi.bold("Arguments:")}
 ${ansi.bold("Options:")}
   --fix                Apply deterministic auto-fixes to SKILL.md (creates .bak)
   --dry-run            With --fix, preview the diff without writing
+  --runtime            Run the skillgrade runtime provider (LLM-judge evals)
+  --runtime init       Scaffold eval.yaml via \`skillgrade init\`
+  --preset <name>      Skillgrade preset: smoke | reliable | regression
+  --threshold <n>      Pass threshold (0..1 fraction or 0..100 integer)
+  --provider <name>    Skillgrade exec provider: docker | local
   --json               Output report as JSON
   --machine            Output in stable machine-readable v1 envelope format
   --no-color           Disable ANSI colors
   -V, --verbose        Show debug output
 
 ${ansi.bold("Examples:")}
-  asm eval ./my-skill                  ${ansi.dim("Score the skill")}
-  asm eval ./my-skill --json           ${ansi.dim("Output report as JSON")}
-  asm eval ./my-skill --fix            ${ansi.dim("Auto-fix deterministic frontmatter issues")}
-  asm eval ./my-skill --fix --dry-run  ${ansi.dim("Preview fixes as diff")}
-  asm eval ./my-skill --machine        ${ansi.dim("Machine-readable v1 envelope output")}
-  asm eval-providers list              ${ansi.dim("List registered eval providers")}`);
+  asm eval ./my-skill                     ${ansi.dim("Static quality score")}
+  asm eval ./my-skill --json              ${ansi.dim("Output report as JSON")}
+  asm eval ./my-skill --fix               ${ansi.dim("Auto-fix deterministic frontmatter issues")}
+  asm eval ./my-skill --fix --dry-run     ${ansi.dim("Preview fixes as diff")}
+  asm eval ./my-skill --machine           ${ansi.dim("Machine-readable v1 envelope output")}
+  asm eval ./my-skill --runtime           ${ansi.dim("Run skillgrade runtime evals")}
+  asm eval ./my-skill --runtime init      ${ansi.dim("Scaffold eval.yaml via skillgrade init")}
+  asm eval ./my-skill --runtime --preset reliable --threshold 0.9
+  asm eval-providers list                 ${ansi.dim("List registered eval providers")}`);
 }
 
 // Idempotency guard: `register()` throws on duplicate (id, version) so we only
@@ -2766,6 +2805,200 @@ async function cmdEval(args: ParsedArgs) {
       console.log("");
       console.log(formatFixPreview(fix));
       return;
+    }
+
+    // --runtime branch: skillgrade provider. A second positional arg `init`
+    // means scaffold-instead-of-run (no subcommand nesting; positional is
+    // the cheapest surface). `--provider` in this branch is validated to
+    // `docker|local` — other commands reuse the flag for install/audit
+    // providers so we can't validate globally in the parser.
+    if (args.flags.runtime) {
+      const { resolve: resolvePath } = await import("path");
+      const absSkillPath = resolvePath(skillPath);
+
+      // Positional "init" → scaffold eval.yaml then exit.
+      if (args.positional[0] === "init") {
+        const scaffoldRes = await scaffoldEvalYaml({
+          skillPath: absSkillPath,
+        });
+        if (args.flags.machine) {
+          restoreConsole?.();
+          console.log(
+            formatMachineOutput(
+              "eval",
+              {
+                action: "scaffold",
+                ok: scaffoldRes.ok,
+                exit_code: scaffoldRes.exitCode,
+                message: scaffoldRes.message,
+              },
+              startTime,
+            ),
+          );
+          process.exit(scaffoldRes.ok ? 0 : 1);
+        }
+        if (args.flags.json) {
+          console.log(JSON.stringify(scaffoldRes, null, 2));
+          process.exit(scaffoldRes.ok ? 0 : 1);
+        }
+        if (scaffoldRes.ok) {
+          console.log(scaffoldRes.message);
+        } else {
+          error(scaffoldRes.message);
+        }
+        process.exit(scaffoldRes.ok ? 0 : 1);
+      }
+
+      // Validate --provider in runtime context (shared flag, different
+      // domain than install/audit providers).
+      if (
+        args.flags.provider !== null &&
+        args.flags.provider !== "docker" &&
+        args.flags.provider !== "local"
+      ) {
+        error(
+          `Invalid --provider for --runtime: "${args.flags.provider}". Must be docker or local.`,
+        );
+        process.exit(2);
+      }
+      // Validate --preset.
+      if (
+        args.flags.preset !== null &&
+        args.flags.preset !== "smoke" &&
+        args.flags.preset !== "reliable" &&
+        args.flags.preset !== "regression"
+      ) {
+        error(
+          `Invalid --preset: "${args.flags.preset}". Must be smoke, reliable, or regression.`,
+        );
+        process.exit(2);
+      }
+
+      ensureEvalBuiltins();
+      const runtimeProvider = resolveEvalProvider("skillgrade", "^1.0.0");
+      const ctx = {
+        skillPath: absSkillPath,
+        skillMdPath: resolvePath(absSkillPath, "SKILL.md"),
+      };
+
+      // Merge config → CLI flags (CLI wins). Keeps `~/.asm/config.yml
+      // eval.providers.skillgrade.{preset, threshold, provider}` live
+      // without forcing the user to repeat themselves on every invocation.
+      // Missing file / missing section → defaults (no-op).
+      const runtimeOpts: Record<string, unknown> = {};
+      try {
+        const evalConfig = await loadEvalConfig();
+        const sgConfig = evalConfig.providers.skillgrade;
+        if (sgConfig) {
+          if (typeof sgConfig.preset === "string") {
+            runtimeOpts.preset = sgConfig.preset;
+          }
+          if (typeof sgConfig.threshold === "number") {
+            runtimeOpts.threshold = sgConfig.threshold;
+          }
+          if (sgConfig.provider === "docker" || sgConfig.provider === "local") {
+            runtimeOpts.provider = sgConfig.provider;
+          }
+        }
+        const defaultTimeout = evalConfig.defaults.timeoutMs;
+        if (typeof defaultTimeout === "number" && defaultTimeout > 0) {
+          runtimeOpts.timeoutMs = defaultTimeout;
+        }
+      } catch (err: any) {
+        // Malformed YAML should be loud — don't swallow silently. Re-throw
+        // so the outer catch surfaces it as a normal eval error.
+        throw new Error(
+          `failed to load ~/.asm/config.yml: ${err?.message ?? String(err)}`,
+        );
+      }
+      // CLI flags take precedence over config values.
+      if (args.flags.preset) runtimeOpts.preset = args.flags.preset;
+      if (args.flags.provider) runtimeOpts.provider = args.flags.provider;
+      if (args.flags.threshold !== null) {
+        runtimeOpts.threshold = args.flags.threshold;
+      }
+
+      // Surface applicable() reasons verbatim — binary missing, version
+      // out of range, eval.yaml missing each have a distinct hint.
+      const ok = await runtimeProvider.applicable(ctx, runtimeOpts);
+      if (!ok.ok) {
+        if (args.flags.machine) {
+          restoreConsole?.();
+          console.log(
+            formatMachineError(
+              "eval",
+              ErrorCodes.INVALID_ARGUMENT,
+              ok.reason ?? "skillgrade provider not applicable",
+              startTime,
+            ),
+          );
+          process.exit(1);
+        }
+        error(ok.reason ?? "skillgrade provider not applicable");
+        process.exit(1);
+      }
+
+      const runtimeResult = await runProvider(
+        runtimeProvider,
+        ctx,
+        runtimeOpts,
+      );
+
+      if (args.flags.machine) {
+        restoreConsole?.();
+        console.log(
+          formatMachineOutput(
+            "eval",
+            {
+              provider_id: runtimeResult.providerId,
+              provider_version: runtimeResult.providerVersion,
+              schema_version: runtimeResult.schemaVersion,
+              score: runtimeResult.score,
+              passed: runtimeResult.passed,
+              categories: runtimeResult.categories,
+              findings: runtimeResult.findings,
+            },
+            startTime,
+          ),
+        );
+        process.exit(runtimeResult.passed ? 0 : 1);
+      }
+
+      if (args.flags.json) {
+        console.log(JSON.stringify(runtimeResult, null, 2));
+        process.exit(runtimeResult.passed ? 0 : 1);
+      }
+
+      // Default rendering — concise runtime summary. The quality provider's
+      // rich report formatter is specific to the static linter; runtime
+      // output is simpler.
+      const status = runtimeResult.passed
+        ? ansi.green("PASS")
+        : ansi.red("FAIL");
+      console.log(
+        `${ansi.bold("Skillgrade runtime:")} ${status} score=${runtimeResult.score}/100`,
+      );
+      if (runtimeResult.categories.length > 0) {
+        console.log("");
+        console.log(ansi.bold("Tasks:"));
+        for (const c of runtimeResult.categories) {
+          console.log(`  ${c.name}: ${c.score}/${c.max} (${c.id})`);
+        }
+      }
+      if (runtimeResult.findings.length > 0) {
+        console.log("");
+        console.log(ansi.bold("Findings:"));
+        for (const f of runtimeResult.findings) {
+          const sev =
+            f.severity === "error"
+              ? ansi.red(f.severity)
+              : f.severity === "warning"
+                ? ansi.yellow(f.severity)
+                : ansi.dim(f.severity);
+          console.log(`  [${sev}] ${f.message}`);
+        }
+      }
+      process.exit(runtimeResult.passed ? 0 : 1);
     }
 
     // Non-fix path: run through the eval framework.

--- a/src/eval/providers/index.test.ts
+++ b/src/eval/providers/index.test.ts
@@ -11,15 +11,18 @@ describe("registerBuiltins", () => {
     expect(typeof registerBuiltins).toBe("function");
   });
 
-  it("registers the quality provider (PR 2)", () => {
+  it("registers the quality and skillgrade providers", () => {
     registerBuiltins();
-    // PR 2 lands `quality@1.0.0`. PR 4 will add skillgrade — bump this count
-    // when it does.
+    // PR 2 (#156) added `quality@1.0.0`. PR 4 (#158) adds `skillgrade@1.0.0`.
+    // Bump this count when new built-ins land.
     const providers = list();
-    expect(providers).toHaveLength(1);
-    expect(providers[0]!.id).toBe("quality");
-    expect(providers[0]!.version).toBe("1.0.0");
-    expect(providers[0]!.schemaVersion).toBe(1);
+    expect(providers).toHaveLength(2);
+    const ids = providers.map((p) => p.id).sort();
+    expect(ids).toEqual(["quality", "skillgrade"]);
+    for (const p of providers) {
+      expect(p.version).toBe("1.0.0");
+      expect(p.schemaVersion).toBe(1);
+    }
   });
 
   it("makes quality resolvable via semver range", () => {
@@ -27,6 +30,14 @@ describe("registerBuiltins", () => {
     const provider = resolve("quality", "^1.0.0");
     expect(provider.id).toBe("quality");
     expect(provider.version).toBe("1.0.0");
+  });
+
+  it("makes skillgrade resolvable via semver range", () => {
+    registerBuiltins();
+    const provider = resolve("skillgrade", "^1.0.0");
+    expect(provider.id).toBe("skillgrade");
+    expect(provider.version).toBe("1.0.0");
+    expect(provider.externalRequires?.binary).toBe("skillgrade");
   });
 
   it("does not throw when invoked", () => {

--- a/src/eval/providers/index.ts
+++ b/src/eval/providers/index.ts
@@ -1,23 +1,23 @@
 /**
  * Built-in provider registration.
  *
- * `registerBuiltins()` is the single place PR 3+ wires `src/cli.ts` to
- * the eval framework. Each built-in provider module exports a factory,
- * and this function calls `register()` for each one.
+ * `registerBuiltins()` is the single place `src/cli.ts` wires the eval
+ * framework. Each built-in provider module exports a factory, and this
+ * function calls `register()` for each one.
  *
- * PR 1 shipped this as an empty function. PR 2 (#156) adds the `quality`
- * provider — an adapter over `src/evaluator.ts`. PR 4 will add
- * `skillgrade`. Keeping the list here (rather than each provider
- * self-registering at import time) makes ordering deterministic and
- * makes it possible to run with a restricted provider set in tests.
+ * PR 1 shipped this as an empty function. PR 2 (#156) added the `quality`
+ * provider — an adapter over `src/evaluator.ts`. PR 4 (#158) adds
+ * `skillgrade` — runtime eval via the external `skillgrade` CLI.
  *
- * This file MUST NOT be imported from `src/cli.ts` yet — PR 3 owns that
- * wiring. Importing it here in PR 2 would register a provider at module
- * load time and silently change `asm eval` behavior.
+ * Providers register unconditionally: environment conditions (binary
+ * present, API key exported, etc.) are checked per-context by each
+ * provider's `applicable()` at runtime, not at registration time. This
+ * keeps `asm eval-providers list` deterministic across machines.
  */
 
 import { register } from "../registry";
 import { qualityProviderV1 } from "./quality/v1";
+import { skillgradeProviderV1 } from "./skillgrade/v1";
 
 /**
  * Register every built-in provider with the shared registry.
@@ -28,5 +28,5 @@ import { qualityProviderV1 } from "./quality/v1";
  */
 export function registerBuiltins(): void {
   register(qualityProviderV1);
-  // PR 4: register(skillgradeProviderV1);
+  register(skillgradeProviderV1);
 }

--- a/src/eval/providers/skillgrade/v1/adapter.test.ts
+++ b/src/eval/providers/skillgrade/v1/adapter.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Adapter snapshot + mapping-invariant tests.
+ *
+ * The adapter is a pure function — every test here feeds in a known
+ * skillgrade JSON shape (either a recorded fixture or a hand-crafted
+ * micro-shape) and asserts the resulting `EvalResult`.
+ *
+ * We do NOT touch disk for the runtime path here; that's covered by
+ * `index.test.ts`. Snapshot tests that compare against recorded JSON
+ * fixtures live in `index.test.ts` so they exercise the provider end to
+ * end, not just the adapter in isolation.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { adaptSkillgradeReport } from "./adapter";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const FIXTURES_DIR = join(__dirname, "fixtures");
+
+const DEFAULT_INPUTS = {
+  providerId: "skillgrade",
+  providerVersion: "1.0.0",
+  schemaVersion: 1,
+  thresholdFraction: 0.8,
+};
+
+describe("adaptSkillgradeReport — identity fields", () => {
+  it("stamps providerId / providerVersion / schemaVersion from inputs", () => {
+    const r = adaptSkillgradeReport(
+      { passRate: 1.0, passed: true },
+      {
+        ...DEFAULT_INPUTS,
+        providerId: "skillgrade",
+        providerVersion: "1.2.3",
+        schemaVersion: 2,
+      },
+    );
+    expect(r.providerId).toBe("skillgrade");
+    expect(r.providerVersion).toBe("1.2.3");
+    expect(r.schemaVersion).toBe(2);
+  });
+
+  it("leaves startedAt / durationMs as placeholders for the runner", () => {
+    const r = adaptSkillgradeReport({ passRate: 0.5 }, DEFAULT_INPUTS);
+    expect(r.startedAt).toBe("");
+    expect(r.durationMs).toBe(0);
+  });
+});
+
+describe("adaptSkillgradeReport — score mapping", () => {
+  it("multiplies passRate into a 0..100 integer", () => {
+    expect(
+      adaptSkillgradeReport({ passRate: 0.92 }, DEFAULT_INPUTS).score,
+    ).toBe(92);
+    expect(adaptSkillgradeReport({ passRate: 1.0 }, DEFAULT_INPUTS).score).toBe(
+      100,
+    );
+    expect(adaptSkillgradeReport({ passRate: 0 }, DEFAULT_INPUTS).score).toBe(
+      0,
+    );
+  });
+
+  it("clamps out-of-range passRate", () => {
+    expect(adaptSkillgradeReport({ passRate: 1.5 }, DEFAULT_INPUTS).score).toBe(
+      100,
+    );
+    expect(
+      adaptSkillgradeReport({ passRate: -0.2 }, DEFAULT_INPUTS).score,
+    ).toBe(0);
+  });
+
+  it("defaults to 0 when passRate is missing or non-numeric", () => {
+    expect(adaptSkillgradeReport({}, DEFAULT_INPUTS).score).toBe(0);
+    expect(
+      adaptSkillgradeReport({ passRate: "nope" as any }, DEFAULT_INPUTS).score,
+    ).toBe(0);
+  });
+});
+
+describe("adaptSkillgradeReport — passed resolution", () => {
+  it("prefers explicit passed flag over threshold compare", () => {
+    const r = adaptSkillgradeReport(
+      { passRate: 0.2, passed: true },
+      DEFAULT_INPUTS,
+    );
+    expect(r.passed).toBe(true);
+  });
+
+  it("falls back to threshold compare when passed is absent", () => {
+    expect(
+      adaptSkillgradeReport({ passRate: 0.9 }, DEFAULT_INPUTS).passed,
+    ).toBe(true);
+    expect(
+      adaptSkillgradeReport({ passRate: 0.4 }, DEFAULT_INPUTS).passed,
+    ).toBe(false);
+  });
+
+  it("is false when both passed and passRate are missing", () => {
+    expect(adaptSkillgradeReport({}, DEFAULT_INPUTS).passed).toBe(false);
+  });
+});
+
+describe("adaptSkillgradeReport — categories", () => {
+  it("produces one category per task, using passing/trials directly", () => {
+    const r = adaptSkillgradeReport(
+      {
+        passRate: 0.8,
+        tasks: [
+          { id: "first", passing: 4, trials: 5, passRate: 0.8 },
+          { id: "second", passing: 5, trials: 5, passRate: 1.0 },
+        ],
+      },
+      DEFAULT_INPUTS,
+    );
+    expect(r.categories).toHaveLength(2);
+    expect(r.categories[0]).toEqual({
+      id: "first",
+      name: "First",
+      score: 4,
+      max: 5,
+    });
+    expect(r.categories[1]).toEqual({
+      id: "second",
+      name: "Second",
+      score: 5,
+      max: 5,
+    });
+  });
+
+  it("falls back to passRate × 10 when trials are absent", () => {
+    const r = adaptSkillgradeReport(
+      {
+        tasks: [{ id: "only", passRate: 0.6 }],
+      },
+      DEFAULT_INPUTS,
+    );
+    expect(r.categories[0]).toEqual({
+      id: "only",
+      name: "Only",
+      score: 6,
+      max: 10,
+    });
+  });
+
+  it("synthesizes an id when task.id is missing", () => {
+    const r = adaptSkillgradeReport(
+      { tasks: [{ passing: 1, trials: 2 }] },
+      DEFAULT_INPUTS,
+    );
+    expect(r.categories[0]!.id).toBe("task-1");
+  });
+
+  it("humanizes hyphenated ids", () => {
+    const r = adaptSkillgradeReport(
+      { tasks: [{ id: "weather-known-city", passing: 2, trials: 5 }] },
+      DEFAULT_INPUTS,
+    );
+    expect(r.categories[0]!.name).toBe("Weather Known City");
+  });
+});
+
+describe("adaptSkillgradeReport — findings", () => {
+  it("emits one finding per grader with severity by pass", () => {
+    const r = adaptSkillgradeReport(
+      {
+        tasks: [
+          {
+            id: "t",
+            passing: 1,
+            trials: 2,
+            graders: [
+              { id: "g1", passed: true, message: "OK" },
+              { id: "g2", passed: false, message: "BAD" },
+            ],
+          },
+        ],
+      },
+      DEFAULT_INPUTS,
+    );
+    expect(r.findings).toHaveLength(2);
+    expect(r.findings[0]).toEqual({
+      severity: "info",
+      message: "OK",
+      categoryId: "t",
+      code: "grader:g1",
+    });
+    expect(r.findings[1]).toEqual({
+      severity: "warning",
+      message: "BAD",
+      categoryId: "t",
+      code: "grader:g2",
+    });
+  });
+
+  it("synthesizes a finding for tasks with no graders", () => {
+    const r = adaptSkillgradeReport(
+      {
+        tasks: [
+          { id: "quiet", passing: 2, trials: 5, passed: true },
+          { id: "loud", passing: 0, trials: 5, passed: false },
+        ],
+      },
+      DEFAULT_INPUTS,
+    );
+    expect(r.findings).toHaveLength(2);
+    expect(r.findings[0]!.severity).toBe("info");
+    expect(r.findings[1]!.severity).toBe("warning");
+  });
+});
+
+describe("adaptSkillgradeReport — raw passthrough", () => {
+  it("keeps the original report under raw", () => {
+    const report = { passRate: 0.5, custom: "data" };
+    const r = adaptSkillgradeReport(report, DEFAULT_INPUTS);
+    expect(r.raw).toEqual(report);
+  });
+
+  it("accepts non-object input without throwing", () => {
+    const r = adaptSkillgradeReport(null as any, DEFAULT_INPUTS);
+    expect(r.passed).toBe(false);
+    expect(r.score).toBe(0);
+    expect(r.categories).toEqual([]);
+  });
+});
+
+describe("adaptSkillgradeReport — snapshot of recorded fixtures", () => {
+  it("maps with-eval-yaml.skillgrade.json onto a passing EvalResult", () => {
+    const raw = JSON.parse(
+      readFileSync(
+        join(FIXTURES_DIR, "with-eval-yaml.skillgrade.json"),
+        "utf-8",
+      ),
+    );
+    const r = adaptSkillgradeReport(raw, DEFAULT_INPUTS);
+    expect(r.passed).toBe(true);
+    expect(r.score).toBe(92);
+    expect(r.categories.map((c) => c.id)).toEqual([
+      "summarize-empty-range",
+      "summarize-typical-range",
+    ]);
+    // Every finding should carry its task's categoryId.
+    for (const f of r.findings) {
+      expect(typeof f.categoryId).toBe("string");
+    }
+  });
+
+  it("maps runtime-broken.skillgrade.json onto a failing EvalResult", () => {
+    const raw = JSON.parse(
+      readFileSync(
+        join(FIXTURES_DIR, "runtime-broken.skillgrade.json"),
+        "utf-8",
+      ),
+    );
+    const r = adaptSkillgradeReport(raw, DEFAULT_INPUTS);
+    expect(r.passed).toBe(false);
+    expect(r.score).toBe(40);
+    // At least one grader-derived warning must surface.
+    expect(r.findings.some((f) => f.severity === "warning")).toBe(true);
+  });
+});

--- a/src/eval/providers/skillgrade/v1/adapter.ts
+++ b/src/eval/providers/skillgrade/v1/adapter.ts
@@ -1,0 +1,251 @@
+/**
+ * Adapter: skillgrade JSON → `EvalResult` (shape from `src/eval/types.ts`).
+ *
+ * The adapter is a pure function. It takes a single parsed skillgrade
+ * run-report (the `--json` output from `skillgrade run`) and returns a
+ * normalized `EvalResult`. Nothing else in the provider should ever
+ * manipulate skillgrade JSON directly — all shape knowledge lives here.
+ *
+ * Mapping rules (see `docs/SKILLGRADE_INTEGRATION_PLAN.md` §4 PR 4):
+ *
+ *   - `passRate`           → `score`       (scaled to 0..100 integer)
+ *   - `passed` / threshold → `passed`      (if `passed` is explicitly
+ *                                           present, it wins; otherwise we
+ *                                           compute `passRate >= threshold`)
+ *   - `tasks[]`            → `categories`  (one category per task — id,
+ *                                           name derived from id, score
+ *                                           from task.passRate × max,
+ *                                           max = task.trials)
+ *   - `tasks[].graders[]`  → `findings`    (per-grader; severity `warning`
+ *                                           when failing, `info` when passing)
+ *   - full input JSON      → `raw`
+ *
+ * The adapter never throws on shape drift — it degrades gracefully so a
+ * slightly newer skillgrade can still be introspected. Missing fields
+ * fall back to reasonable defaults (empty arrays, zero scores). Fixture
+ * snapshot tests catch any drift that matters.
+ */
+
+import type { CategoryResult, EvalResult, Finding } from "../../../types";
+
+// ─── Input shape (best-effort, permissive) ──────────────────────────────────
+
+/**
+ * A single grader output from skillgrade JSON.
+ *
+ * Skillgrade's grader shape varies by grader kind; we read a small
+ * stable subset and carry the rest through in `raw`.
+ */
+export interface SkillgradeGrader {
+  id?: string;
+  passed?: boolean;
+  message?: string;
+  score?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * A single task result from skillgrade JSON.
+ */
+export interface SkillgradeTask {
+  id?: string;
+  passed?: boolean;
+  trials?: number;
+  passing?: number;
+  passRate?: number;
+  graders?: SkillgradeGrader[];
+  [key: string]: unknown;
+}
+
+/**
+ * Top-level skillgrade run report. Fields not listed here are preserved
+ * verbatim in `EvalResult.raw`.
+ */
+export interface SkillgradeReport {
+  version?: string;
+  skill?: string;
+  preset?: string;
+  threshold?: number;
+  passRate?: number;
+  passed?: boolean;
+  tasks?: SkillgradeTask[];
+  summary?: {
+    totalTrials?: number;
+    passingTrials?: number;
+    durationMs?: number;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Inputs the adapter needs beyond the raw JSON: the provider identity
+ * (so the caller controls id/version/schemaVersion) and the threshold
+ * used for pass/fail resolution when the JSON omits `passed`.
+ */
+export interface AdaptInputs {
+  providerId: string;
+  providerVersion: string;
+  schemaVersion: number;
+  /** Threshold in 0..1 used for `passed` fallback computation. */
+  thresholdFraction: number;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Clamp an arbitrary number to `[0..100]` and round to a stable integer.
+ * Used for both overall `score` and per-category `score`. Non-numeric
+ * inputs degrade to 0 so shape drift can't break score arithmetic.
+ */
+function toPercentage(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  const pct = Math.round(value * 100);
+  if (pct < 0) return 0;
+  if (pct > 100) return 100;
+  return pct;
+}
+
+/**
+ * Humanize an id like `"weather-known-city"` into `"Weather Known City"`
+ * for `CategoryResult.name`. Kept local so snapshots stay stable without
+ * depending on an external casing library.
+ */
+function humanize(id: string): string {
+  return id
+    .split(/[-_]+/)
+    .map((part) =>
+      part.length > 0 ? part[0]!.toUpperCase() + part.slice(1) : "",
+    )
+    .join(" ");
+}
+
+/**
+ * Map one skillgrade task to a `CategoryResult`.
+ *
+ * `score` / `max` are integers: when skillgrade reports both `passing`
+ * and `trials`, we use them directly. Otherwise `passRate × 10` with
+ * max 10 gives a usable category breakdown for UIs.
+ */
+function taskToCategory(task: SkillgradeTask, index: number): CategoryResult {
+  const id =
+    typeof task.id === "string" && task.id.length > 0
+      ? task.id
+      : `task-${index + 1}`;
+  const name = humanize(id);
+  if (
+    typeof task.passing === "number" &&
+    typeof task.trials === "number" &&
+    task.trials > 0
+  ) {
+    return {
+      id,
+      name,
+      score: Math.max(0, Math.min(task.passing, task.trials)),
+      max: task.trials,
+    };
+  }
+  const passRate = typeof task.passRate === "number" ? task.passRate : 0;
+  return {
+    id,
+    name,
+    score: Math.max(0, Math.min(10, Math.round(passRate * 10))),
+    max: 10,
+  };
+}
+
+/**
+ * Map graders across all tasks to `Finding[]`.
+ *
+ * Severity rules:
+ *   - Passing grader  → severity `info` (still surfaced so users see
+ *                       what skillgrade checked successfully).
+ *   - Failing grader  → severity `warning` (the overall `passed` flag
+ *                       already captures whether the run was a fail).
+ *
+ * Tasks with no graders contribute one synthetic finding summarizing
+ * the task's own pass/fail so UIs always have something to show.
+ */
+function graderFindings(tasks: SkillgradeTask[]): Finding[] {
+  const out: Finding[] = [];
+  for (const task of tasks) {
+    const categoryId = typeof task.id === "string" ? task.id : undefined;
+    const graders = Array.isArray(task.graders) ? task.graders : [];
+    if (graders.length === 0) {
+      out.push({
+        severity: task.passed === false ? "warning" : "info",
+        message: `task ${categoryId ?? "(unnamed)"} ${
+          task.passed === false ? "failed" : "passed"
+        }`,
+        categoryId,
+      });
+      continue;
+    }
+    for (const g of graders) {
+      const message =
+        typeof g.message === "string" && g.message.length > 0
+          ? g.message
+          : `grader ${g.id ?? "(unnamed)"} ${g.passed ? "passed" : "failed"}`;
+      out.push({
+        severity: g.passed === false ? "warning" : "info",
+        message,
+        categoryId,
+        code: typeof g.id === "string" ? `grader:${g.id}` : undefined,
+      });
+    }
+  }
+  return out;
+}
+
+// ─── Public entry point ─────────────────────────────────────────────────────
+
+/**
+ * Convert a parsed skillgrade run-report into an `EvalResult`.
+ *
+ * Contract:
+ *   - Never throws on malformed shape — missing fields fall back to
+ *     safe defaults so fixture drift doesn't crash the CLI.
+ *   - `raw` is the input report by reference; callers pass already-parsed
+ *     JSON so the adapter does not own string handling.
+ *   - Timing fields (`startedAt`, `durationMs`) are placeholders; the
+ *     runner stamps them. Keeping this file unaware of wall clock makes
+ *     snapshot testing trivial.
+ */
+export function adaptSkillgradeReport(
+  report: SkillgradeReport | unknown,
+  inputs: AdaptInputs,
+): EvalResult {
+  // Defensive unwrap: accept any parsed JSON, coerce to report-shape.
+  const safe: SkillgradeReport =
+    report && typeof report === "object" ? (report as SkillgradeReport) : {};
+
+  const tasks = Array.isArray(safe.tasks) ? safe.tasks : [];
+  const categories = tasks.map(taskToCategory);
+  const findings = graderFindings(tasks);
+
+  const score = toPercentage(safe.passRate);
+
+  // `passed` resolution: explicit flag wins; otherwise threshold compare.
+  // skillgrade historically emits `passed` but we belt-and-brace so a
+  // newer build that drops it still yields a deterministic result.
+  let passed: boolean;
+  if (typeof safe.passed === "boolean") {
+    passed = safe.passed;
+  } else if (typeof safe.passRate === "number") {
+    passed = safe.passRate >= inputs.thresholdFraction;
+  } else {
+    passed = false;
+  }
+
+  return {
+    providerId: inputs.providerId,
+    providerVersion: inputs.providerVersion,
+    schemaVersion: inputs.schemaVersion,
+    score,
+    passed,
+    categories,
+    findings,
+    raw: safe,
+    startedAt: "",
+    durationMs: 0,
+  };
+}

--- a/src/eval/providers/skillgrade/v1/fixtures/runtime-broken.skillgrade.json
+++ b/src/eval/providers/skillgrade/v1/fixtures/runtime-broken.skillgrade.json
@@ -1,0 +1,53 @@
+{
+  "version": "0.1.4",
+  "skill": "runtime-broken",
+  "preset": "smoke",
+  "threshold": 0.8,
+  "passRate": 0.4,
+  "passed": false,
+  "tasks": [
+    {
+      "id": "weather-known-city",
+      "passed": false,
+      "trials": 5,
+      "passing": 2,
+      "passRate": 0.4,
+      "graders": [
+        {
+          "id": "exactly-two-lines",
+          "passed": false,
+          "message": "output had 3 lines, expected exactly 2"
+        },
+        {
+          "id": "contains",
+          "passed": true,
+          "message": "output contained \"°\""
+        }
+      ]
+    },
+    {
+      "id": "weather-unknown-city",
+      "passed": false,
+      "trials": 5,
+      "passing": 2,
+      "passRate": 0.4,
+      "graders": [
+        {
+          "id": "contains",
+          "passed": true,
+          "message": "output contained \"unknown\""
+        },
+        {
+          "id": "exactly-two-lines",
+          "passed": false,
+          "message": "output had 3 lines, expected exactly 2"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "totalTrials": 10,
+    "passingTrials": 4,
+    "durationMs": 6014
+  }
+}

--- a/src/eval/providers/skillgrade/v1/fixtures/with-eval-yaml.skillgrade.json
+++ b/src/eval/providers/skillgrade/v1/fixtures/with-eval-yaml.skillgrade.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.1.4",
+  "skill": "with-eval-yaml",
+  "preset": "smoke",
+  "threshold": 0.8,
+  "passRate": 0.92,
+  "passed": true,
+  "tasks": [
+    {
+      "id": "summarize-empty-range",
+      "passed": true,
+      "trials": 5,
+      "passing": 5,
+      "passRate": 1.0,
+      "graders": [
+        {
+          "id": "contains",
+          "passed": true,
+          "message": "output contained \"no changes\""
+        }
+      ]
+    },
+    {
+      "id": "summarize-typical-range",
+      "passed": true,
+      "trials": 5,
+      "passing": 4,
+      "passRate": 0.8,
+      "graders": [
+        {
+          "id": "contains",
+          "passed": true,
+          "message": "output contained \"feat\""
+        },
+        {
+          "id": "markdown-shape",
+          "passed": true,
+          "message": "output contained a \"## \" heading"
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "totalTrials": 10,
+    "passingTrials": 9,
+    "durationMs": 7421
+  }
+}

--- a/src/eval/providers/skillgrade/v1/index.test.ts
+++ b/src/eval/providers/skillgrade/v1/index.test.ts
@@ -1,0 +1,551 @@
+/**
+ * Provider tests for skillgrade v1.
+ *
+ * All tests build a provider instance with a fake `Spawner` + fake
+ * `fileExists` so no real binary, filesystem, or network is touched.
+ * This is the single biggest property of the skillgrade integration:
+ * CI must stay offline.
+ *
+ * Two axes covered:
+ *   1. `applicable()` — every failure reason (binary missing, version
+ *      out of range, eval.yaml missing, invalid range config).
+ *   2. `run()` — success path against recorded fixtures, plus every
+ *      failure mode (missing API key, Docker unavailable, timeout,
+ *      abort, non-zero exit, bad JSON).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFile } from "fs/promises";
+import { join } from "path";
+import {
+  buildRunArgv,
+  classifyStderr,
+  createSkillgradeProvider,
+  DEFAULT_THRESHOLD_FRACTION,
+  detectVersion,
+  resolveRunOpts,
+} from "./index";
+import type { Spawner, SpawnResult } from "./spawn";
+import type { SkillContext } from "../../../types";
+
+const FIXTURES_DIR = join(__dirname, "fixtures");
+const CORPUS_DIR = join(__dirname, "../../../../..", "tests/fixtures/skills");
+
+const CTX_WITH: SkillContext = {
+  skillPath: join(CORPUS_DIR, "with-eval-yaml"),
+  skillMdPath: join(CORPUS_DIR, "with-eval-yaml", "SKILL.md"),
+  skillName: "with-eval-yaml",
+};
+
+const CTX_BROKEN: SkillContext = {
+  skillPath: join(CORPUS_DIR, "runtime-broken"),
+  skillMdPath: join(CORPUS_DIR, "runtime-broken", "SKILL.md"),
+  skillName: "runtime-broken",
+};
+
+// ─── Spawner builders ───────────────────────────────────────────────────────
+
+/** Reusable spawner that dispatches on the first argv token after the binary. */
+function makeSpawner(handlers: {
+  version?: () => SpawnResult | Promise<SpawnResult>;
+  run?: (argv: string[]) => SpawnResult | Promise<SpawnResult>;
+  init?: () => SpawnResult | Promise<SpawnResult>;
+}): Spawner {
+  return async (argv) => {
+    const sub = argv[1];
+    if (sub === "--version" && handlers.version) return handlers.version();
+    if (sub === "run" && handlers.run) return handlers.run(argv);
+    if (sub === "init" && handlers.init) return handlers.init();
+    return {
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+      aborted: false,
+    };
+  };
+}
+
+function okVersion(version = "0.1.4"): SpawnResult {
+  return {
+    exitCode: 0,
+    stdout: `skillgrade ${version}\n`,
+    stderr: "",
+    timedOut: false,
+    aborted: false,
+  };
+}
+
+// ─── Provider shape ─────────────────────────────────────────────────────────
+
+describe("skillgrade provider — identity", () => {
+  it("has id=skillgrade, version=1.0.0, schemaVersion=1", () => {
+    const p = createSkillgradeProvider();
+    expect(p.id).toBe("skillgrade");
+    expect(p.version).toBe("1.0.0");
+    expect(p.schemaVersion).toBe(1);
+    expect(p.externalRequires?.binary).toBe("skillgrade");
+    expect(p.externalRequires?.installHint).toContain("npm i -g skillgrade");
+  });
+});
+
+// ─── detectVersion + helpers ────────────────────────────────────────────────
+
+describe("detectVersion", () => {
+  it("parses `skillgrade 0.1.4` from stdout", async () => {
+    const v = await detectVersion(
+      makeSpawner({ version: () => okVersion("0.1.4") }),
+      "skillgrade",
+    );
+    expect(v).toBe("0.1.4");
+  });
+
+  it("falls back to stderr when stdout is empty", async () => {
+    const v = await detectVersion(
+      makeSpawner({
+        version: () => ({
+          exitCode: 0,
+          stdout: "",
+          stderr: "v0.2.0\n",
+          timedOut: false,
+          aborted: false,
+        }),
+      }),
+      "skillgrade",
+    );
+    expect(v).toBe("0.2.0");
+  });
+
+  it("returns null on non-zero exit", async () => {
+    const v = await detectVersion(
+      makeSpawner({
+        version: () => ({
+          exitCode: 1,
+          stdout: "",
+          stderr: "bad",
+          timedOut: false,
+          aborted: false,
+        }),
+      }),
+      "skillgrade",
+    );
+    expect(v).toBeNull();
+  });
+
+  it("returns null when the spawner throws", async () => {
+    const v = await detectVersion(async () => {
+      const e: any = new Error("ENOENT");
+      e.code = "ENOENT";
+      throw e;
+    }, "skillgrade");
+    expect(v).toBeNull();
+  });
+});
+
+describe("resolveRunOpts", () => {
+  it("applies defaults when nothing is set", () => {
+    expect(resolveRunOpts({})).toEqual({
+      thresholdFraction: DEFAULT_THRESHOLD_FRACTION,
+      preset: "smoke",
+      provider: "docker",
+    });
+  });
+
+  it("accepts fraction threshold verbatim", () => {
+    expect(resolveRunOpts({ threshold: 0.5 }).thresholdFraction).toBe(0.5);
+  });
+
+  it("converts >1 threshold as 0..100 integer to fraction", () => {
+    expect(resolveRunOpts({ threshold: 80 }).thresholdFraction).toBe(0.8);
+  });
+
+  it("rejects unknown presets & providers (fallback to default)", () => {
+    const r = resolveRunOpts({
+      preset: "bogus" as any,
+      provider: "alien" as any,
+    });
+    expect(r.preset).toBe("smoke");
+    expect(r.provider).toBe("docker");
+  });
+});
+
+describe("buildRunArgv", () => {
+  it("produces the canonical --ci --json argv", () => {
+    const argv = buildRunArgv("skillgrade", {
+      thresholdFraction: 0.9,
+      preset: "reliable",
+      provider: "local",
+    });
+    expect(argv).toEqual([
+      "skillgrade",
+      "run",
+      "--ci",
+      "--threshold",
+      "0.9",
+      "--preset",
+      "reliable",
+      "--provider",
+      "local",
+      "--json",
+    ]);
+  });
+});
+
+describe("classifyStderr", () => {
+  it("detects missing API key", () => {
+    expect(classifyStderr("ANTHROPIC_API_KEY is not set").code).toBe(
+      "missing-api-key",
+    );
+    expect(classifyStderr("401 Unauthorized").code).toBe("missing-api-key");
+  });
+
+  it("detects docker unavailable", () => {
+    expect(classifyStderr("cannot connect to the docker daemon").code).toBe(
+      "docker-unavailable",
+    );
+    expect(classifyStderr("docker is not running").code).toBe(
+      "docker-unavailable",
+    );
+  });
+
+  it("defaults to skillgrade-nonzero-exit for unknown stderr", () => {
+    expect(classifyStderr("something else went wrong").code).toBe(
+      "skillgrade-nonzero-exit",
+    );
+  });
+});
+
+// ─── applicable() ───────────────────────────────────────────────────────────
+
+describe("applicable() — binary", () => {
+  it("returns ok:false when skillgrade is not on PATH", async () => {
+    const p = createSkillgradeProvider({
+      spawn: async () => {
+        const e: any = new Error("ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      },
+      fileExists: async () => true,
+    });
+    const r = await p.applicable(CTX_WITH, {});
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("npm i -g skillgrade");
+  });
+
+  it("returns ok:false when `skillgrade --version` exits non-zero", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({
+        version: () => ({
+          exitCode: 127,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          aborted: false,
+        }),
+      }),
+      fileExists: async () => true,
+    });
+    const r = await p.applicable(CTX_WITH, {});
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/not installed or unreachable/i);
+  });
+});
+
+describe("applicable() — version range", () => {
+  it("returns ok:false when version is below range", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({ version: () => okVersion("0.1.2") }),
+      fileExists: async () => true,
+    });
+    const r = await p.applicable(CTX_WITH, {});
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("0.1.2");
+    expect(r.reason).toContain("0.1.3");
+  });
+
+  it("returns ok:false when version is above range", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({ version: () => okVersion("0.3.0") }),
+      fileExists: async () => true,
+    });
+    const r = await p.applicable(CTX_WITH, {});
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/outside required range/i);
+  });
+
+  it("returns ok:true for versions inside the declared range", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({ version: () => okVersion("0.2.1") }),
+      fileExists: async () => true,
+    });
+    const r = await p.applicable(CTX_WITH, {});
+    expect(r.ok).toBe(true);
+  });
+
+  it("returns ok:false with a clear error when externalRequires is invalid", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({ version: () => okVersion("0.1.4") }),
+      fileExists: async () => true,
+      externalRequires: "totally-bogus-range",
+    });
+    const r = await p.applicable(CTX_WITH, {});
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("invalid externalRequires");
+  });
+});
+
+describe("applicable() — eval.yaml", () => {
+  it("returns ok:false when eval.yaml is missing in the skill dir", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({ version: () => okVersion() }),
+      fileExists: async () => false,
+    });
+    const r = await p.applicable(CTX_WITH, {});
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("no eval.yaml");
+    expect(r.reason).toContain("asm eval --runtime init");
+  });
+
+  it("returns ok:true when all three stages pass", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({ version: () => okVersion() }),
+      fileExists: async () => true,
+    });
+    const r = await p.applicable(CTX_WITH, {});
+    expect(r.ok).toBe(true);
+  });
+});
+
+// ─── run() ──────────────────────────────────────────────────────────────────
+
+async function loadFixture(name: string): Promise<string> {
+  return readFile(join(FIXTURES_DIR, `${name}.skillgrade.json`), "utf-8");
+}
+
+describe("run() — happy path", () => {
+  it("maps with-eval-yaml recorded JSON to a passing EvalResult", async () => {
+    const stdout = await loadFixture("with-eval-yaml");
+    let argvSeen: string[] = [];
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({
+        run: (argv) => {
+          argvSeen = argv;
+          return {
+            exitCode: 0,
+            stdout,
+            stderr: "",
+            timedOut: false,
+            aborted: false,
+          };
+        },
+      }),
+      fileExists: async () => true,
+    });
+    const r = await p.run(CTX_WITH, {});
+    expect(r.passed).toBe(true);
+    expect(r.score).toBe(92);
+    expect(r.providerId).toBe("skillgrade");
+    expect(r.providerVersion).toBe("1.0.0");
+    expect(r.categories.map((c) => c.id)).toEqual([
+      "summarize-empty-range",
+      "summarize-typical-range",
+    ]);
+    // Verify argv carried defaults through.
+    expect(argvSeen).toContain("--ci");
+    expect(argvSeen).toContain("--json");
+    expect(argvSeen).toContain("--preset");
+    expect(argvSeen).toContain("smoke");
+  });
+
+  it("maps runtime-broken recorded JSON to a failing EvalResult", async () => {
+    const stdout = await loadFixture("runtime-broken");
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({
+        run: () => ({
+          exitCode: 0,
+          stdout,
+          stderr: "",
+          timedOut: false,
+          aborted: false,
+        }),
+      }),
+      fileExists: async () => true,
+    });
+    const r = await p.run(CTX_BROKEN, {});
+    expect(r.passed).toBe(false);
+    expect(r.score).toBe(40);
+    expect(r.findings.some((f) => f.severity === "warning")).toBe(true);
+  });
+
+  it("threads --threshold / --preset / --provider from EvalOpts", async () => {
+    const stdout = await loadFixture("with-eval-yaml");
+    let argvSeen: string[] = [];
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({
+        run: (argv) => {
+          argvSeen = argv;
+          return {
+            exitCode: 0,
+            stdout,
+            stderr: "",
+            timedOut: false,
+            aborted: false,
+          };
+        },
+      }),
+      fileExists: async () => true,
+    });
+    await p.run(CTX_WITH, {
+      threshold: 0.95,
+      preset: "reliable",
+      provider: "local",
+    });
+    expect(argvSeen).toEqual([
+      "skillgrade",
+      "run",
+      "--ci",
+      "--threshold",
+      "0.95",
+      "--preset",
+      "reliable",
+      "--provider",
+      "local",
+      "--json",
+    ]);
+  });
+});
+
+describe("run() — failure modes", () => {
+  it("returns a missing-api-key finding when skillgrade complains about keys", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({
+        run: () => ({
+          exitCode: 2,
+          stdout: "",
+          stderr: "ANTHROPIC_API_KEY is not set",
+          timedOut: false,
+          aborted: false,
+        }),
+      }),
+      fileExists: async () => true,
+    });
+    const r = await p.run(CTX_WITH, {});
+    expect(r.passed).toBe(false);
+    expect(r.findings[0]!.code).toBe("missing-api-key");
+    expect(r.findings[0]!.severity).toBe("error");
+  });
+
+  it("returns a docker-unavailable finding when Docker isn't running", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({
+        run: () => ({
+          exitCode: 1,
+          stdout: "",
+          stderr: "docker: cannot connect to the docker daemon",
+          timedOut: false,
+          aborted: false,
+        }),
+      }),
+      fileExists: async () => true,
+    });
+    const r = await p.run(CTX_WITH, {});
+    expect(r.findings[0]!.code).toBe("docker-unavailable");
+  });
+
+  it("returns a timeout finding when the spawner reports timedOut", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({
+        run: () => ({
+          exitCode: null,
+          stdout: "",
+          stderr: "",
+          timedOut: true,
+          aborted: false,
+        }),
+      }),
+      fileExists: async () => true,
+    });
+    const r = await p.run(CTX_WITH, { timeoutMs: 5 });
+    expect(r.findings[0]!.code).toBe("timeout");
+  });
+
+  it("returns an aborted finding when the spawner reports aborted", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({
+        run: () => ({
+          exitCode: null,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          aborted: true,
+        }),
+      }),
+      fileExists: async () => true,
+    });
+    const r = await p.run(CTX_WITH, {});
+    expect(r.findings[0]!.code).toBe("aborted");
+  });
+
+  it("returns a bad-JSON finding when stdout is not JSON", async () => {
+    const p = createSkillgradeProvider({
+      spawn: makeSpawner({
+        run: () => ({
+          exitCode: 0,
+          stdout: "not-json-at-all",
+          stderr: "",
+          timedOut: false,
+          aborted: false,
+        }),
+      }),
+      fileExists: async () => true,
+    });
+    const r = await p.run(CTX_WITH, {});
+    expect(r.findings[0]!.code).toBe("skillgrade-bad-json");
+  });
+
+  it("returns a binary-missing finding when the spawner throws ENOENT at run time", async () => {
+    const p = createSkillgradeProvider({
+      spawn: async () => {
+        const e: any = new Error("spawn skillgrade ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      },
+      fileExists: async () => true,
+    });
+    const r = await p.run(CTX_WITH, {});
+    expect(r.findings[0]!.code).toBe("binary-missing");
+  });
+
+  it("returns a spawn-failed finding for generic spawn errors", async () => {
+    const p = createSkillgradeProvider({
+      spawn: async () => {
+        throw new Error("EACCES");
+      },
+      fileExists: async () => true,
+    });
+    const r = await p.run(CTX_WITH, {});
+    expect(r.findings[0]!.code).toBe("spawn-failed");
+  });
+});
+
+describe("run() — cwd is the skill directory", () => {
+  it("invokes the spawner with cwd = ctx.skillPath", async () => {
+    const stdout = await loadFixture("with-eval-yaml");
+    let cwdSeen: string | undefined;
+    const p = createSkillgradeProvider({
+      spawn: async (_argv, opts) => {
+        cwdSeen = opts?.cwd;
+        return {
+          exitCode: 0,
+          stdout,
+          stderr: "",
+          timedOut: false,
+          aborted: false,
+        };
+      },
+      fileExists: async () => true,
+    });
+    await p.run(CTX_WITH, {});
+    expect(cwdSeen).toBe(CTX_WITH.skillPath);
+  });
+});

--- a/src/eval/providers/skillgrade/v1/index.ts
+++ b/src/eval/providers/skillgrade/v1/index.ts
@@ -1,0 +1,445 @@
+/**
+ * Skillgrade provider — v1.
+ *
+ * Shells out to the `skillgrade` CLI (https://github.com/mgechev/skillgrade)
+ * to answer the orthogonal question *"does this skill actually work?"*.
+ * The quality provider (PR 2, #156) already answers *"is it well-written?"*.
+ *
+ * Architecture (see `docs/SKILLGRADE_INTEGRATION_PLAN.md` §4 PR 4):
+ *
+ *   - `applicable()` performs three cheap checks:
+ *       1. `skillgrade` binary on PATH
+ *       2. binary version inside `externalRequires` range
+ *       3. `eval.yaml` present in the skill directory
+ *     Each failure returns an actionable `reason` the CLI renders.
+ *
+ *   - `run()` invokes `skillgrade run --ci --threshold <n> --preset <p>
+ *     --json` via a `Spawner` (injectable seam for tests). The JSON
+ *     stdout is parsed and handed to `adaptSkillgradeReport` which is
+ *     the single source of shape knowledge.
+ *
+ *   - Every external dependency (spawn, filesystem stat) goes through
+ *     a passed-in function so `index.test.ts` never touches the real
+ *     binary or network.
+ *
+ * Error surface (aligned with the runner's error-wrap contract):
+ *   - Missing API key        → severity `error`, code `missing-api-key`
+ *   - Docker unavailable     → severity `error`, code `docker-unavailable`
+ *   - Timeout                → runner's `code: "timeout"` (we signal abort)
+ *   - Non-zero exit          → severity `error`, code `skillgrade-nonzero-exit`
+ *   - Unparseable stdout     → severity `error`, code `skillgrade-bad-json`
+ *
+ * The runner stamps `startedAt` / `durationMs` — we leave them blank.
+ */
+
+import { stat } from "fs/promises";
+import { join } from "path";
+import type {
+  ApplicableResult,
+  EvalOpts,
+  EvalProvider,
+  EvalResult,
+  Finding,
+  SkillContext,
+} from "../../../types";
+import type { Spawner, SpawnOptions, SpawnResult } from "./spawn";
+import { bunSpawn } from "./spawn";
+import { adaptSkillgradeReport, type SkillgradeReport } from "./adapter";
+import { satisfiesExternalRange } from "./semver-range";
+
+// ─── Identity constants ─────────────────────────────────────────────────────
+
+/** Stable provider id used by `registry.resolve("skillgrade", "^1.0.0")`. */
+export const PROVIDER_ID = "skillgrade";
+
+/** Provider semver. Bump on adapter feature/fix releases. */
+export const PROVIDER_VERSION = "1.0.0";
+
+/** Result-shape version. Bump only on structural breaks to EvalResult. */
+export const SCHEMA_VERSION = 1;
+
+/** Default external binary range. Overridable via config. */
+export const DEFAULT_EXTERNAL_REQUIRES = ">=0.1.3 <0.3.0";
+
+/** Default threshold (fraction, skillgrade convention). */
+export const DEFAULT_THRESHOLD_FRACTION = 0.8;
+
+/** Default preset. */
+export const DEFAULT_PRESET: "smoke" | "reliable" | "regression" = "smoke";
+
+/** Default execution provider (skillgrade CLI flag). */
+export const DEFAULT_SKILLGRADE_PROVIDER: "docker" | "local" = "docker";
+
+// ─── Injection seams ────────────────────────────────────────────────────────
+
+/**
+ * Optional filesystem `exists` seam. Defaults to `fs/promises.stat`.
+ * Overridden in tests so `applicable()` can fake "eval.yaml is missing"
+ * without touching disk.
+ */
+export type FileExists = (path: string) => Promise<boolean>;
+
+/**
+ * Full configuration for constructing a skillgrade provider instance.
+ *
+ * Production code calls `createSkillgradeProvider()` with no args and
+ * gets the singleton wired to `bunSpawn` + real filesystem. Tests build
+ * their own instance per test with hand-rolled fakes.
+ */
+export interface SkillgradeProviderOptions {
+  /** Spawner seam (default: `bunSpawn`). */
+  spawn?: Spawner;
+  /** File-exists seam (default: `fs/promises.stat`). */
+  fileExists?: FileExists;
+  /** Binary name (default: `"skillgrade"`). */
+  binary?: string;
+  /** Override the declared `externalRequires` range. */
+  externalRequires?: string;
+}
+
+// ─── Internal helpers ───────────────────────────────────────────────────────
+
+/** Default `FileExists` backed by `fs/promises.stat`. */
+const defaultFileExists: FileExists = async (p: string) => {
+  try {
+    const s = await stat(p);
+    return s.isFile();
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Build an error-shaped `EvalResult` the runner would otherwise wrap.
+ * Used for skillgrade-specific failure modes (missing API key, docker
+ * unavailable, non-zero exit) where we want a semantic `code` — the
+ * runner's generic `"provider-threw"` wouldn't tell the CLI *why*.
+ */
+function errorResult(finding: Finding, raw?: unknown): EvalResult {
+  return {
+    providerId: PROVIDER_ID,
+    providerVersion: PROVIDER_VERSION,
+    schemaVersion: SCHEMA_VERSION,
+    score: 0,
+    passed: false,
+    categories: [],
+    findings: [finding],
+    raw,
+    startedAt: "",
+    durationMs: 0,
+  };
+}
+
+/**
+ * Classify skillgrade stderr output. `skillgrade` itself does not expose a
+ * stable exit-code taxonomy yet, so we use keyword matching on stderr.
+ * Each category maps to a distinct `Finding.code` so the CLI can render
+ * a targeted hint (e.g. "export ANTHROPIC_API_KEY=…").
+ *
+ * Keywords are intentionally broad — false positives degrade to a
+ * generic `skillgrade-nonzero-exit` finding with stderr embedded in
+ * `message` so users still see the full context.
+ */
+export function classifyStderr(stderr: string): {
+  code: string;
+  hint: string;
+} {
+  const lower = stderr.toLowerCase();
+  if (
+    lower.includes("api key") ||
+    lower.includes("anthropic_api_key") ||
+    lower.includes("openai_api_key") ||
+    lower.includes("unauthorized") ||
+    lower.includes("401")
+  ) {
+    return {
+      code: "missing-api-key",
+      hint: "set ANTHROPIC_API_KEY or OPENAI_API_KEY in your environment",
+    };
+  }
+  if (
+    lower.includes("docker") &&
+    (lower.includes("not found") ||
+      lower.includes("cannot connect") ||
+      lower.includes("unavailable") ||
+      lower.includes("is not running"))
+  ) {
+    return {
+      code: "docker-unavailable",
+      hint: "start Docker or pass --provider local",
+    };
+  }
+  return {
+    code: "skillgrade-nonzero-exit",
+    hint: "check skillgrade logs above for details",
+  };
+}
+
+/**
+ * Detect the version of the installed `skillgrade` binary.
+ *
+ * Returns `null` when the binary isn't on PATH (spawn threw ENOENT) or
+ * the `--version` output can't be parsed. Callers use `null` to mean
+ * "skip the version gate" — `applicable()` still separately verifies
+ * the binary is present before reaching the version check.
+ */
+export async function detectVersion(
+  spawn: Spawner,
+  binary: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  let res: SpawnResult;
+  try {
+    res = await spawn([binary, "--version"], { timeoutMs: 5_000, signal });
+  } catch {
+    return null;
+  }
+  if (res.exitCode !== 0) return null;
+  const combined = `${res.stdout}\n${res.stderr}`;
+  // Match the first `X.Y.Z` (optionally prefixed by `v`) — skillgrade
+  // and most CLIs print `skillgrade 0.1.4\n` or `v0.1.4\n`. We don't
+  // use `\b` around the leading digit because letters like `v` are word
+  // characters too, so there's no boundary between `v` and `0`.
+  const match =
+    /(?:^|[^\w.-])v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?=$|[^\w.-])/m.exec(
+      combined,
+    );
+  return match ? match[1]! : null;
+}
+
+/**
+ * Compute the absolute path to the skill's `eval.yaml`.
+ * Skillgrade looks for this file at the skill root.
+ */
+export function evalYamlPath(ctx: SkillContext): string {
+  return join(ctx.skillPath, "eval.yaml");
+}
+
+/**
+ * Build the argv for `skillgrade run`, respecting runtime options.
+ *
+ * `--threshold` accepts a 0..1 fraction; ASM stores thresholds as
+ * 0..100 integers in `EvalOpts` but skillgrade wants the fraction,
+ * so we scale on the way out.
+ */
+export function buildRunArgv(
+  binary: string,
+  resolvedOpts: {
+    thresholdFraction: number;
+    preset: "smoke" | "reliable" | "regression";
+    provider: "docker" | "local";
+  },
+): string[] {
+  return [
+    binary,
+    "run",
+    "--ci",
+    "--threshold",
+    String(resolvedOpts.thresholdFraction),
+    "--preset",
+    resolvedOpts.preset,
+    "--provider",
+    resolvedOpts.provider,
+    "--json",
+  ];
+}
+
+/**
+ * Resolve the threshold/preset/provider knobs from raw `EvalOpts`,
+ * applying skillgrade defaults so the provider always has a complete
+ * set. Exported for tests and for the CLI, which reuses this when
+ * printing what it's about to do.
+ */
+export function resolveRunOpts(opts: EvalOpts): {
+  thresholdFraction: number;
+  preset: "smoke" | "reliable" | "regression";
+  provider: "docker" | "local";
+} {
+  const thresholdFraction =
+    typeof opts.threshold === "number" && Number.isFinite(opts.threshold)
+      ? opts.threshold > 1
+        ? opts.threshold / 100
+        : opts.threshold
+      : DEFAULT_THRESHOLD_FRACTION;
+  const preset =
+    opts.preset === "smoke" ||
+    opts.preset === "reliable" ||
+    opts.preset === "regression"
+      ? opts.preset
+      : DEFAULT_PRESET;
+  const provider =
+    opts.provider === "docker" || opts.provider === "local"
+      ? opts.provider
+      : DEFAULT_SKILLGRADE_PROVIDER;
+  return { thresholdFraction, preset, provider };
+}
+
+// ─── Provider factory ───────────────────────────────────────────────────────
+
+/**
+ * Construct a skillgrade provider instance with the given injection
+ * points. Production imports the prebuilt `skillgradeProviderV1` below;
+ * tests build their own instances with fake spawners and filesystem
+ * stubs so every code path is deterministic.
+ */
+export function createSkillgradeProvider(
+  options: SkillgradeProviderOptions = {},
+): EvalProvider {
+  const spawn = options.spawn ?? bunSpawn;
+  const fileExists = options.fileExists ?? defaultFileExists;
+  const binary = options.binary ?? "skillgrade";
+  const externalRequires =
+    options.externalRequires ?? DEFAULT_EXTERNAL_REQUIRES;
+
+  return {
+    id: PROVIDER_ID,
+    version: PROVIDER_VERSION,
+    schemaVersion: SCHEMA_VERSION,
+    description:
+      "Runtime eval via skillgrade: runs task prompts through LLM judges and computes a pass rate.",
+    externalRequires: {
+      binary,
+      semverRange: externalRequires,
+      installHint: "npm i -g skillgrade",
+    },
+
+    /**
+     * Three-stage feasibility check. Each failure returns the first
+     * blocking reason — no point telling the user about the missing
+     * eval.yaml when the binary isn't even installed.
+     */
+    async applicable(
+      ctx: SkillContext,
+      opts: EvalOpts,
+    ): Promise<ApplicableResult> {
+      // Stage 1: binary on PATH (and responsive to --version).
+      const detected = await detectVersion(spawn, binary, opts.signal);
+      if (detected === null) {
+        return {
+          ok: false,
+          reason: `${binary} not installed or unreachable — run: npm i -g skillgrade`,
+        };
+      }
+
+      // Stage 2: version inside externalRequires range.
+      try {
+        if (!satisfiesExternalRange(detected, externalRequires)) {
+          return {
+            ok: false,
+            reason: `${binary} ${detected} is outside required range "${externalRequires}" — upgrade or downgrade the binary`,
+          };
+        }
+      } catch (err: any) {
+        return {
+          ok: false,
+          reason: `invalid externalRequires "${externalRequires}": ${err?.message ?? String(err)}`,
+        };
+      }
+
+      // Stage 3: eval.yaml present at skill root.
+      const yamlPath = evalYamlPath(ctx);
+      if (!(await fileExists(yamlPath))) {
+        return {
+          ok: false,
+          reason: `no eval.yaml at ${yamlPath} — run: asm eval --runtime init`,
+        };
+      }
+
+      return { ok: true };
+    },
+
+    /**
+     * Execute `skillgrade run ... --json`, parse stdout, adapt to
+     * `EvalResult`. The runner handles timeout and wall-clock stamping;
+     * we just pipe the timeout through as a cooperative hint.
+     */
+    async run(ctx: SkillContext, opts: EvalOpts): Promise<EvalResult> {
+      const resolved = resolveRunOpts(opts);
+      const argv = buildRunArgv(binary, resolved);
+
+      const spawnOpts: SpawnOptions = {
+        cwd: ctx.skillPath,
+        signal: opts.signal,
+      };
+      if (typeof opts.timeoutMs === "number" && opts.timeoutMs > 0) {
+        spawnOpts.timeoutMs = opts.timeoutMs;
+      }
+
+      let res: SpawnResult;
+      try {
+        res = await spawn(argv, spawnOpts);
+      } catch (err: any) {
+        // Most likely ENOENT — binary vanished between applicable() and run().
+        return errorResult({
+          severity: "error",
+          message: `failed to spawn ${binary}: ${err?.message ?? String(err)}`,
+          code: err?.code === "ENOENT" ? "binary-missing" : "spawn-failed",
+        });
+      }
+
+      if (res.timedOut) {
+        // Align with the runner's `"timeout"` code so callers treat this
+        // the same as a runner-enforced timeout.
+        return errorResult({
+          severity: "error",
+          message: `skillgrade run timed out`,
+          code: "timeout",
+        });
+      }
+
+      if (res.aborted) {
+        return errorResult({
+          severity: "error",
+          message: `skillgrade run aborted`,
+          code: "aborted",
+        });
+      }
+
+      if (res.exitCode !== 0) {
+        const { code, hint } = classifyStderr(res.stderr);
+        const stderrExcerpt = res.stderr.trim().slice(0, 2_000);
+        return errorResult(
+          {
+            severity: "error",
+            message: `skillgrade exited ${res.exitCode}: ${hint}${
+              stderrExcerpt.length > 0 ? `\n${stderrExcerpt}` : ""
+            }`,
+            code,
+          },
+          { exitCode: res.exitCode, stderr: res.stderr },
+        );
+      }
+
+      // Exit code 0 — expect JSON on stdout.
+      let parsed: SkillgradeReport;
+      try {
+        parsed = JSON.parse(res.stdout) as SkillgradeReport;
+      } catch (err: any) {
+        return errorResult(
+          {
+            severity: "error",
+            message: `skillgrade stdout was not valid JSON: ${err?.message ?? String(err)}`,
+            code: "skillgrade-bad-json",
+          },
+          { stdout: res.stdout, stderr: res.stderr },
+        );
+      }
+
+      return adaptSkillgradeReport(parsed, {
+        providerId: PROVIDER_ID,
+        providerVersion: PROVIDER_VERSION,
+        schemaVersion: SCHEMA_VERSION,
+        thresholdFraction: resolved.thresholdFraction,
+      });
+    },
+  };
+}
+
+/**
+ * Singleton provider instance wired to production Bun spawn + filesystem.
+ * Registered in `src/eval/providers/index.ts`. Tests construct their own
+ * via `createSkillgradeProvider(...)`.
+ */
+export const skillgradeProviderV1: EvalProvider = createSkillgradeProvider();
+
+export default skillgradeProviderV1;

--- a/src/eval/providers/skillgrade/v1/scaffold.test.ts
+++ b/src/eval/providers/skillgrade/v1/scaffold.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Scaffold tests. The `Spawner` seam keeps these hermetic — no actual
+ * `skillgrade init` is ever run.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { scaffoldEvalYaml } from "./scaffold";
+import type { Spawner, SpawnResult } from "./spawn";
+
+function makeSpawn(result: Partial<SpawnResult>): Spawner {
+  return async () => ({
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    timedOut: false,
+    aborted: false,
+    ...result,
+  });
+}
+
+describe("scaffoldEvalYaml", () => {
+  it("returns ok:true when skillgrade init exits 0", async () => {
+    const res = await scaffoldEvalYaml({
+      skillPath: "/tmp/skill",
+      spawn: makeSpawn({ exitCode: 0, stdout: "created eval.yaml" }),
+    });
+    expect(res.ok).toBe(true);
+    expect(res.exitCode).toBe(0);
+    expect(res.message).toContain("/tmp/skill");
+  });
+
+  it("returns ok:false with stderr detail on non-zero exit", async () => {
+    const res = await scaffoldEvalYaml({
+      skillPath: "/tmp/skill",
+      spawn: makeSpawn({
+        exitCode: 1,
+        stderr: "error: eval.yaml already exists",
+      }),
+    });
+    expect(res.ok).toBe(false);
+    expect(res.exitCode).toBe(1);
+    expect(res.message).toContain("already exists");
+  });
+
+  it("falls back to stdout when stderr is empty", async () => {
+    const res = await scaffoldEvalYaml({
+      skillPath: "/tmp/skill",
+      spawn: makeSpawn({
+        exitCode: 2,
+        stdout: "usage: skillgrade init",
+      }),
+    });
+    expect(res.ok).toBe(false);
+    expect(res.message).toContain("usage:");
+  });
+
+  it("handles timeout cleanly", async () => {
+    const res = await scaffoldEvalYaml({
+      skillPath: "/tmp/skill",
+      timeoutMs: 10,
+      spawn: makeSpawn({ exitCode: null, timedOut: true }),
+    });
+    expect(res.ok).toBe(false);
+    expect(res.message).toMatch(/timed out/);
+  });
+
+  it("handles abort cleanly", async () => {
+    const res = await scaffoldEvalYaml({
+      skillPath: "/tmp/skill",
+      spawn: makeSpawn({ exitCode: null, aborted: true }),
+    });
+    expect(res.ok).toBe(false);
+    expect(res.message).toMatch(/aborted/);
+  });
+
+  it("surfaces ENOENT with an npm install hint", async () => {
+    const res = await scaffoldEvalYaml({
+      skillPath: "/tmp/skill",
+      spawn: async () => {
+        const e: any = new Error("spawn skillgrade ENOENT");
+        e.code = "ENOENT";
+        throw e;
+      },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.message).toContain("not installed");
+    expect(res.message).toContain("npm i -g skillgrade");
+  });
+
+  it("surfaces non-ENOENT spawn failures verbatim", async () => {
+    const res = await scaffoldEvalYaml({
+      skillPath: "/tmp/skill",
+      spawn: async () => {
+        throw new Error("EACCES: permission denied");
+      },
+    });
+    expect(res.ok).toBe(false);
+    expect(res.message).toContain("permission denied");
+  });
+
+  it("passes skillPath as cwd to the spawner", async () => {
+    let cwdSeen: string | undefined;
+    const spy: Spawner = async (_argv, opts) => {
+      cwdSeen = opts?.cwd;
+      return {
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        aborted: false,
+      };
+    };
+    await scaffoldEvalYaml({ skillPath: "/my/skill", spawn: spy });
+    expect(cwdSeen).toBe("/my/skill");
+  });
+
+  it("uses the configured binary name", async () => {
+    let argvSeen: string[] | undefined;
+    const spy: Spawner = async (argv) => {
+      argvSeen = argv;
+      return {
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        aborted: false,
+      };
+    };
+    await scaffoldEvalYaml({
+      skillPath: "/x",
+      binary: "my-skillgrade",
+      spawn: spy,
+    });
+    expect(argvSeen).toEqual(["my-skillgrade", "init"]);
+  });
+});

--- a/src/eval/providers/skillgrade/v1/scaffold.ts
+++ b/src/eval/providers/skillgrade/v1/scaffold.ts
@@ -1,0 +1,136 @@
+/**
+ * Scaffold — wraps `skillgrade init` to create `eval.yaml` in a skill dir.
+ *
+ * Invoked by the CLI when the user runs `asm eval <skill> --runtime init`.
+ * Kept separate from `index.ts` so the provider contract stays minimal:
+ * scaffolding is a one-shot action, not a recurring evaluation, and it
+ * should never appear in the `EvalResult` pipeline.
+ *
+ * Like the provider itself, scaffold goes through an injected `Spawner`
+ * so tests can exercise every branch (binary missing, non-zero exit,
+ * success) without ever touching the real `skillgrade` CLI.
+ */
+
+import type { Spawner, SpawnResult } from "./spawn";
+import { bunSpawn } from "./spawn";
+
+/** Outcome of a scaffold attempt — consumed directly by the CLI. */
+export interface ScaffoldResult {
+  /** `true` iff `skillgrade init` exited 0. */
+  ok: boolean;
+  /** Human-readable message suitable for stdout/stderr. */
+  message: string;
+  /** Exit code returned by the child process, `null` on signal/timeout. */
+  exitCode: number | null;
+  /** Raw stdout from `skillgrade init` (kept for verbose mode). */
+  stdout: string;
+  /** Raw stderr from `skillgrade init` (kept for debugging failures). */
+  stderr: string;
+}
+
+/**
+ * Options accepted by `scaffoldEvalYaml`.
+ *
+ * `spawn` is the single injection point. Tests pass a fake; production
+ * uses the default `bunSpawn`.
+ */
+export interface ScaffoldOptions {
+  /** Absolute path to the skill directory — `skillgrade init` runs here. */
+  skillPath: string;
+  /** Override the binary name (default: `"skillgrade"`). */
+  binary?: string;
+  /** Override the timeout in ms (default: 30_000). */
+  timeoutMs?: number;
+  /** Injection point for testing (default: `bunSpawn`). */
+  spawn?: Spawner;
+  /** Abort signal for cooperative cancellation. */
+  signal?: AbortSignal;
+}
+
+const DEFAULT_BINARY = "skillgrade";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Run `skillgrade init` in the given skill directory.
+ *
+ * Behavior:
+ *   - Returns `ok: true` on exit code 0 with a concise success message.
+ *   - Returns `ok: false` with a reason on non-zero exit, timeout, or
+ *     aborted signal. The reason embeds stderr so users can copy/paste
+ *     it into an issue report.
+ *   - Never throws — the CLI only needs to render `message` and pick
+ *     the right exit code.
+ */
+export async function scaffoldEvalYaml(
+  opts: ScaffoldOptions,
+): Promise<ScaffoldResult> {
+  const spawn = opts.spawn ?? bunSpawn;
+  const binary = opts.binary ?? DEFAULT_BINARY;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  let res: SpawnResult;
+  try {
+    res = await spawn([binary, "init"], {
+      cwd: opts.skillPath,
+      timeoutMs,
+      signal: opts.signal,
+    });
+  } catch (err: any) {
+    // ENOENT / spawn failure — most commonly the binary is not on PATH.
+    const message =
+      err?.code === "ENOENT"
+        ? `${binary} not installed — run: npm i -g skillgrade`
+        : `failed to spawn ${binary}: ${err?.message ?? String(err)}`;
+    return {
+      ok: false,
+      message,
+      exitCode: null,
+      stdout: "",
+      stderr: err?.message ?? String(err),
+    };
+  }
+
+  if (res.timedOut) {
+    return {
+      ok: false,
+      message: `${binary} init timed out after ${timeoutMs}ms`,
+      exitCode: res.exitCode,
+      stdout: res.stdout,
+      stderr: res.stderr,
+    };
+  }
+
+  if (res.aborted) {
+    return {
+      ok: false,
+      message: `${binary} init aborted`,
+      exitCode: res.exitCode,
+      stdout: res.stdout,
+      stderr: res.stderr,
+    };
+  }
+
+  if (res.exitCode !== 0) {
+    const detail =
+      res.stderr.trim().length > 0
+        ? res.stderr.trim()
+        : res.stdout.trim().length > 0
+          ? res.stdout.trim()
+          : "no stderr output";
+    return {
+      ok: false,
+      message: `${binary} init failed (exit ${res.exitCode}): ${detail}`,
+      exitCode: res.exitCode,
+      stdout: res.stdout,
+      stderr: res.stderr,
+    };
+  }
+
+  return {
+    ok: true,
+    message: `eval.yaml scaffolded in ${opts.skillPath}`,
+    exitCode: 0,
+    stdout: res.stdout,
+    stderr: res.stderr,
+  };
+}

--- a/src/eval/providers/skillgrade/v1/semver-range.test.ts
+++ b/src/eval/providers/skillgrade/v1/semver-range.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the compound-range matcher used by `externalRequires`.
+ *
+ * The registry's built-in matcher covers ^ / ~ / exact — this helper
+ * adds ≥, >, ≤, <, = and conjunctions. Tests exercise each operator,
+ * compound ranges, invalid input, and pre-release precedence.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { satisfiesExternalRange } from "./semver-range";
+
+describe("satisfiesExternalRange — single comparator", () => {
+  it(">= matches higher and equal", () => {
+    expect(satisfiesExternalRange("0.1.3", ">=0.1.3")).toBe(true);
+    expect(satisfiesExternalRange("0.2.0", ">=0.1.3")).toBe(true);
+  });
+
+  it(">= rejects lower", () => {
+    expect(satisfiesExternalRange("0.1.2", ">=0.1.3")).toBe(false);
+  });
+
+  it("> rejects equal", () => {
+    expect(satisfiesExternalRange("0.1.3", ">0.1.3")).toBe(false);
+    expect(satisfiesExternalRange("0.1.4", ">0.1.3")).toBe(true);
+  });
+
+  it("<= matches lower and equal", () => {
+    expect(satisfiesExternalRange("0.1.3", "<=0.1.3")).toBe(true);
+    expect(satisfiesExternalRange("0.1.2", "<=0.1.3")).toBe(true);
+  });
+
+  it("< rejects equal", () => {
+    expect(satisfiesExternalRange("0.1.3", "<0.1.3")).toBe(false);
+  });
+
+  it("= matches exact only", () => {
+    expect(satisfiesExternalRange("0.1.3", "=0.1.3")).toBe(true);
+    expect(satisfiesExternalRange("0.1.4", "=0.1.3")).toBe(false);
+  });
+});
+
+describe("satisfiesExternalRange — compound conjunction", () => {
+  it("matches inside a closed half-open range", () => {
+    expect(satisfiesExternalRange("0.1.3", ">=0.1.3 <0.3.0")).toBe(true);
+    expect(satisfiesExternalRange("0.2.9", ">=0.1.3 <0.3.0")).toBe(true);
+  });
+
+  it("rejects outside a closed half-open range", () => {
+    expect(satisfiesExternalRange("0.1.2", ">=0.1.3 <0.3.0")).toBe(false);
+    expect(satisfiesExternalRange("0.3.0", ">=0.1.3 <0.3.0")).toBe(false);
+    expect(satisfiesExternalRange("1.0.0", ">=0.1.3 <0.3.0")).toBe(false);
+  });
+
+  it("tolerates extra whitespace between clauses", () => {
+    expect(satisfiesExternalRange("0.2.0", " >=0.1.3   <0.3.0 ")).toBe(true);
+  });
+});
+
+describe("satisfiesExternalRange — wildcards & empty", () => {
+  it("undefined / empty range matches every version", () => {
+    expect(satisfiesExternalRange("0.0.1", undefined)).toBe(true);
+    expect(satisfiesExternalRange("0.0.1", "")).toBe(true);
+    expect(satisfiesExternalRange("0.0.1", "   ")).toBe(true);
+  });
+
+  it("* / x / X match every version", () => {
+    expect(satisfiesExternalRange("1.2.3", "*")).toBe(true);
+    expect(satisfiesExternalRange("1.2.3", "x")).toBe(true);
+    expect(satisfiesExternalRange("1.2.3", "X")).toBe(true);
+  });
+});
+
+describe("satisfiesExternalRange — delegation to registry", () => {
+  it("supports ^ ranges via registry matcher", () => {
+    expect(satisfiesExternalRange("1.4.0", "^1.0.0")).toBe(true);
+    expect(satisfiesExternalRange("2.0.0", "^1.0.0")).toBe(false);
+  });
+
+  it("supports ~ ranges via registry matcher", () => {
+    expect(satisfiesExternalRange("1.2.5", "~1.2.0")).toBe(true);
+    expect(satisfiesExternalRange("1.3.0", "~1.2.0")).toBe(false);
+  });
+
+  it("supports bare exact", () => {
+    expect(satisfiesExternalRange("1.2.3", "1.2.3")).toBe(true);
+    expect(satisfiesExternalRange("1.2.4", "1.2.3")).toBe(false);
+  });
+});
+
+describe("satisfiesExternalRange — pre-release", () => {
+  it("treats pre-releases as lower than their base", () => {
+    expect(satisfiesExternalRange("0.2.0-next", ">=0.2.0")).toBe(false);
+    expect(satisfiesExternalRange("0.2.0-next", "<0.2.0")).toBe(true);
+  });
+});
+
+describe("satisfiesExternalRange — invalid input", () => {
+  it("throws on nonsense clauses", () => {
+    expect(() => satisfiesExternalRange("1.0.0", "totally-bogus")).toThrow(
+      /invalid/i,
+    );
+  });
+
+  it("returns false for invalid version strings", () => {
+    expect(satisfiesExternalRange("not-semver", ">=1.0.0")).toBe(false);
+  });
+});

--- a/src/eval/providers/skillgrade/v1/semver-range.ts
+++ b/src/eval/providers/skillgrade/v1/semver-range.ts
@@ -1,0 +1,134 @@
+/**
+ * Tiny semver range matcher for `externalRequires` — skillgrade binary pin.
+ *
+ * The main registry's `satisfiesRange` handles the shapes ASM cares about
+ * internally (`^`, `~`, exact, `*`) but `externalRequires` in
+ * `~/.asm/config.yml` typically uses **compound comparator ranges** like
+ * `">=0.1.3 <0.3.0"` — ANDed inequalities. Rather than expand the registry
+ * matcher and ripple changes through every provider, this helper stays
+ * local to the skillgrade provider: it understands the subset we use for
+ * external binary pins and nothing more.
+ *
+ * Supported range shapes:
+ *   - `"*"` / `"x"` / `""`            — any version matches
+ *   - `"X.Y.Z"` (exact)               — strict equality
+ *   - `"^X.Y.Z"`                      — caret (delegated to registry matcher)
+ *   - `"~X.Y.Z"`                      — tilde (delegated to registry matcher)
+ *   - `">=X.Y.Z"`, `">X.Y.Z"`,
+ *     `"<=X.Y.Z"`, `"<X.Y.Z"`,
+ *     `"=X.Y.Z"`                     — single comparator
+ *   - Space-separated conjunction of the above: `">=0.1.3 <0.3.0"`
+ *
+ * Pre-release versions are accepted but follow standard SemVer ordering
+ * (a pre-release is strictly less than its base release). Invalid ranges
+ * throw — silently matching nothing would mask config mistakes.
+ */
+import {
+  compareSemver,
+  parseSemver,
+  satisfiesRange as satisfiesRegistryRange,
+} from "../../../registry";
+
+type Comparator = ">=" | ">" | "<=" | "<" | "=";
+
+interface SingleComparator {
+  op: Comparator;
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+const COMPARATOR_RE = /^(>=|<=|>|<|=)(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/;
+
+/**
+ * Parse a single comparator clause like `">=0.1.3"` or `"<0.3.0"`.
+ * Returns null for shapes this helper does not own (e.g. `^1.0.0`).
+ */
+function parseComparator(clause: string): SingleComparator | null {
+  const m = COMPARATOR_RE.exec(clause);
+  if (!m) return null;
+  const [, op, ver] = m;
+  const parsed = parseSemver(ver);
+  if (!parsed) return null;
+  return {
+    op: op as Comparator,
+    major: parsed.major,
+    minor: parsed.minor,
+    patch: parsed.patch,
+    prerelease: parsed.prerelease,
+  };
+}
+
+/**
+ * Evaluate a single comparator clause against a parsed version.
+ * Throws only if the clause is structurally invalid (already filtered
+ * by `parseComparator`), which is why this is a pure function.
+ */
+function matchComparator(
+  version: ReturnType<typeof parseSemver>,
+  clause: SingleComparator,
+): boolean {
+  if (!version) return false;
+  const diff = compareSemver(version, {
+    major: clause.major,
+    minor: clause.minor,
+    patch: clause.patch,
+    prerelease: clause.prerelease,
+  });
+  switch (clause.op) {
+    case ">=":
+      return diff >= 0;
+    case ">":
+      return diff > 0;
+    case "<=":
+      return diff <= 0;
+    case "<":
+      return diff < 0;
+    case "=":
+      return diff === 0;
+  }
+}
+
+/**
+ * Main entry point — does `version` satisfy `range`?
+ *
+ * Empty / wildcard range matches every version. Compound ranges (space
+ * separated) require every clause to match (AND semantics). Invalid
+ * ranges throw so bad config is loud, not silent.
+ */
+export function satisfiesExternalRange(
+  version: string,
+  range: string | undefined,
+): boolean {
+  if (!range || range.trim().length === 0) return true;
+  const trimmed = range.trim();
+  if (trimmed === "*" || trimmed === "x" || trimmed === "X") return true;
+
+  const parsedVersion = parseSemver(version);
+  if (!parsedVersion) return false;
+
+  const clauses = trimmed.split(/\s+/);
+  for (const raw of clauses) {
+    if (raw.length === 0) continue;
+
+    // Comparator clauses owned by this helper: >=, >, <=, <, =
+    const comp = parseComparator(raw);
+    if (comp) {
+      if (!matchComparator(parsedVersion, comp)) return false;
+      continue;
+    }
+
+    // Shapes the registry matcher understands: ^, ~, exact
+    // Delegate so we stay consistent with internal resolution rules.
+    try {
+      if (!satisfiesRegistryRange(version, raw)) return false;
+      continue;
+    } catch {
+      throw new Error(
+        `invalid externalRequires range clause: ${JSON.stringify(raw)} in ${JSON.stringify(range)}`,
+      );
+    }
+  }
+  return true;
+}

--- a/src/eval/providers/skillgrade/v1/spawn.ts
+++ b/src/eval/providers/skillgrade/v1/spawn.ts
@@ -1,0 +1,154 @@
+/**
+ * Spawner seam for the skillgrade provider.
+ *
+ * The skillgrade provider never shells out directly — it always goes through
+ * a `Spawner` function. Tests inject a fake Spawner that returns recorded
+ * fixture strings; production wires the default `bunSpawn` below.
+ *
+ * Why a seam (and not `jest.mock`-style module mocking)? Bun test's module
+ * patching story is thin and brittle. A first-class function injection
+ * point is explicit, zero-magic, and makes the mock obvious at the call
+ * site of every test.
+ *
+ * Contract:
+ *   - `argv[0]` is the binary name (looked up on PATH by `Bun.spawn`).
+ *   - `opts.timeoutMs` enforces a hard deadline. On expiry, the process
+ *     is killed with SIGTERM and the promise resolves with `exitCode: -1`
+ *     and `timedOut: true` (no throw — consumers decide how to handle).
+ *   - `stdout` / `stderr` are captured as UTF-8 strings.
+ *   - `env` is merged onto `process.env`; callers may pass their own
+ *     API keys without pulling in the entire environment.
+ *   - Signal-based abort is supported via `opts.signal`.
+ */
+
+/**
+ * Result of a spawn invocation.
+ *
+ * `timedOut` fires only when the provided timeout fired; `aborted` fires
+ * only when the provided signal fired. Both are `false` on a clean exit,
+ * regardless of `exitCode`.
+ */
+export interface SpawnResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  aborted: boolean;
+}
+
+/**
+ * Options accepted by a `Spawner`.
+ */
+export interface SpawnOptions {
+  /** Working directory for the spawned process. */
+  cwd?: string;
+  /** Hard timeout in milliseconds. Non-positive values disable the timer. */
+  timeoutMs?: number;
+  /** Environment overrides merged onto `process.env`. */
+  env?: Record<string, string>;
+  /** Cooperative abort signal — fires SIGTERM on the spawned process. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Function signature every caller (provider, scaffold, version probe)
+ * uses. Tests implement this directly; production uses `bunSpawn` below.
+ */
+export type Spawner = (
+  argv: string[],
+  opts?: SpawnOptions,
+) => Promise<SpawnResult>;
+
+/**
+ * Read all chunks from a web-readable stream and concatenate them as UTF-8.
+ *
+ * Bun exposes stdout/stderr as `ReadableStream<Uint8Array>`. We drain
+ * fully so tests never observe truncated output on short-lived children.
+ */
+async function drainStream(
+  stream: ReadableStream<Uint8Array> | null,
+): Promise<string> {
+  if (!stream) return "";
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return new TextDecoder("utf-8").decode(out);
+}
+
+/**
+ * Default production Spawner backed by `Bun.spawn`.
+ *
+ * Kept thin: it owns process lifecycle, timeout, signal plumbing, and
+ * stream draining — nothing else. All skillgrade-specific framing
+ * (argv construction, JSON parsing) lives in the provider/adapter.
+ */
+export const bunSpawn: Spawner = async (
+  argv: string[],
+  opts: SpawnOptions = {},
+): Promise<SpawnResult> => {
+  const env = { ...process.env, ...(opts.env ?? {}) } as Record<string, string>;
+
+  const proc = Bun.spawn(argv, {
+    cwd: opts.cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Wire timeout + signal → SIGTERM. Both are cooperative: skillgrade
+  // runs LLM evals which respect Ctrl-C, so terminal signals suffice.
+  let timedOut = false;
+  let aborted = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  if (typeof opts.timeoutMs === "number" && opts.timeoutMs > 0) {
+    timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        /* already exited */
+      }
+    }, opts.timeoutMs);
+  }
+  const onAbort = () => {
+    aborted = true;
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      /* already exited */
+    }
+  };
+  if (opts.signal) {
+    if (opts.signal.aborted) onAbort();
+    else opts.signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      drainStream(proc.stdout as unknown as ReadableStream<Uint8Array> | null),
+      drainStream(proc.stderr as unknown as ReadableStream<Uint8Array> | null),
+      proc.exited,
+    ]);
+    return {
+      exitCode: typeof exitCode === "number" ? exitCode : null,
+      stdout,
+      stderr,
+      timedOut,
+      aborted,
+    };
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    if (opts.signal) opts.signal.removeEventListener("abort", onAbort);
+  }
+};

--- a/tests/fixtures/skills/runtime-broken/SKILL.md
+++ b/tests/fixtures/skills/runtime-broken/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: runtime-broken
+description: Fetch the latest weather for a city and render a two-line terminal card with the temperature and a mood emoji.
+version: 1.0.0
+license: MIT
+creator: ASM Fixtures
+compatibility: Claude Code
+allowed-tools: WebFetch
+effort: low
+---
+
+# Runtime-broken corpus skill
+
+## When to Use
+
+- When the user asks "what's the weather in <city>?"
+- When a chat thread needs a quick ambient-mood card
+
+## Prerequisites
+
+- Network access
+- A user-supplied city name
+
+## Instructions
+
+1. Call the weather API for the supplied city
+2. Render a two-line card: line 1 temperature, line 2 mood emoji
+3. Exit without asking follow-up questions
+
+## Example
+
+```bash
+$ asm eval ./runtime-broken --runtime
+Runtime pass rate: 40%
+```
+
+## Acceptance Criteria
+
+- Two-line output only
+- Temperature unit is clearly labeled (C or F)
+- No follow-up questions
+
+## Edge cases
+
+- Unknown city: render a card with "unknown" and no emoji
+- Network failure: say "offline" on line 1
+
+## Safety
+
+Never write to disk. Never call destructive commands. Read-only network access only.

--- a/tests/fixtures/skills/runtime-broken/eval.yaml
+++ b/tests/fixtures/skills/runtime-broken/eval.yaml
@@ -1,0 +1,27 @@
+# Skillgrade eval spec for `runtime-broken`.
+#
+# Designed to fail the runtime threshold so the snapshot covers the
+# `passed: false` path in the adapter. The skill is "runtime-broken"
+# because the recorded skillgrade output shows it returning three-line
+# cards when two-line is required, dropping the pass rate below 0.8.
+name: runtime-broken
+preset: smoke
+threshold: 0.8
+
+tasks:
+  - id: weather-known-city
+    prompt: "Render the weather for Paris"
+    expect:
+      contains: "°"
+      lines: 2
+
+  - id: weather-unknown-city
+    prompt: "Render the weather for Xzyx"
+    expect:
+      contains: "unknown"
+      lines: 2
+
+graders:
+  - id: exactly-two-lines
+    kind: regex
+    pattern: '^[^\n]+\n[^\n]+$'

--- a/tests/fixtures/skills/with-eval-yaml/SKILL.md
+++ b/tests/fixtures/skills/with-eval-yaml/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: with-eval-yaml
+description: Summarize a git commit range into bullet-point release notes suitable for a public CHANGELOG.
+version: 1.0.0
+license: MIT
+creator: ASM Fixtures
+compatibility: Claude Code
+allowed-tools: Read Bash
+effort: low
+---
+
+# With eval.yaml corpus skill
+
+## When to Use
+
+- When the user says "summarize commits" or "draft release notes"
+- After a batch of merges, before cutting a version
+
+## Prerequisites
+
+- A git repository with commit history
+- Knowledge of the target commit range (e.g. `v1.2.0..HEAD`)
+
+## Instructions
+
+1. Run `git log --oneline <range>` to list commits
+2. Group commits by conventional-commit type (feat/fix/chore)
+3. Emit a bullet list under each heading
+
+## Example
+
+```bash
+$ asm eval ./with-eval-yaml --runtime
+Runtime pass rate: 92%
+```
+
+## Acceptance Criteria
+
+- Produces a markdown bullet list grouped by type
+- Preserves commit short SHAs as citations
+- Does not modify the git working tree
+
+## Edge cases
+
+- Empty range: emit a "no changes since last release" note
+- Merge commits: skip unless `--include-merges` is set
+
+## Safety
+
+Always read-only. Never run `git rebase`, `git reset`, or force-push commands.

--- a/tests/fixtures/skills/with-eval-yaml/eval.yaml
+++ b/tests/fixtures/skills/with-eval-yaml/eval.yaml
@@ -1,0 +1,25 @@
+# Skillgrade eval spec for `with-eval-yaml`.
+#
+# This is a minimal valid eval.yaml shape used by the recorded fixture
+# tests in `src/eval/providers/skillgrade/v1/fixtures/`. ASM does not
+# parse this file — skillgrade does — so only the presence of this file
+# matters for `applicable()`.
+name: with-eval-yaml
+preset: smoke
+threshold: 0.8
+
+tasks:
+  - id: summarize-empty-range
+    prompt: "Summarize commits in an empty range"
+    expect:
+      contains: "no changes"
+
+  - id: summarize-typical-range
+    prompt: "Summarize commits for v1.0.0..HEAD"
+    expect:
+      contains: "feat"
+
+graders:
+  - id: markdown-shape
+    kind: contains
+    needle: "## "


### PR DESCRIPTION
Closes #158

## Summary

PR 4 of 5 from the Skillgrade integration plan. Ships runtime evaluation via the external `skillgrade` CLI (mgechev/skillgrade). The new provider answers *"does this skill actually work?"* by running task prompts through LLM-judge graders — orthogonal to the existing static quality linter.

## Approach

- **Injectable spawn seam.** Every interaction with the external binary (`skillgrade --version`, `skillgrade run`, `skillgrade init`) goes through a `Spawner` function argument. Production wires `Bun.spawn`; tests inject a fake that returns recorded fixture strings. CI never shells out for real.
- **Three-stage `applicable()`.** Checks binary on PATH, version inside `externalRequires` range, and `eval.yaml` presence — each with a distinct actionable reason string.
- **Compound-range matcher.** `externalRequires` like `">=0.1.3 <0.3.0"` is resolved by a small local matcher in `src/eval/providers/skillgrade/v1/semver-range.ts` — the main registry matcher stays single-clause.
- **Error classification.** `run()` distinguishes missing API key, Docker unavailable, timeout, abort, non-zero exit, unparseable stdout, and binary-missing (spawn-time ENOENT) — each with a distinct `Finding.code`.
- **Config + CLI wiring.** `~/.asm/config.yml eval.providers.skillgrade.{preset,threshold,provider}` is loaded by `cmdEval` and overridden by CLI flags.

## Changes

| File | Change |
|------|--------|
| `src/eval/providers/skillgrade/v1/index.ts` | Provider factory with injection seams |
| `src/eval/providers/skillgrade/v1/adapter.ts` | Pure `skillgrade JSON → EvalResult` adapter |
| `src/eval/providers/skillgrade/v1/scaffold.ts` | `skillgrade init` wrapper for `--runtime init` |
| `src/eval/providers/skillgrade/v1/spawn.ts` | `Spawner` contract + production `Bun.spawn` impl |
| `src/eval/providers/skillgrade/v1/semver-range.ts` | Compound range matcher for `externalRequires` |
| `src/eval/providers/skillgrade/v1/fixtures/` | Recorded skillgrade JSON outputs (passing + failing) |
| `src/eval/providers/skillgrade/v1/*.test.ts` | 76 unit tests with injected spawner |
| `src/eval/providers/index.ts` | Register `skillgradeProviderV1` |
| `src/cli.ts` | `--runtime`, `--runtime init`, `--preset`, `--threshold`, `--provider`, config loader wiring |
| `src/cli.test.ts` | 10 CLI integration tests including stub-binary end-to-end |
| `tests/fixtures/skills/with-eval-yaml/` | Corpus skill w/ checked-in `eval.yaml` |
| `tests/fixtures/skills/runtime-broken/` | Corpus skill w/ threshold-failing `eval.yaml` |

## Test Results

- **86 new tests** (76 provider + 10 CLI runtime), all passing.
- **Full repo suite:** 1691 pass / 14 fail — the 14 failures are the pre-existing `publisher.test.ts` and `cli.test.ts > import existing skills are skipped` failures called out in the issue description as unrelated. No new regressions.
- **Zero live LLM calls** in CI — spawner seam for unit tests, shell stub for end-to-end CLI tests.

## Acceptance Criteria

- [x] `asm eval ./fixture --runtime` produces expected output against recorded skillgrade JSON (stub-binary CLI test + provider unit tests)
- [x] CI does not make live LLM calls — all tests use recorded fixtures
- [x] `asm eval --runtime init` scaffolds `eval.yaml` via `skillgrade init`
- [x] Graceful `applicable()` messages when binary missing, version out of range, or no `eval.yaml`
- [x] Error handling covers missing API key, Docker unavailable, timeout, non-zero exit
- [x] All flags (`--preset`, `--threshold`, `--provider`) wired through config + CLI (CLI overrides config)