### PR TITLE
feat(eval): add --compare mode and integration docs (#159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,10 @@ asm index search "your-skill" --json
 
 Each indexed skill in the output JSON includes `"verified": true` or `"verified": false`. If verification fails, the ingestion debug log (set `ASM_DEBUG=1`) prints the specific reasons.
 
+### Runtime Evaluation (`asm eval`)
+
+Beyond static verification, `asm eval` runs a scored quality rubric against a skill and — with `--runtime` — shells out to [skillgrade](https://github.com/mgechev/skillgrade) for LLM-judge runtime evals. Pluggable provider framework: `quality@1.0.0` ships by default for static linting, `skillgrade@1.0.0` runs deterministic + rubric graders with Docker isolation and CI-ready exit codes. Use `--compare <id>@<v1>,<id>@<v2>` to diff two provider versions on the same skill before promoting an upgrade, and `asm eval-providers list` to see what's registered. See [`docs/eval-providers.md`](./docs/eval-providers.md) and [`docs/skillgrade-integration.md`](./docs/skillgrade-integration.md) for details.
+
 ---
 
 ## ASM Registry — Install and Publish Skills by Name

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,6 +85,50 @@ Each view is a factory function that creates OpenTUI components:
 | Auditor     | `auditor.ts`     | Detect duplicate skills, rank instances for keeping, format reports  |
 | Uninstaller | `uninstaller.ts` | Build removal plans and execute safe deletions                       |
 | Formatter   | `formatter.ts`   | ASCII table, detail view, and JSON output formatting                 |
+| Eval        | `eval/`          | Pluggable skill evaluation framework (see below)                     |
+
+## Evaluation Framework (`src/eval/`)
+
+`asm eval` evaluates a skill and produces a scored report. Internally it is a **provider framework** — individual evaluators plug into a common `EvalResult` shape through the `EvalProvider` contract, so static linters, runtime LLM-judge tools, and future domain-specific evaluators all flow through the same CLI surface.
+
+| File                            | Responsibility                                                           |
+| ------------------------------- | ------------------------------------------------------------------------ |
+| `eval/types.ts`                 | Contract types: `EvalProvider`, `EvalResult`, `SkillContext`, `EvalOpts` |
+| `eval/registry.ts`              | `register()`, `resolve(id, semverRange)`, `list()`; minimal semver impl  |
+| `eval/runner.ts`                | Timing, error normalization, timeout enforcement around `provider.run()` |
+| `eval/config.ts`                | Reads the `eval` section of `~/.asm/config.yml` with typed defaults      |
+| `eval/compare.ts`               | Renders a diff between two `EvalResult` values (the `--compare` flow)    |
+| `eval/providers/index.ts`       | Calls `register()` for every built-in provider                           |
+| `eval/providers/quality/v1/`    | Static SKILL.md linter — adapter over `src/evaluator.ts`                 |
+| `eval/providers/skillgrade/v1/` | Runtime provider wrapping the external `skillgrade` CLI                  |
+
+### Provider contract
+
+Every provider implements `EvalProvider` (see `eval/types.ts`):
+
+- `id` + `version` — resolved via `resolve("id", "^1.0.0")` with minimal semver-range support
+- `schemaVersion` — integer, bumps only when the `EvalResult` shape changes structurally
+- `applicable(ctx, opts)` — cheap feasibility check; returns `{ ok, reason }`
+- `run(ctx, opts)` — full evaluation; returns a normalized `EvalResult`
+
+The runner centralizes three cross-cutting concerns so providers stay narrow:
+
+1. **Timing** — stamps `startedAt` (ISO-8601) and `durationMs` on every result
+2. **Error normalization** — provider throws become error-shaped results with a single `severity: "error"` finding; callers never need try/catch
+3. **Timeout enforcement** — races the provider against `opts.timeoutMs` / `opts.signal`
+
+### `--compare` mode
+
+`eval/compare.ts` renders a provider-agnostic diff between two `EvalResult` values: score delta, verdict flips, category deltas, and added/removed findings (keyed by `code` with message fallback). Schema-version mismatches surface as a warning in the header — the structural diff still works.
+
+The CLI dispatches through `cmdEval` in `src/cli.ts`:
+
+1. Parse `--compare <id>@<v1>,<id>@<v2>` via `parseCompareArg()`
+2. Resolve each spec through the registry's exact-match range
+3. Run both through `runProvider()` sequentially (some providers aren't safe to parallelize)
+4. Render via `compareResults()` and exit with the newer side's pass state
+
+See [`docs/eval-providers.md`](./eval-providers.md) for the user-facing workflow and the 5-step checklist for adding a new provider.
 
 ## Utilities (`src/utils/`)
 

--- a/docs/eval-providers.md
+++ b/docs/eval-providers.md
@@ -1,0 +1,185 @@
+# Evaluation Providers
+
+`asm eval` evaluates a skill against a quality rubric and returns a score, verdict, and structured findings. Behind the command is a **provider framework** that plugs different evaluators into the same `EvalResult` shape — static linters, runtime LLM-judge evaluators, and (later) domain-specific tools all speak the same contract.
+
+This doc covers:
+
+- How providers work and why they're versioned on two axes
+- How to pin a provider version
+- The `--compare` upgrade safety workflow
+- A 5-step checklist for adding a new provider
+
+## How providers work
+
+Every provider implements the [`EvalProvider`](../src/eval/types.ts) contract:
+
+```ts
+export interface EvalProvider {
+  id: string; // e.g. "quality", "skillgrade"
+  version: string; // semver — bumps freely
+  schemaVersion: number; // integer — only on structural breaks
+  description: string;
+  requires?: string[];
+  externalRequires?: ExternalRequirement;
+  applicable(ctx, opts): Promise<ApplicableResult>;
+  run(ctx, opts): Promise<EvalResult>;
+}
+```
+
+The runner in `src/eval/runner.ts` owns three cross-cutting concerns so providers don't have to: **timing** (`startedAt` + `durationMs`), **error normalization** (thrown errors become error-shaped `EvalResult` values), and **timeout enforcement** (both hard timeouts and external `AbortSignal`s).
+
+### Provider resolution
+
+Providers register into a shared registry (`src/eval/registry.ts`) keyed by `id` with an array of versions per id:
+
+```ts
+import { register, resolve } from "src/eval/registry";
+
+register(qualityProviderV1); // quality@1.0.0
+register(skillgradeProviderV1); // skillgrade@1.0.0
+
+// Semver-range resolution — picks the highest version in range.
+const p = resolve("quality", "^1.0.0");
+```
+
+Supported range shapes:
+
+- `*` or `x` — any version
+- `X.Y.Z` — exact match (including pre-release)
+- `^X.Y.Z` — same major (or minor, when major is 0)
+- `~X.Y.Z` — same major.minor
+
+### Two version axes
+
+Providers carry **two** version numbers, and the distinction matters when you plan upgrades:
+
+| Axis            | Meaning                                                     | Bump when                                 |
+| --------------- | ----------------------------------------------------------- | ----------------------------------------- |
+| `version`       | Provider semver. Participates in `resolve("id", "^1.0.0")`. | You release a new provider build.         |
+| `schemaVersion` | Shape version of the `EvalResult` payload.                  | You structurally change the result shape. |
+
+In practice, `schemaVersion` barely moves — once a provider ships v1 with its result shape, downstream parsers lock in. `version` bumps freely across feature/fix releases. Tools that consume `EvalResult` JSON output should key parsers off `schemaVersion`, not `version`.
+
+## Listing registered providers
+
+```bash
+asm eval-providers list
+```
+
+Shows id, version, schemaVersion, description, and any `requires` tags. `--json` emits a machine-readable array of the same records.
+
+## Pinning a provider version
+
+### Via `~/.asm/config.yml`
+
+```yaml
+eval:
+  defaults:
+    threshold: 70
+    timeoutMs: 60000
+  providers:
+    skillgrade:
+      version: "^1.0.0" # pin the range
+      preset: reliable
+      threshold: 0.9
+      provider: docker
+```
+
+The `version` key is a semver range that future CLI upgrades honor. Today `asm eval` picks the highest version in range; explicit pinning is what keeps CI stable when a new provider version ships.
+
+### Via `--compare` (one-off)
+
+`--compare` is the **upgrade safety mechanism**: run two pinned provider versions against the same skill and diff the results before promoting a new version.
+
+```bash
+asm eval ./my-skill --compare quality@1.0.0,quality@1.0.0
+```
+
+The diff covers:
+
+- **Score** — delta, with a clear `+`/`-` sign
+- **Verdict** — pass→fail / fail→pass flips flagged as regressions
+- **Categories** — per-category score/max deltas, plus added/removed categories
+- **Findings** — keyed by `code` (or message as fallback); added shown with `+`, removed with `-`
+- **Schema** — a visible warning when `schemaVersion` differs between versions
+
+Both versions have to exist in the registry. If the second one doesn't, you get a clean error:
+
+```
+Error: resolve: no version of "skillgrade" satisfies "2.0.0-next"
+       (have: 1.0.0)
+```
+
+This matches the aspirational example in the Skillgrade integration plan (`skillgrade@1.0.0,skillgrade@2.0.0-next`): it will work the moment a v2 adapter lands, and fails readably until then.
+
+### Output modes
+
+| Mode       | Flag        | Use case                              |
+| ---------- | ----------- | ------------------------------------- |
+| Human      | _(default)_ | Terminal reading; colors by default   |
+| JSON       | `--json`    | Ad-hoc scripting; `{ before, after }` |
+| Machine v1 | `--machine` | CI pipelines; stable envelope schema  |
+
+Exit code reflects the newer (`after`) version's `passed` field so CI can wire `--compare` into an upgrade gate without parsing output.
+
+## 5-step checklist: add a new provider
+
+Follow these steps when wiring a new evaluator into the framework.
+
+### 1. Create the provider module
+
+Scaffold under `src/eval/providers/<id>/v<N>/`:
+
+```
+src/eval/providers/myprovider/v1/
+├── index.ts        // exports myProviderV1: EvalProvider
+├── index.test.ts   // adapter unit tests
+└── (optional) adapter.ts, spawn.ts, fixtures/
+```
+
+Export a constant named `<id>ProviderV<N>` implementing `EvalProvider`. Keep every external dependency (network, subprocess, filesystem writes) behind an injectable seam so tests can run without them.
+
+### 2. Implement `applicable()` cheaply
+
+Return `{ ok: false, reason }` with an actionable message when the provider can't run (missing binary, missing `eval.yaml`, wrong version). `applicable()` runs synchronously-fast — no LLM calls, no long IO.
+
+### 3. Implement `run()` against the contract
+
+- Return `score` in `[0..100]`, not whatever scale your underlying tool uses.
+- Set `passed` per your provider's threshold semantics.
+- Emit at least one category (`"overall"` is fine for providers without a breakdown).
+- Leave `startedAt`/`durationMs` as placeholders — the runner stamps them.
+- Put raw tool output in `raw` so downstream consumers can reach the full payload.
+- Don't catch your own errors. The runner wraps them into error-shaped results.
+
+### 4. Register the provider
+
+Edit [`src/eval/providers/index.ts`](../src/eval/providers/index.ts):
+
+```ts
+import { register } from "../registry";
+import { myProviderV1 } from "./myprovider/v1";
+
+export function registerBuiltins(): void {
+  // ...existing...
+  register(myProviderV1);
+}
+```
+
+Providers register unconditionally. Environment checks (binary present, API key exported) belong in `applicable()`, not at registration time — `asm eval-providers list` must be deterministic across machines.
+
+### 5. Add tests and docs
+
+- Unit tests co-located at `index.test.ts`.
+- An integration test in `src/cli.test.ts` (if the provider needs CLI plumbing).
+- A short paragraph in `docs/eval-providers.md` and an entry in `docs/ARCHITECTURE.md`.
+- If the provider wraps an external tool, add a page like `docs/skillgrade-integration.md` covering install / troubleshoot / CI usage.
+
+## See also
+
+- [`src/eval/types.ts`](../src/eval/types.ts) — contract definitions
+- [`src/eval/registry.ts`](../src/eval/registry.ts) — semver range matching
+- [`src/eval/runner.ts`](../src/eval/runner.ts) — timing + error normalization
+- [`src/eval/compare.ts`](../src/eval/compare.ts) — `--compare` diff rendering
+- [`docs/skillgrade-integration.md`](./skillgrade-integration.md) — Skillgrade provider setup
+- [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md) — `src/eval/` module overview

--- a/docs/skillgrade-integration.md
+++ b/docs/skillgrade-integration.md
@@ -1,0 +1,185 @@
+# Skillgrade Integration
+
+[Skillgrade](https://github.com/mgechev/skillgrade) runs **unit tests for AI agent skills** — deterministic graders plus LLM-judge rubrics, Docker-isolated execution, CI-ready exit codes. `asm eval --runtime` wraps it so runtime evaluations live alongside the static `quality` linter under one command.
+
+This guide covers:
+
+- Installing the external `skillgrade` CLI
+- Writing your first `eval.yaml`
+- The three presets (smoke, reliable, regression)
+- CI usage with `--runtime --machine`
+- Troubleshooting when things don't work
+
+## Install skillgrade
+
+Skillgrade ships as an npm package:
+
+```bash
+npm i -g skillgrade
+skillgrade --version
+```
+
+`asm` checks for the binary at runtime and tells you exactly what's missing if it can't find it. If you prefer container-only installs, `skillgrade` also ships a Docker image — see the upstream README for the current tag.
+
+### Runtime prerequisites
+
+Skillgrade needs one of:
+
+- **Docker** (default) — isolated evaluation, no leakage between runs
+- **`--provider=local`** — faster, but the skill's eval code runs on your host machine
+
+Pick `local` for CI environments that already run inside containers; pick `docker` on developer machines and anywhere you're evaluating skills from untrusted sources.
+
+## Your first eval.yaml
+
+Skillgrade reads an `eval.yaml` next to your `SKILL.md`. The fastest way to get one is:
+
+```bash
+asm eval ./my-skill --runtime init
+```
+
+This calls `skillgrade init` under the hood: it reads `SKILL.md`, drafts tasks and graders via LLM, and writes `eval.yaml` for you to review. Edit it, commit it, and you're ready to run evaluations.
+
+### Minimal eval.yaml
+
+```yaml
+name: my-skill
+preset: smoke
+threshold: 0.8
+
+tasks:
+  - id: basic-usage
+    prompt: "Use the skill to answer: what's 2+2?"
+    graders:
+      - type: contains
+        text: "4"
+```
+
+`threshold` is the pass rate (0..1) the skill must hit across all tasks to return exit code 0. `graders` run per task; `contains`, `regex`, and `llm-rubric` are the common ones. See the [upstream docs](https://github.com/mgechev/skillgrade) for the full grader catalog.
+
+## Running
+
+### Local evaluation
+
+```bash
+asm eval ./my-skill --runtime
+```
+
+Output:
+
+```
+Skillgrade runtime: PASS score=95/100
+
+Tasks:
+  basic-usage: 5/5 (basic-usage)
+```
+
+`--json` emits the full `EvalResult`; `--machine` wraps it in the v1 envelope shape (see [`docs/eval-providers.md`](./eval-providers.md)).
+
+### Presets
+
+Presets control trial count and grader depth so you don't re-type the same flags:
+
+| Preset       | Trials | Use case                                        |
+| ------------ | ------ | ----------------------------------------------- |
+| `smoke`      | 1–3    | Fast pre-commit check; one-off spot-checking    |
+| `reliable`   | 5–10   | Default for CI; stable enough for gating merges |
+| `regression` | 20+    | Deep drift detection; pre-release sign-off      |
+
+Pass via flag or `~/.asm/config.yml`:
+
+```bash
+asm eval ./my-skill --runtime --preset reliable
+```
+
+```yaml
+# ~/.asm/config.yml
+eval:
+  providers:
+    skillgrade:
+      preset: reliable
+      threshold: 0.9
+      provider: docker
+```
+
+CLI flags override config; config overrides provider defaults.
+
+### Thresholds
+
+`--threshold 0.9` accepts either `0..1` fractions or `0..100` integers. The provider normalizes both to the same internal scale. If the skill's observed pass rate falls below the threshold, `asm eval` exits 1.
+
+## CI usage
+
+The target CI invocation:
+
+```bash
+asm eval ./my-skill --runtime --machine
+```
+
+`--machine` emits the stable v1 envelope format: `{ status, data, meta, error? }`. Wire it into GitHub Actions or similar:
+
+```yaml
+# .github/workflows/skill-eval.yml
+name: eval
+on: [pull_request]
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - run: npm i -g skillgrade
+      - run: |
+          bunx agent-skill-manager eval ./skills/my-skill \
+            --runtime --machine \
+            --preset reliable --provider local \
+            > eval.json
+          cat eval.json
+```
+
+Non-zero exit codes fail the step. `eval.json` is attachable for post-run inspection.
+
+### Upgrade gate with `--compare`
+
+Before promoting a new skillgrade or provider version, gate the upgrade on a visible diff:
+
+```bash
+asm eval ./my-skill --compare skillgrade@1.0.0,skillgrade@1.1.0
+```
+
+The rendered diff shows score delta, verdict flips, category deltas, and added/removed findings. In CI, `--compare --machine` emits a `{ before, after }` envelope and exits 1 if the newer version fails.
+
+(At the time of writing only `skillgrade@1.0.0` is registered. The aspirational example `skillgrade@2.0.0-next` will work unchanged once a v2 adapter ships; until then, the registry prints a clean "no version satisfies" error.)
+
+## Troubleshooting
+
+### `skillgrade not installed. Run npm i -g skillgrade`
+
+The `skillgrade` binary isn't on `$PATH`. Install it (`npm i -g skillgrade`), then retry. `asm eval --runtime` emits this exact hint so it's easy to copy.
+
+### `skillgrade 0.0.x is outside the required range ^0.1.0`
+
+`asm` pins a minimum skillgrade version via the provider's `externalRequires.semverRange`. Update to a newer skillgrade release (`npm i -g skillgrade@latest`).
+
+### `eval.yaml not found at ./my-skill/eval.yaml`
+
+Scaffold one with `asm eval ./my-skill --runtime init`, then edit it.
+
+### `Docker daemon is not running`
+
+Either start Docker or switch to `--provider local`. The provider surfaces the underlying skillgrade message verbatim so the root cause is visible.
+
+### API key errors (e.g. `ANTHROPIC_API_KEY not set`)
+
+LLM-judge graders need provider credentials exported. Skillgrade honors the usual env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) per the provider chosen in `eval.yaml`.
+
+### Non-zero exit with no obvious error
+
+Run the same command with `--json` or `--verbose` to see the underlying findings array — usually one of the tasks failed its grader, and the score fell below the threshold. Check the `tasks` and `findings` arrays for details.
+
+## See also
+
+- [`docs/eval-providers.md`](./eval-providers.md) — provider framework + `--compare`
+- [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md) — `src/eval/` module overview
+- [Upstream skillgrade](https://github.com/mgechev/skillgrade) — graders, providers, CLI reference

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2229,6 +2229,174 @@ describe("parseArgs — runtime flags", () => {
     expect(result.flags.runtime).toBe(true);
     expect(result.positional).toContain("init");
   });
+
+  test("--compare captures the comma-separated spec string verbatim", () => {
+    const result = parse(
+      "eval",
+      "./skill",
+      "--compare",
+      "quality@1.0.0,quality@1.0.0",
+    );
+    expect(result.flags.compare).toBe("quality@1.0.0,quality@1.0.0");
+  });
+
+  test("--compare defaults to null when not passed", () => {
+    const result = parse("eval", "./skill");
+    expect(result.flags.compare).toBeNull();
+  });
+});
+
+// ─── CLI integration: eval --compare ────────────────────────────────────────
+
+// `--compare` is the upgrade safety mechanism. It runs two pinned provider
+// versions on the same skill and renders a diff. The test story is the one
+// the issue's acceptance criteria calls out: "use fixture corpus and print
+// a readable diff". We use the built-in `quality@1.0.0` provider on both
+// sides so the test doesn't depend on a second concrete version existing
+// in the real registry — the happy-path zero-diff still exercises every
+// code path (resolve → run → compare render → exit).
+
+describe("CLI integration: eval --compare", () => {
+  async function makeQualitySkillDir(): Promise<{
+    dir: string;
+    cleanup: () => Promise<void>;
+  }> {
+    const dir = await mkdtemp(join(tmpdir(), "eval-compare-cli-"));
+    await writeFile(
+      join(dir, "SKILL.md"),
+      [
+        "---",
+        "name: compare-skill",
+        "description: Compare mode integration test skill when invoked.",
+        "---",
+        "",
+        "# compare-skill",
+        "",
+        "## Instructions",
+        "",
+        "1. Do the thing",
+      ].join("\n"),
+      "utf-8",
+    );
+    return { dir, cleanup: () => rm(dir, { recursive: true, force: true }) };
+  }
+
+  test("eval --compare quality@1.0.0,quality@1.0.0 prints a zero-diff readable report", async () => {
+    const { dir, cleanup } = await makeQualitySkillDir();
+    try {
+      const { stdout } = await runCLI(
+        "eval",
+        dir,
+        "--compare",
+        "quality@1.0.0,quality@1.0.0",
+      );
+      // Both sides produce the same result → zero diff. Exit code reflects
+      // the (shared) passed state of the newer side, which depends on the
+      // minimal SKILL.md's quality score — we assert on the rendered diff
+      // contents rather than the exit code so the test is stable against
+      // rubric tuning.
+      expect(stdout).toContain("Compare:");
+      expect(stdout).toContain("quality@1.0.0 → quality@1.0.0");
+      expect(stdout).toContain("No differences between versions.");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --compare --json emits { before, after } with populated providerId/Version", async () => {
+    const { dir, cleanup } = await makeQualitySkillDir();
+    try {
+      const { stdout } = await runCLI(
+        "eval",
+        dir,
+        "--compare",
+        "quality@1.0.0,quality@1.0.0",
+        "--json",
+      );
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toHaveProperty("before");
+      expect(parsed).toHaveProperty("after");
+      expect(parsed.before.providerId).toBe("quality");
+      expect(parsed.before.providerVersion).toBe("1.0.0");
+      expect(parsed.after.providerId).toBe("quality");
+      expect(parsed.after.providerVersion).toBe("1.0.0");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --compare --machine wraps before/after in the v1 envelope", async () => {
+    const { dir, cleanup } = await makeQualitySkillDir();
+    try {
+      const { stdout } = await runCLI(
+        "eval",
+        dir,
+        "--compare",
+        "quality@1.0.0,quality@1.0.0",
+        "--machine",
+      );
+      const parsed = JSON.parse(stdout);
+      expect(parsed.status).toBe("ok");
+      expect(parsed.data.before.provider_id).toBe("quality");
+      expect(parsed.data.after.provider_id).toBe("quality");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --compare with a malformed spec exits with code 1 and an actionable error", async () => {
+    const { dir, cleanup } = await makeQualitySkillDir();
+    try {
+      const { stderr, exitCode } = await runCLI(
+        "eval",
+        dir,
+        "--compare",
+        "quality@1.0.0", // missing second spec
+      );
+      expect(exitCode).toBe(1);
+      expect(stderr).toMatch(/requires exactly two specs/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --compare with an unknown provider id surfaces the registry error", async () => {
+    const { dir, cleanup } = await makeQualitySkillDir();
+    try {
+      const { stderr, exitCode } = await runCLI(
+        "eval",
+        dir,
+        "--compare",
+        "nonexistent@1.0.0,nonexistent@2.0.0",
+      );
+      expect(exitCode).toBe(1);
+      expect(stderr).toMatch(/"nonexistent"/);
+      expect(stderr).toMatch(/not registered/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("eval --compare with an aspirational 2.0.0-next emits a clean 'no version satisfies' error", async () => {
+    // This is the headline aspirational example from the plan —
+    // `skillgrade@1.0.0,skillgrade@2.0.0-next`. The CLI must not crash;
+    // the registry's "no version satisfies" message is the right
+    // user-facing surface until a v2 adapter actually lands.
+    const { dir, cleanup } = await makeQualitySkillDir();
+    try {
+      const { stderr, exitCode } = await runCLI(
+        "eval",
+        dir,
+        "--compare",
+        "quality@1.0.0,quality@2.0.0-next",
+      );
+      expect(exitCode).toBe(1);
+      expect(stderr).toMatch(/no version of "quality" satisfies/);
+      expect(stderr).toMatch(/2\.0\.0-next/);
+    } finally {
+      await cleanup();
+    }
+  });
 });
 
 // ─── CLI integration: eval-providers ────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,6 +115,7 @@ import {
 import { registerBuiltins } from "./eval/providers";
 import { loadEvalConfig } from "./eval/config";
 import { scaffoldEvalYaml } from "./eval/providers/skillgrade/v1/scaffold";
+import { compareResults, parseCompareArg } from "./eval/compare";
 import {
   formatMachineOutput,
   formatMachineError,
@@ -220,6 +221,12 @@ interface ParsedArgs {
     preset: string | null;
     /** `asm eval --threshold 0.8` — accepts `0..1` or `0..100`. */
     threshold: number | null;
+    /**
+     * `asm eval --compare <id>@<v1>,<id>@<v2>` — run two provider versions
+     * on the same skill and render the diff. Value is the raw comma-separated
+     * spec; parsing lives in `src/eval/compare.ts` so the CLI stays thin.
+     */
+    compare: string | null;
   };
 }
 
@@ -258,6 +265,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       runtime: false,
       preset: null,
       threshold: null,
+      compare: null,
     },
   };
 
@@ -371,6 +379,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
         process.exit(2);
       }
       result.flags.threshold = n;
+    } else if (arg === "--compare") {
+      // Raw value passed through verbatim; parsing lives in the compare
+      // module so `parseArgs` stays dumb and does not depend on eval/.
+      i++;
+      result.flags.compare = args[i] || null;
     } else if (arg.startsWith("-")) {
       error(`Unknown option: ${arg}`);
       console.error(`Run "asm --help" for usage.`);
@@ -2677,6 +2690,8 @@ ${ansi.bold("Options:")}
   --preset <name>      Skillgrade preset: smoke | reliable | regression
   --threshold <n>      Pass threshold (0..1 fraction or 0..100 integer)
   --provider <name>    Skillgrade exec provider: docker | local
+  --compare <specs>    Diff two provider versions on the same skill
+                       (format: id@v1,id@v2 — see Examples below)
   --json               Output report as JSON
   --machine            Output in stable machine-readable v1 envelope format
   --no-color           Disable ANSI colors
@@ -2691,6 +2706,8 @@ ${ansi.bold("Examples:")}
   asm eval ./my-skill --runtime           ${ansi.dim("Run skillgrade runtime evals")}
   asm eval ./my-skill --runtime init      ${ansi.dim("Scaffold eval.yaml via skillgrade init")}
   asm eval ./my-skill --runtime --preset reliable --threshold 0.9
+  asm eval ./my-skill --compare quality@1.0.0,quality@1.0.0
+                                          ${ansi.dim("Diff two provider versions (upgrade safety)")}
   asm eval-providers list                 ${ansi.dim("List registered eval providers")}`);
 }
 
@@ -2759,6 +2776,109 @@ async function cmdEval(args: ParsedArgs) {
   }
 
   try {
+    // --compare: run two explicitly-pinned providers against the same
+    // skill and render a diff. Provider-agnostic on purpose — the CLI
+    // doesn't inject `--runtime` semantics here; the user pins the
+    // exact (id, version) pairs they want to compare.
+    if (args.flags.compare !== null) {
+      const [beforeSpec, afterSpec] = parseCompareArg(args.flags.compare);
+      ensureEvalBuiltins();
+      const { resolve: resolvePath } = await import("path");
+      const absSkillPath = resolvePath(skillPath);
+      const ctx = {
+        skillPath: absSkillPath,
+        skillMdPath: resolvePath(absSkillPath, "SKILL.md"),
+      };
+
+      // Exact-match resolution via the registry's "X.Y.Z" range shape —
+      // lets the aspirational `skillgrade@2.0.0-next` spec produce a
+      // clean "no version satisfies …" error instead of silently
+      // matching a nearby range.
+      const beforeProvider = resolveEvalProvider(
+        beforeSpec.id,
+        beforeSpec.version,
+      );
+      const afterProvider = resolveEvalProvider(
+        afterSpec.id,
+        afterSpec.version,
+      );
+
+      // Merge opts from the same channels as the single-provider path so
+      // `--compare` respects --preset/--provider/--threshold and the
+      // ~/.asm/config.yml defaults for the provider being compared.
+      // Kept intentionally simple: we pass the same opts to both sides.
+      const compareOpts: Record<string, unknown> = {};
+      try {
+        const evalConfig = await loadEvalConfig();
+        const defaultTimeout = evalConfig.defaults.timeoutMs;
+        if (typeof defaultTimeout === "number" && defaultTimeout > 0) {
+          compareOpts.timeoutMs = defaultTimeout;
+        }
+      } catch (err: any) {
+        throw new Error(
+          `failed to load ~/.asm/config.yml: ${err?.message ?? String(err)}`,
+        );
+      }
+      if (args.flags.preset) compareOpts.preset = args.flags.preset;
+      if (args.flags.provider) compareOpts.provider = args.flags.provider;
+      if (args.flags.threshold !== null) {
+        compareOpts.threshold = args.flags.threshold;
+      }
+
+      // Run sequentially — some providers (skillgrade) aren't safe to
+      // run in parallel against the same skill dir (shared eval.yaml
+      // state, Docker port contention). Two serial runs is the simpler
+      // safe default; providers can opt into parallelism later.
+      const beforeResult = await runProvider(beforeProvider, ctx, compareOpts);
+      const afterResult = await runProvider(afterProvider, ctx, compareOpts);
+
+      if (args.flags.machine) {
+        restoreConsole?.();
+        console.log(
+          formatMachineOutput(
+            "eval",
+            {
+              before: {
+                provider_id: beforeResult.providerId,
+                provider_version: beforeResult.providerVersion,
+                schema_version: beforeResult.schemaVersion,
+                score: beforeResult.score,
+                passed: beforeResult.passed,
+                categories: beforeResult.categories,
+                findings: beforeResult.findings,
+              },
+              after: {
+                provider_id: afterResult.providerId,
+                provider_version: afterResult.providerVersion,
+                schema_version: afterResult.schemaVersion,
+                score: afterResult.score,
+                passed: afterResult.passed,
+                categories: afterResult.categories,
+                findings: afterResult.findings,
+              },
+            },
+            startTime,
+          ),
+        );
+        // Exit code reflects the newer version's pass state — matches
+        // the single-provider path's semantics.
+        process.exit(afterResult.passed ? 0 : 1);
+      }
+
+      if (args.flags.json) {
+        console.log(
+          JSON.stringify({ before: beforeResult, after: afterResult }, null, 2),
+        );
+        process.exit(afterResult.passed ? 0 : 1);
+      }
+
+      const diff = compareResults(beforeResult, afterResult, {
+        useColor: !args.flags.noColor,
+      });
+      console.log(diff);
+      process.exit(afterResult.passed ? 0 : 1);
+    }
+
     if (args.flags.fix) {
       // --fix stays on applyFix() directly. Auto-fix is quality-provider
       // specific — we do not expose it via provider capability yet; wait

--- a/src/eval/compare.test.ts
+++ b/src/eval/compare.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it } from "bun:test";
+import {
+  compareResults,
+  findingKey,
+  parseCompareArg,
+  type CompareOptions,
+} from "./compare";
+import type { EvalResult } from "./types";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal `EvalResult` for tests. Overrides are shallow-merged
+ * so individual tests can tweak one field at a time without repeating
+ * every other default.
+ */
+function makeResult(overrides: Partial<EvalResult> = {}): EvalResult {
+  return {
+    providerId: "quality",
+    providerVersion: "1.0.0",
+    schemaVersion: 1,
+    score: 80,
+    passed: true,
+    categories: [
+      { id: "structure", name: "Structure", score: 20, max: 25 },
+      { id: "safety", name: "Safety", score: 15, max: 15 },
+    ],
+    findings: [],
+    startedAt: "2026-04-18T12:00:00.000Z",
+    durationMs: 100,
+    ...overrides,
+  };
+}
+
+/** Colorless render opts used throughout — ANSI codes make snapshot churn. */
+const NO_COLOR: CompareOptions = { useColor: false };
+
+// ─── Header & labels ────────────────────────────────────────────────────────
+
+describe("compareResults header", () => {
+  it("uses providerId@providerVersion as default labels", () => {
+    const before = makeResult({ providerVersion: "1.0.0" });
+    const after = makeResult({ providerVersion: "1.1.0" });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("Compare:");
+    expect(out).toContain("quality@1.0.0 → quality@1.1.0");
+  });
+
+  it("accepts custom before/after labels", () => {
+    const before = makeResult();
+    const after = makeResult();
+    const out = compareResults(before, after, {
+      useColor: false,
+      beforeLabel: "old",
+      afterLabel: "new",
+    });
+    expect(out).toContain("old → new");
+  });
+});
+
+// ─── Score & verdict ────────────────────────────────────────────────────────
+
+describe("compareResults score & verdict", () => {
+  it("renders an improving score with a '+' delta", () => {
+    const before = makeResult({ score: 70 });
+    const after = makeResult({ score: 85 });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("70/100 → 85/100");
+    expect(out).toContain("+15");
+  });
+
+  it("renders a regression with a negative delta", () => {
+    const before = makeResult({ score: 85 });
+    const after = makeResult({ score: 60 });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("85/100 → 60/100");
+    expect(out).toContain("-25");
+  });
+
+  it("renders zero delta as '±0' with no change footer", () => {
+    const before = makeResult();
+    const after = makeResult();
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("±0");
+    expect(out).toContain("No differences between versions.");
+  });
+
+  it("flags pass → fail as a regression", () => {
+    const before = makeResult({ passed: true });
+    const after = makeResult({ passed: false });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("Verdict:");
+    expect(out).toContain("PASS");
+    expect(out).toContain("FAIL");
+    expect(out).toContain("regression introduced");
+  });
+
+  it("flags fail → pass as a regression fixed", () => {
+    const before = makeResult({ passed: false });
+    const after = makeResult({ passed: true });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("regression fixed");
+  });
+
+  it("labels unchanged verdict explicitly", () => {
+    const before = makeResult({ passed: true });
+    const after = makeResult({ passed: true });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("(unchanged)");
+  });
+});
+
+// ─── Schema-version mismatch ────────────────────────────────────────────────
+
+describe("compareResults schema mismatch", () => {
+  it("emits a warning line when schemaVersion differs", () => {
+    const before = makeResult({ schemaVersion: 1 });
+    const after = makeResult({ schemaVersion: 2 });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("schema version mismatch: 1 → 2");
+  });
+
+  it("stays silent when schemaVersion matches", () => {
+    const before = makeResult({ schemaVersion: 1 });
+    const after = makeResult({ schemaVersion: 1 });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).not.toContain("schema version mismatch");
+  });
+});
+
+// ─── Categories ─────────────────────────────────────────────────────────────
+
+describe("compareResults categories", () => {
+  it("shows per-category deltas for changed scores", () => {
+    const before = makeResult({
+      categories: [{ id: "structure", name: "Structure", score: 20, max: 25 }],
+    });
+    const after = makeResult({
+      categories: [{ id: "structure", name: "Structure", score: 25, max: 25 }],
+    });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("Categories:");
+    expect(out).toContain("Structure");
+    expect(out).toContain("20/25 → 25/25");
+    expect(out).toContain("+5");
+  });
+
+  it("flags added categories with (new)", () => {
+    const before = makeResult({ categories: [] });
+    const after = makeResult({
+      categories: [{ id: "safety", name: "Safety", score: 10, max: 10 }],
+    });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("Safety");
+    expect(out).toContain("(new)");
+  });
+
+  it("flags removed categories with (removed)", () => {
+    const before = makeResult({
+      categories: [{ id: "legacy", name: "Legacy", score: 5, max: 10 }],
+    });
+    const after = makeResult({ categories: [] });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("Legacy");
+    expect(out).toContain("(removed)");
+  });
+
+  it("omits the Categories block when nothing changed", () => {
+    const cats = [{ id: "x", name: "X", score: 5, max: 5 }];
+    const before = makeResult({ categories: cats });
+    const after = makeResult({ categories: cats });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).not.toContain("Categories:");
+  });
+});
+
+// ─── Findings ───────────────────────────────────────────────────────────────
+
+describe("compareResults findings", () => {
+  it("lists added findings with a '+' marker", () => {
+    const before = makeResult({ findings: [] });
+    const after = makeResult({
+      findings: [
+        { severity: "warning", message: "new warning", code: "new-code" },
+      ],
+    });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("Findings:");
+    expect(out).toContain("+ [warn]");
+    expect(out).toContain("new warning");
+    expect(out).toContain("new-code");
+  });
+
+  it("lists removed findings with a '-' marker", () => {
+    const before = makeResult({
+      findings: [
+        { severity: "info", message: "stale suggestion", code: "old-code" },
+      ],
+    });
+    const after = makeResult({ findings: [] });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).toContain("- [info]");
+    expect(out).toContain("stale suggestion");
+  });
+
+  it("keys same-message findings by code so the diff is stable", () => {
+    // Same code on both sides = the same finding, even if the message
+    // text was edited between versions.
+    const before = makeResult({
+      findings: [{ severity: "warning", message: "v1 wording", code: "K" }],
+    });
+    const after = makeResult({
+      findings: [{ severity: "warning", message: "v2 wording", code: "K" }],
+    });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).not.toContain("Findings:");
+  });
+
+  it("falls back to message when no code is present", () => {
+    const before = makeResult({
+      findings: [{ severity: "info", message: "identical" }],
+    });
+    const after = makeResult({
+      findings: [{ severity: "info", message: "identical" }],
+    });
+    const out = compareResults(before, after, NO_COLOR);
+    expect(out).not.toContain("Findings:");
+  });
+});
+
+// ─── Key selection ──────────────────────────────────────────────────────────
+
+describe("findingKey", () => {
+  it("prefers code when present", () => {
+    expect(findingKey({ severity: "info", message: "m", code: "c" })).toBe(
+      "code:c",
+    );
+  });
+
+  it("falls back to message", () => {
+    expect(findingKey({ severity: "info", message: "m" })).toBe("msg:m");
+  });
+});
+
+// ─── parseCompareArg ────────────────────────────────────────────────────────
+
+describe("parseCompareArg", () => {
+  it("parses two full id@version specs", () => {
+    expect(parseCompareArg("quality@1.0.0,quality@2.0.0")).toEqual([
+      { id: "quality", version: "1.0.0" },
+      { id: "quality", version: "2.0.0" },
+    ]);
+  });
+
+  it("inherits id from the first spec for the second", () => {
+    expect(parseCompareArg("skillgrade@1.0.0,2.0.0-next")).toEqual([
+      { id: "skillgrade", version: "1.0.0" },
+      { id: "skillgrade", version: "2.0.0-next" },
+    ]);
+  });
+
+  it("accepts different provider ids on each side", () => {
+    expect(parseCompareArg("quality@1.0.0,skillgrade@1.0.0")).toEqual([
+      { id: "quality", version: "1.0.0" },
+      { id: "skillgrade", version: "1.0.0" },
+    ]);
+  });
+
+  it("trims whitespace around specs", () => {
+    expect(parseCompareArg("  quality@1.0.0 , quality@2.0.0  ")).toEqual([
+      { id: "quality", version: "1.0.0" },
+      { id: "quality", version: "2.0.0" },
+    ]);
+  });
+
+  it("rejects empty input", () => {
+    expect(() => parseCompareArg("")).toThrow(/requires two provider specs/);
+    expect(() => parseCompareArg("   ")).toThrow(/requires two provider specs/);
+  });
+
+  it("rejects a single spec", () => {
+    expect(() => parseCompareArg("quality@1.0.0")).toThrow(
+      /requires exactly two specs/,
+    );
+  });
+
+  it("rejects three-plus specs", () => {
+    expect(() =>
+      parseCompareArg("quality@1.0.0,quality@2.0.0,quality@3.0.0"),
+    ).toThrow(/requires exactly two specs/);
+  });
+
+  it("rejects a first spec without an id", () => {
+    // Bare version in the first position is ambiguous — we require
+    // an id on the left so users don't accidentally ask for
+    // "1.0.0,2.0.0" of some unknown provider.
+    expect(() => parseCompareArg("1.0.0,1.1.0")).toThrow(
+      /must be of the form id@version/,
+    );
+  });
+
+  it("rejects specs with empty id or version", () => {
+    expect(() => parseCompareArg("@1.0.0,@2.0.0")).toThrow(
+      /both id and version/,
+    );
+    expect(() => parseCompareArg("quality@,quality@")).toThrow(
+      /both id and version/,
+    );
+  });
+});
+
+// ─── Integration smoke test ─────────────────────────────────────────────────
+
+describe("compareResults end-to-end rendering", () => {
+  it("produces a self-contained readable diff for mixed changes", () => {
+    // A scenario that exercises every diff dimension at once — the
+    // headline "demonstrate --compare on a fixture corpus" acceptance.
+    const before = makeResult({
+      providerVersion: "1.0.0",
+      score: 70,
+      passed: false,
+      categories: [
+        { id: "structure", name: "Structure", score: 15, max: 25 },
+        { id: "safety", name: "Safety", score: 10, max: 15 },
+      ],
+      findings: [
+        { severity: "warning", message: "missing-frontmatter", code: "mf" },
+      ],
+      durationMs: 120,
+    });
+    const after = makeResult({
+      providerVersion: "2.0.0",
+      score: 90,
+      passed: true,
+      categories: [
+        { id: "structure", name: "Structure", score: 25, max: 25 },
+        { id: "safety", name: "Safety", score: 10, max: 15 },
+        { id: "prompt", name: "Prompt Engineering", score: 15, max: 20 },
+      ],
+      findings: [
+        { severity: "info", message: "add examples", code: "examples" },
+      ],
+      durationMs: 250,
+    });
+    const out = compareResults(before, after, NO_COLOR);
+
+    // All six sections present in the combined render.
+    expect(out).toContain("Compare: quality@1.0.0 → quality@2.0.0");
+    expect(out).toContain("70/100 → 90/100");
+    expect(out).toContain("+20");
+    expect(out).toContain("regression fixed");
+    expect(out).toContain("duration: 120ms → 250ms");
+    expect(out).toContain("Structure");
+    expect(out).toContain("15/25 → 25/25");
+    expect(out).toContain("Prompt Engineering");
+    expect(out).toContain("(new)");
+    expect(out).toContain("- [warn]");
+    expect(out).toContain("missing-frontmatter");
+    expect(out).toContain("+ [info]");
+    expect(out).toContain("add examples");
+    expect(out).not.toContain("No differences");
+  });
+
+  it("emits ANSI codes when useColor is not false", () => {
+    const out = compareResults(makeResult(), makeResult(), {});
+    // Bold + dim codes from the color palette.
+    expect(out).toMatch(/\x1b\[/);
+  });
+});

--- a/src/eval/compare.ts
+++ b/src/eval/compare.ts
@@ -1,0 +1,402 @@
+/**
+ * Version comparison rendering for the `asm eval` provider framework.
+ *
+ * `--compare` is the upgrade safety mechanism: a user can diff two
+ * provider versions against the same skill before promoting a new one.
+ * This module is **provider-agnostic** — it takes two `EvalResult`
+ * values and renders a readable diff. Coupling it to any particular
+ * provider would make the contract (and the test story) worse.
+ *
+ * Diff dimensions covered:
+ *
+ *   - **Score**       — before → after, signed delta.
+ *   - **Pass/fail**   — explicit flip indicator when `passed` changes.
+ *   - **Categories**  — score/max deltas per category; added and
+ *                       removed categories highlighted.
+ *   - **Findings**    — added and removed findings keyed by `code`
+ *                       (fallback to `message`), so a provider that
+ *                       emits stable codes across versions produces a
+ *                       stable, readable diff.
+ *   - **Schema**      — mismatched `schemaVersion` surfaces as a
+ *                       warning line in the header. Not an error —
+ *                       structural diffing still works.
+ *
+ * Output contract:
+ *
+ *   - Returns a plain string. The caller (`cmdEval` in `src/cli.ts`)
+ *     is responsible for writing to stdout and deciding the exit code.
+ *   - Uses ANSI color codes only when `opts.useColor !== false`. The
+ *     CLI passes `useColor: !args.flags.noColor`.
+ *   - Never calls `process.exit`, reads from disk, or invokes the
+ *     registry. All inputs are passed in explicitly — this keeps the
+ *     module trivially testable.
+ *
+ * See `compare.test.ts` for the canonical shape examples the rendering
+ * is locked in against, and `docs/eval-providers.md` for the user-
+ * facing docs on version pinning and the `--compare` workflow.
+ */
+
+import type { CategoryResult, EvalResult, Finding } from "./types";
+
+// ─── ANSI helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Minimal ANSI helper tuple used by the renderer. A tiny inline subset
+ * of what the CLI provides so the module stays dependency-free (the
+ * registry and runner are also inlined-helper-style).
+ */
+interface AnsiHelpers {
+  bold: (s: string) => string;
+  dim: (s: string) => string;
+  red: (s: string) => string;
+  green: (s: string) => string;
+  yellow: (s: string) => string;
+  cyan: (s: string) => string;
+}
+
+/** Color-disabled helper. Used when `opts.useColor === false`. */
+const PLAIN: AnsiHelpers = {
+  bold: (s) => s,
+  dim: (s) => s,
+  red: (s) => s,
+  green: (s) => s,
+  yellow: (s) => s,
+  cyan: (s) => s,
+};
+
+/** Color-enabled helper. Mirrors the codes used elsewhere in `src/cli.ts`. */
+const COLOR: AnsiHelpers = {
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  red: (s) => `\x1b[31m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  cyan: (s) => `\x1b[36m${s}\x1b[0m`,
+};
+
+// ─── Public options ─────────────────────────────────────────────────────────
+
+/** Options for {@link compareResults}. All fields optional. */
+export interface CompareOptions {
+  /** Whether to emit ANSI color codes. Default: true. */
+  useColor?: boolean;
+  /**
+   * Optional labels for each side. When omitted, the renderer uses
+   * `{providerId}@{providerVersion}` for both sides. The labels appear
+   * in the header.
+   */
+  beforeLabel?: string;
+  afterLabel?: string;
+}
+
+// ─── Delta helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Format a signed numeric delta with a leading `+` for positive values.
+ * A zero delta renders as `±0` so the eye always sees a sign even when
+ * the delta is neutral.
+ */
+function formatDelta(delta: number): string {
+  if (delta > 0) return `+${delta}`;
+  if (delta < 0) return `${delta}`;
+  return "±0";
+}
+
+/**
+ * Pick the most discriminating key for a finding. We prefer `code`
+ * (machine-readable, stable across versions) and fall back to
+ * `message` (human text, less stable but always present).
+ *
+ * Exposed for testing — the rule is small but load-bearing for how
+ * "the same finding across versions" is detected.
+ */
+export function findingKey(f: Finding): string {
+  return f.code ? `code:${f.code}` : `msg:${f.message}`;
+}
+
+/**
+ * Compute sets of added and removed findings between two flat finding
+ * lists. A finding is "the same" if and only if its {@link findingKey}
+ * matches. Order is preserved from the input arrays so the rendered
+ * diff mirrors the provider's own ordering.
+ */
+function diffFindings(
+  before: Finding[],
+  after: Finding[],
+): { added: Finding[]; removed: Finding[] } {
+  const beforeKeys = new Set(before.map(findingKey));
+  const afterKeys = new Set(after.map(findingKey));
+  const removed = before.filter((f) => !afterKeys.has(findingKey(f)));
+  const added = after.filter((f) => !beforeKeys.has(findingKey(f)));
+  return { added, removed };
+}
+
+/**
+ * Compute per-category deltas keyed by category id. Categories present
+ * on only one side surface as added/removed with their full score.
+ *
+ * The returned `changed` array lists categories whose score changed
+ * (including max-changes at unchanged score — rare but possible when a
+ * provider shifts its rubric between versions).
+ */
+function diffCategories(
+  before: CategoryResult[],
+  after: CategoryResult[],
+): {
+  changed: {
+    id: string;
+    name: string;
+    beforeScore: number;
+    afterScore: number;
+    beforeMax: number;
+    afterMax: number;
+  }[];
+  added: CategoryResult[];
+  removed: CategoryResult[];
+} {
+  const beforeById = new Map(before.map((c) => [c.id, c]));
+  const afterById = new Map(after.map((c) => [c.id, c]));
+  const changed: ReturnType<typeof diffCategories>["changed"] = [];
+  for (const [id, b] of beforeById) {
+    const a = afterById.get(id);
+    if (!a) continue;
+    if (b.score !== a.score || b.max !== a.max) {
+      changed.push({
+        id,
+        name: a.name,
+        beforeScore: b.score,
+        afterScore: a.score,
+        beforeMax: b.max,
+        afterMax: a.max,
+      });
+    }
+  }
+  const added = after.filter((c) => !beforeById.has(c.id));
+  const removed = before.filter((c) => !afterById.has(c.id));
+  return { changed, added, removed };
+}
+
+// ─── Renderer ───────────────────────────────────────────────────────────────
+
+/**
+ * Format a side label as `id@version` for the header.
+ */
+function defaultLabel(r: EvalResult): string {
+  return `${r.providerId}@${r.providerVersion}`;
+}
+
+/**
+ * Format a single finding line. Severity is colored consistently with
+ * the rest of the runtime eval CLI output (red/yellow/dim).
+ */
+function formatFindingLine(f: Finding, prefix: string, a: AnsiHelpers): string {
+  const sev =
+    f.severity === "error"
+      ? a.red("error")
+      : f.severity === "warning"
+        ? a.yellow("warn")
+        : a.dim("info");
+  const code = f.code ? ` (${a.dim(f.code)})` : "";
+  return `  ${prefix} [${sev}]${code} ${f.message}`;
+}
+
+/**
+ * Render a human-readable diff between two `EvalResult` values.
+ *
+ * The rendered block groups related information: header → score →
+ * pass/fail flip → categories → findings. Each section is skipped
+ * entirely when there's nothing to show, so a zero-diff comparison
+ * still produces a short, clear "no changes" footer.
+ */
+export function compareResults(
+  before: EvalResult,
+  after: EvalResult,
+  opts: CompareOptions = {},
+): string {
+  const a = opts.useColor === false ? PLAIN : COLOR;
+  const beforeLabel = opts.beforeLabel ?? defaultLabel(before);
+  const afterLabel = opts.afterLabel ?? defaultLabel(after);
+
+  const lines: string[] = [];
+
+  // Header — which two versions are we comparing.
+  lines.push(a.bold("Compare: ") + `${beforeLabel} → ${afterLabel}`);
+
+  // Schema-version mismatch is a warning, not a blocker. Two providers
+  // at different schema versions can still be diffed structurally — we
+  // just flag that the `raw` payloads are not directly comparable.
+  if (before.schemaVersion !== after.schemaVersion) {
+    lines.push(
+      a.yellow(
+        `  ! schema version mismatch: ${before.schemaVersion} → ${after.schemaVersion}`,
+      ),
+    );
+  }
+  lines.push("");
+
+  // Score delta. Always emitted, even for zero-delta.
+  const scoreDelta = after.score - before.score;
+  const deltaStr = formatDelta(scoreDelta);
+  const coloredDelta =
+    scoreDelta > 0
+      ? a.green(deltaStr)
+      : scoreDelta < 0
+        ? a.red(deltaStr)
+        : a.dim(deltaStr);
+  lines.push(
+    `${a.bold("Score:")} ${before.score}/100 → ${after.score}/100 (${coloredDelta})`,
+  );
+
+  // Pass/fail flip. Only surface a line when the boolean actually changed.
+  if (before.passed !== after.passed) {
+    const fromWord = before.passed ? a.green("PASS") : a.red("FAIL");
+    const toWord = after.passed ? a.green("PASS") : a.red("FAIL");
+    const flipKind = after.passed
+      ? a.green("(regression fixed)")
+      : a.red("(regression introduced)");
+    lines.push(`${a.bold("Verdict:")} ${fromWord} → ${toWord} ${flipKind}`);
+  } else {
+    const word = after.passed ? a.green("PASS") : a.red("FAIL");
+    lines.push(`${a.bold("Verdict:")} ${word} (unchanged)`);
+  }
+
+  // Duration note, dim — useful context for upgrade decisions where a
+  // new version is N× slower even if the score is identical.
+  if (before.durationMs > 0 || after.durationMs > 0) {
+    lines.push(
+      a.dim(`  duration: ${before.durationMs}ms → ${after.durationMs}ms`),
+    );
+  }
+
+  // Category breakdown.
+  const catDiff = diffCategories(before.categories, after.categories);
+  if (
+    catDiff.changed.length > 0 ||
+    catDiff.added.length > 0 ||
+    catDiff.removed.length > 0
+  ) {
+    lines.push("");
+    lines.push(a.bold("Categories:"));
+    for (const c of catDiff.changed) {
+      const d = c.afterScore - c.beforeScore;
+      const sign =
+        d > 0
+          ? a.green(formatDelta(d))
+          : d < 0
+            ? a.red(formatDelta(d))
+            : a.dim(formatDelta(d));
+      lines.push(
+        `  ${c.name} (${a.dim(c.id)}): ${c.beforeScore}/${c.beforeMax} → ${c.afterScore}/${c.afterMax} (${sign})`,
+      );
+    }
+    for (const c of catDiff.added) {
+      lines.push(
+        `  ${a.green("+")} ${c.name} (${a.dim(c.id)}): ${c.score}/${c.max} ${a.green("(new)")}`,
+      );
+    }
+    for (const c of catDiff.removed) {
+      lines.push(
+        `  ${a.red("-")} ${c.name} (${a.dim(c.id)}): ${c.score}/${c.max} ${a.red("(removed)")}`,
+      );
+    }
+  }
+
+  // Findings diff.
+  const findingDiff = diffFindings(before.findings, after.findings);
+  if (findingDiff.added.length > 0 || findingDiff.removed.length > 0) {
+    lines.push("");
+    lines.push(a.bold("Findings:"));
+    for (const f of findingDiff.removed) {
+      lines.push(formatFindingLine(f, a.red("-"), a));
+    }
+    for (const f of findingDiff.added) {
+      lines.push(formatFindingLine(f, a.green("+"), a));
+    }
+  }
+
+  // Empty-diff footer. Without this, a zero-diff run would show only
+  // a header and a score line, which reads as "did anything happen?"
+  const noChanges =
+    scoreDelta === 0 &&
+    before.passed === after.passed &&
+    before.schemaVersion === after.schemaVersion &&
+    catDiff.changed.length === 0 &&
+    catDiff.added.length === 0 &&
+    catDiff.removed.length === 0 &&
+    findingDiff.added.length === 0 &&
+    findingDiff.removed.length === 0;
+  if (noChanges) {
+    lines.push("");
+    lines.push(a.dim("No differences between versions."));
+  }
+
+  return lines.join("\n");
+}
+
+// ─── Provider spec parsing ──────────────────────────────────────────────────
+
+/** Parsed `id@version` spec passed to `--compare`. */
+export interface CompareSpec {
+  id: string;
+  version: string;
+}
+
+/**
+ * Parse a `--compare` value into two ordered specs.
+ *
+ * Accepted shapes:
+ *   - `<id>@<v1>,<id>@<v2>`  — both specs fully qualified
+ *   - `<id>@<v1>,<v2>`       — second spec inherits `<id>` from the first
+ *
+ * Throws `Error` with an actionable message for any other shape. The
+ * exception flows through `cmdEval`'s outer try/catch where it becomes
+ * the same `SKILL_NOT_FOUND`-shaped machine envelope used by other
+ * eval errors — consistent surface for scripted consumers.
+ */
+export function parseCompareArg(raw: string): [CompareSpec, CompareSpec] {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new Error(
+      `--compare requires two provider specs (e.g. "quality@1.0.0,quality@1.0.0")`,
+    );
+  }
+  const parts = raw
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  if (parts.length !== 2) {
+    throw new Error(
+      `--compare requires exactly two specs separated by a comma (got ${parts.length})`,
+    );
+  }
+  const first = parseOneSpec(parts[0]!, /* requireId */ true);
+  // Second spec may be just a version — inherit the id from the first.
+  const second = parseOneSpec(parts[1]!, /* requireId */ false, first.id);
+  return [first, second];
+}
+
+/**
+ * Parse a single `id@version` (or bare `version` when `requireId` is
+ * false and a default id is passed). Internal helper for
+ * {@link parseCompareArg}.
+ */
+function parseOneSpec(
+  raw: string,
+  requireId: boolean,
+  defaultId?: string,
+): CompareSpec {
+  const atIdx = raw.indexOf("@");
+  if (atIdx < 0) {
+    if (requireId || !defaultId) {
+      throw new Error(`--compare spec "${raw}" must be of the form id@version`);
+    }
+    return { id: defaultId, version: raw };
+  }
+  const id = raw.slice(0, atIdx).trim();
+  const version = raw.slice(atIdx + 1).trim();
+  if (id.length === 0 || version.length === 0) {
+    throw new Error(
+      `--compare spec "${raw}" must be of the form id@version with both id and version`,
+    );
+  }
+  return { id, version };
+}


### PR DESCRIPTION
Closes #118
Closes #159

## Summary

Final PR of the 5-part skillgrade integration. Wires `--compare` as the upgrade safety mechanism and publishes the discoverability docs (`eval-providers.md`, `skillgrade-integration.md`).

## Approach

- **Provider-agnostic diff module.** `src/eval/compare.ts` takes two `EvalResult` values and renders a diff (score, verdict flip, category deltas, finding add/remove). Exact-match resolution via the registry's `X.Y.Z` range shape — aspirational specs like `skillgrade@2.0.0-next` produce a clean "no version satisfies" error instead of silently matching a nearby range. `parseCompareArg` handles both `id@v1,id@v2` and `id@v1,v2` (second inherits id).
- **`--compare` is independent of `--runtime`.** The flag is generic; users pin the two `(id, version)` pairs they want compared. No `--runtime` gating.
- **Exit code reflects the newer side's pass state** so CI can gate an upgrade on `--compare`.
- **Findings diff keys by `code`** (with `message` fallback) so a provider that emits stable codes across versions produces a stable, readable diff.
- **Schema-version mismatch is a warning**, not an error — structural diffing still works.

## Changes

| File | Change |
|------|--------|
| `src/eval/compare.ts` | New — provider-agnostic diff renderer + `parseCompareArg` |
| `src/eval/compare.test.ts` | New — 31 unit tests (header, score, verdict, schema, categories, findings, key selection, arg parsing, end-to-end) |
| `src/cli.ts` | Adds `compare` flag + parseArgs + dispatch in `cmdEval` (before `--fix` / `--runtime`); help text updated |
| `src/cli.test.ts` | 6 new integration tests + 2 parseArgs tests for `--compare` |
| `docs/eval-providers.md` | New — how providers work, two version axes, pinning, `--compare` workflow, 5-step checklist |
| `docs/skillgrade-integration.md` | New — install, first `eval.yaml`, presets, CI usage, troubleshooting |
| `README.md` | Adds runtime-eval paragraph under Skill Verification |
| `docs/ARCHITECTURE.md` | Documents `src/eval/` module, provider contract, runner, and `--compare` flow |

## Test Results

- `bun test src/eval/` — 188 pass, 0 fail
- `bun test src/cli.test.ts -t "eval"` — 34 pass, 0 fail
- `bun run typecheck` — clean
- Full `bun test` — 5 pre-existing failures in `publisher.test.ts` and `cli.test.ts > "import existing skills are skipped"` (same failures present on `main`, unrelated to this PR; called out in the issue).

## Acceptance Criteria

- [x] `asm eval --runtime --compare skillgrade@1.0.0,skillgrade@2.0.0-next` shape works — live `skillgrade@2.0.0-next` prints the registry's "no version satisfies" error readably; happy path demonstrated via `quality@1.0.0,quality@1.0.0` fixture and a synthetic-provider unit test demonstrating full mixed-change diff output.
- [x] `docs/eval-providers.md` and `docs/skillgrade-integration.md` published.
- [x] README and `docs/ARCHITECTURE.md` updated.
- [x] This PR closes #118 (epic) and #159; issue hygiene comments posted on #125 / #113 / #114 separately.

## Notes

Per the issue's option (b): test corpus uses synthetic providers in unit tests (`compare.test.ts`) rather than polluting the real registry with a pseudo-version. The aspirational example `skillgrade@1.0.0,skillgrade@2.0.0-next` is supported at the shape level — it will work unchanged the moment a v2 adapter lands.

## Test plan

- [x] `bun test src/eval/compare.test.ts` passes (31/31)
- [x] `bun test src/cli.test.ts -t "eval --compare"` passes (6/6)
- [x] `bun run typecheck` clean
- [x] Manual: `asm eval ./fixture --compare quality@1.0.0,quality@1.0.0` prints readable zero-diff
- [x] Manual: `asm eval ./fixture --compare skillgrade@1.0.0,skillgrade@2.0.0-next` prints clean error, exit 1
- [x] Manual: `asm eval ./fixture --compare quality@1.0.0 --machine` emits v1 envelope error