### PR TITLE
fix(eval): auto-init eval.yaml and correct misleading init hint (#171, #170)

### DIFF
--- a/docs/skillgrade-integration.md
+++ b/docs/skillgrade-integration.md
@@ -48,13 +48,12 @@ Pick `local` for CI environments that already run inside containers; pick `docke
 
 ## Your first eval.yaml
 
-Skillgrade reads an `eval.yaml` next to your `SKILL.md`. The fastest way to get one is:
+Skillgrade reads an `eval.yaml` next to your `SKILL.md`. You have two ways to create one:
 
-```bash
-asm eval ./my-skill --runtime init
-```
+- **Auto-init** (easiest) — just run `asm eval ./my-skill --runtime`. If `eval.yaml` doesn't exist, asm scaffolds it on the fly via `skillgrade init`, then proceeds with the evaluation. Existing files are never overwritten.
+- **Explicit init** — run `asm eval ./my-skill --runtime init` when you want to scaffold-and-stop (for example, to review the drafted `eval.yaml` before running any LLM calls).
 
-This calls `skillgrade init` under the hood: it reads `SKILL.md`, drafts tasks and graders via LLM, and writes `eval.yaml` for you to review. Edit it, commit it, and you're ready to run evaluations.
+Either path calls `skillgrade init` under the hood: it reads `SKILL.md`, drafts tasks and graders via LLM, and writes `eval.yaml` for you to review. Edit it, commit it, and you're ready to run evaluations.
 
 ### Minimal eval.yaml
 
@@ -186,7 +185,7 @@ If you're using `ASM_SKILLGRADE_BIN` to point at a custom path, double-check the
 
 ### `eval.yaml not found at ./my-skill/eval.yaml`
 
-Scaffold one with `asm eval ./my-skill --runtime init`, then edit it.
+Normally you shouldn't see this: `asm eval ./my-skill --runtime` auto-scaffolds `eval.yaml` when it's missing. If you do see it (for example, after the scaffold returned success but the file wasn't written), run `asm eval ./my-skill --runtime init` explicitly to retry the scaffold, then edit the drafted `eval.yaml`.
 
 ### `Docker daemon is not running`
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2148,6 +2148,240 @@ describe("CLI integration: eval --runtime", () => {
       await rm(stubDir, { recursive: true, force: true });
     }
   });
+
+  // ─── Auto-init for missing eval.yaml (issue #170) ────────────────────────
+  //
+  // When `asm eval <skill> --runtime` runs against a skill without an
+  // `eval.yaml`, the CLI should transparently scaffold one via
+  // `skillgrade init` and then proceed — no second manual command, no
+  // confusing follow-up error. The stub below mimics a skillgrade that
+  // supports `--version`, `init` (creates eval.yaml), and `run`.
+  test("eval --runtime auto-inits eval.yaml when missing and proceeds", async () => {
+    const { dir: skillDir, cleanup: cleanupSkill } = await makeSkillDir({
+      withEvalYaml: false,
+    });
+    const stubDir = await mkdtemp(join(tmpdir(), "stub-autoinit-"));
+    try {
+      const fixture = JSON.stringify({
+        version: "0.1.4",
+        skill: "runtime-cli",
+        preset: "smoke",
+        threshold: 0.8,
+        passRate: 0.9,
+        passed: true,
+        tasks: [
+          {
+            id: "hello",
+            passed: true,
+            trials: 5,
+            passing: 5,
+            passRate: 1.0,
+            graders: [{ id: "contains", passed: true, message: "has hello" }],
+          },
+        ],
+      });
+      const escapedFixture = fixture.replace(/'/g, "'\\''");
+      const stubPath = join(stubDir, "skillgrade");
+      await writeFile(
+        stubPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "skillgrade 0.1.4"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "init" ]; then',
+          // Create eval.yaml in the cwd so the subsequent applicable()
+          // check passes. Mirrors what the real `skillgrade init` does.
+          '  printf "name: runtime-cli\\npreset: smoke\\nthreshold: 0.8\\n" > eval.yaml',
+          '  echo "created eval.yaml"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "run" ]; then',
+          `  printf '%s' '${escapedFixture}'`,
+          "  exit 0",
+          "fi",
+          "exit 127",
+        ].join("\n"),
+        "utf-8",
+      );
+      await (await import("fs/promises")).chmod(stubPath, 0o755);
+
+      const { stdout, stderr, exitCode } = await runRuntimeCLI(
+        { skillgradeBin: stubPath },
+        "eval",
+        skillDir,
+        "--runtime",
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toMatch(/no eval.yaml/);
+      // The auto-init announcement should appear on stdout, referencing
+      // the scaffolded file path so users see what just happened.
+      expect(stdout).toMatch(/No eval.yaml found.*initializing/);
+      expect(stdout).toMatch(/eval.yaml scaffolded/);
+      // And the runtime evaluation must have run to completion.
+      expect(stdout).toMatch(/Skillgrade runtime:.*PASS/);
+
+      // The eval.yaml must exist on disk after the run and the original
+      // (nonexistent) file must not have been overwritten by anything
+      // other than our stub init. Hence: eval.yaml is present.
+      const { stat: fsStat } = await import("fs/promises");
+      const yamlStat = await fsStat(join(skillDir, "eval.yaml"));
+      expect(yamlStat.isFile()).toBe(true);
+    } finally {
+      await cleanupSkill();
+      await rm(stubDir, { recursive: true, force: true });
+    }
+  });
+
+  test("eval --runtime auto-init emits JSON envelope when --json is set", async () => {
+    const { dir: skillDir, cleanup: cleanupSkill } = await makeSkillDir({
+      withEvalYaml: false,
+    });
+    const stubDir = await mkdtemp(join(tmpdir(), "stub-autoinit-json-"));
+    try {
+      const fixture = JSON.stringify({
+        version: "0.1.4",
+        skill: "runtime-cli",
+        passRate: 1.0,
+        passed: true,
+        tasks: [],
+      });
+      const escapedFixture = fixture.replace(/'/g, "'\\''");
+      const stubPath = join(stubDir, "skillgrade");
+      await writeFile(
+        stubPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "skillgrade 0.1.4"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "init" ]; then',
+          '  printf "name: runtime-cli\\n" > eval.yaml',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "run" ]; then',
+          `  printf '%s' '${escapedFixture}'`,
+          "  exit 0",
+          "fi",
+          "exit 127",
+        ].join("\n"),
+        "utf-8",
+      );
+      await (await import("fs/promises")).chmod(stubPath, 0o755);
+
+      const { stdout, exitCode } = await runRuntimeCLI(
+        { skillgradeBin: stubPath },
+        "eval",
+        skillDir,
+        "--runtime",
+        "--json",
+      );
+
+      expect(exitCode).toBe(0);
+      // --json output must remain a single JSON document — the
+      // auto-init announcement should be suppressed so stdout stays
+      // parseable. `JSON.parse` would throw on any extra prose.
+      const parsed = JSON.parse(stdout);
+      expect(parsed.providerId).toBe("skillgrade");
+      expect(parsed.passed).toBe(true);
+    } finally {
+      await cleanupSkill();
+      await rm(stubDir, { recursive: true, force: true });
+    }
+  });
+
+  test("eval --runtime auto-init surfaces scaffold errors when skillgrade init fails", async () => {
+    const { dir: skillDir, cleanup: cleanupSkill } = await makeSkillDir({
+      withEvalYaml: false,
+    });
+    const stubDir = await mkdtemp(join(tmpdir(), "stub-autoinit-fail-"));
+    try {
+      const stubPath = join(stubDir, "skillgrade");
+      await writeFile(
+        stubPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "--version" ]; then',
+          '  echo "skillgrade 0.1.4"',
+          "  exit 0",
+          "fi",
+          'if [ "$1" = "init" ]; then',
+          '  echo "permission denied" 1>&2',
+          "  exit 3",
+          "fi",
+          "exit 127",
+        ].join("\n"),
+        "utf-8",
+      );
+      await (await import("fs/promises")).chmod(stubPath, 0o755);
+
+      const { stderr, exitCode } = await runRuntimeCLI(
+        { skillgradeBin: stubPath },
+        "eval",
+        skillDir,
+        "--runtime",
+      );
+
+      expect(exitCode).toBe(1);
+      // The scaffold failure is the most specific cause — surface its
+      // message (stderr from the stub) rather than the stale
+      // applicable() reason.
+      expect(stderr).toMatch(/skillgrade init failed/);
+      expect(stderr).toMatch(/permission denied/);
+    } finally {
+      await cleanupSkill();
+      await rm(stubDir, { recursive: true, force: true });
+    }
+  });
+
+  // Regression guard for #171: the missing-eval.yaml hint must embed
+  // the skill path so copy-pasting the suggestion works. This test
+  // exercises the path where applicable() fails in a way that bypasses
+  // auto-init (e.g., if the binary is missing, the reason won't mention
+  // eval.yaml). We test the provider error directly instead via the
+  // scenario where applicable() gets called with a non-working binary.
+  test("applicable() missing-eval.yaml reason includes the skill path (regression #171)", async () => {
+    // Import the provider directly so we can test its reason string
+    // without depending on end-to-end CLI behavior — this mirrors the
+    // unit test at src/eval/providers/skillgrade/v1/index.test.ts but
+    // also guards against future regressions if the CLI ever re-wraps
+    // the reason string.
+    const { createSkillgradeProvider } =
+      await import("./eval/providers/skillgrade/v1/index");
+    const p = createSkillgradeProvider({
+      spawn: async (argv) => {
+        if (argv[1] === "--version") {
+          return {
+            exitCode: 0,
+            stdout: "skillgrade 0.1.4",
+            stderr: "",
+            timedOut: false,
+            aborted: false,
+          };
+        }
+        return {
+          exitCode: 0,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          aborted: false,
+        };
+      },
+      fileExists: async () => false,
+    });
+    const skillPath = "/tmp/my-fake-skill";
+    const r = await p.applicable(
+      { skillPath, skillMdPath: join(skillPath, "SKILL.md") } as any,
+      {},
+    );
+    expect(r.ok).toBe(false);
+    expect((r as any).reason).toContain(`asm eval ${skillPath} --runtime init`);
+    // Must not produce the old broken hint.
+    expect((r as any).reason).not.toMatch(/asm eval --runtime init/);
+  });
 });
 
 // ─── parseArgs: runtime flags ───────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,6 +115,7 @@ import {
 import { registerBuiltins } from "./eval/providers";
 import { loadEvalConfig } from "./eval/config";
 import { scaffoldEvalYaml } from "./eval/providers/skillgrade/v1/scaffold";
+import { resolveProductionBinary as resolveSkillgradeBinary } from "./eval/providers/skillgrade/v1/index";
 import { compareResults, parseCompareArg } from "./eval/compare";
 import {
   formatMachineOutput,
@@ -2686,6 +2687,7 @@ ${ansi.bold("Options:")}
   --fix                Apply deterministic auto-fixes to SKILL.md (creates .bak)
   --dry-run            With --fix, preview the diff without writing
   --runtime            Run the skillgrade runtime provider (LLM-judge evals)
+                       Auto-scaffolds eval.yaml if missing
   --runtime init       Scaffold eval.yaml via \`skillgrade init\`
   --preset <name>      Skillgrade preset: smoke | reliable | regression
   --threshold <n>      Pass threshold (0..1 fraction or 0..100 integer)
@@ -2938,8 +2940,10 @@ async function cmdEval(args: ParsedArgs) {
 
       // Positional "init" → scaffold eval.yaml then exit.
       if (args.positional[0] === "init") {
+        const resolvedBinary = resolveSkillgradeBinary();
         const scaffoldRes = await scaffoldEvalYaml({
           skillPath: absSkillPath,
+          ...(resolvedBinary !== undefined ? { binary: resolvedBinary } : {}),
         });
         if (args.flags.machine) {
           restoreConsole?.();
@@ -3040,7 +3044,85 @@ async function cmdEval(args: ParsedArgs) {
 
       // Surface applicable() reasons verbatim — binary missing, version
       // out of range, eval.yaml missing each have a distinct hint.
-      const ok = await runtimeProvider.applicable(ctx, runtimeOpts);
+      //
+      // Auto-init for missing eval.yaml (issue #170): if the only reason
+      // applicable() fails is that eval.yaml doesn't exist, scaffold it
+      // on the fly via `skillgrade init` and re-check. We detect "missing
+      // eval.yaml" by file existence rather than by string-matching the
+      // reason so the provider contract stays the source of truth.
+      //
+      // Ordering: we call applicable() first so the binary-missing /
+      // version-out-of-range paths keep their curated hints. Only when
+      // every other stage would pass (binary present, version in range)
+      // do we reach into scaffold — which itself needs the binary.
+      let ok = await runtimeProvider.applicable(ctx, runtimeOpts);
+      if (!ok.ok) {
+        const { stat: fsStat } = await import("fs/promises");
+        const yamlPath = resolvePath(absSkillPath, "eval.yaml");
+        let yamlMissing = false;
+        try {
+          const s = await fsStat(yamlPath);
+          yamlMissing = !s.isFile();
+        } catch {
+          yamlMissing = true;
+        }
+        if (yamlMissing) {
+          // Double-check: applicable() may have failed for some other
+          // reason (binary missing, version out of range) even though
+          // eval.yaml is also absent. We don't want to shell out to
+          // `skillgrade init` in that case because the error will be
+          // less informative than the original applicable() hint.
+          // The reason string is the cheapest signal here: the
+          // provider emits "no eval.yaml" only when stages 1+2 passed.
+          const reasonMentionsEvalYaml = (ok.reason ?? "").includes(
+            "no eval.yaml",
+          );
+          if (reasonMentionsEvalYaml) {
+            // Announce the auto-init on stdout before shelling out so
+            // users see a clear "this is what just happened" line even
+            // if skillgrade itself prints nothing. Suppressed under
+            // --json / --machine to keep the output envelope clean.
+            if (!args.flags.json && !args.flags.machine) {
+              console.log(
+                `No eval.yaml found at ${yamlPath} — initializing via skillgrade init...`,
+              );
+            }
+            const resolvedBinary = resolveSkillgradeBinary();
+            const scaffoldRes = await scaffoldEvalYaml({
+              skillPath: absSkillPath,
+              ...(resolvedBinary !== undefined
+                ? { binary: resolvedBinary }
+                : {}),
+            });
+            if (!scaffoldRes.ok) {
+              // Scaffold failed — surface the scaffold error (not the
+              // original applicable() reason) because it's the most
+              // specific cause at this point.
+              if (args.flags.machine) {
+                restoreConsole?.();
+                console.log(
+                  formatMachineError(
+                    "eval",
+                    ErrorCodes.INVALID_ARGUMENT,
+                    scaffoldRes.message,
+                    startTime,
+                  ),
+                );
+                process.exit(1);
+              }
+              error(scaffoldRes.message);
+              process.exit(1);
+            }
+            if (!args.flags.json && !args.flags.machine) {
+              console.log(scaffoldRes.message);
+            }
+            // Re-check applicability now that eval.yaml exists. This
+            // also catches the edge case where `skillgrade init`
+            // reports success but left behind a non-file placeholder.
+            ok = await runtimeProvider.applicable(ctx, runtimeOpts);
+          }
+        }
+      }
       if (!ok.ok) {
         if (args.flags.machine) {
           restoreConsole?.();

--- a/src/eval/providers/skillgrade/v1/index.test.ts
+++ b/src/eval/providers/skillgrade/v1/index.test.ts
@@ -305,7 +305,12 @@ describe("applicable() — eval.yaml", () => {
     const r = await p.applicable(CTX_WITH, {});
     expect(r.ok).toBe(false);
     expect(r.reason).toContain("no eval.yaml");
-    expect(r.reason).toContain("asm eval --runtime init");
+    // Regression guard for #171: the hint must include the skill path
+    // so that copy-pasting the suggestion works (the plain
+    // `asm eval --runtime init` form sends users into a second error
+    // because the CLI treats `init` as a missing skill path).
+    expect(r.reason).toContain(`asm eval ${CTX_WITH.skillPath} --runtime init`);
+    expect(r.reason).not.toMatch(/asm eval --runtime init/);
   });
 
   it("returns ok:true when all three stages pass", async () => {

--- a/src/eval/providers/skillgrade/v1/index.ts
+++ b/src/eval/providers/skillgrade/v1/index.ts
@@ -347,11 +347,18 @@ export function createSkillgradeProvider(
       }
 
       // Stage 3: eval.yaml present at skill root.
+      //
+      // The suggested `asm eval <skillPath> --runtime init` command mirrors
+      // the `--help` examples (which all carry a skill-path positional).
+      // Reusing `ctx.skillPath` keeps the hint copy-pasteable verbatim —
+      // without it users hit a second "no eval.yaml at ./skills/init/"
+      // error because the CLI treats the literal `init` as a skill path
+      // (see issue #171).
       const yamlPath = evalYamlPath(ctx);
       if (!(await fileExists(yamlPath))) {
         return {
           ok: false,
-          reason: `no eval.yaml at ${yamlPath} — run: asm eval --runtime init`,
+          reason: `no eval.yaml at ${yamlPath} — run: asm eval ${ctx.skillPath} --runtime init`,
         };
       }
 
@@ -465,7 +472,16 @@ export function createSkillgradeProvider(
  * Registered in `src/eval/providers/index.ts`. Tests construct their
  * own instance via `createSkillgradeProvider(...)` and are unaffected.
  */
-function resolveProductionBinary(): string | undefined {
+/**
+ * Resolve the skillgrade binary using the same rules as the default
+ * production provider (env override → bundled dep → PATH fallback).
+ *
+ * Exported so sibling callers like `scaffoldEvalYaml` (invoked from the
+ * CLI's `--runtime init` branch and the auto-init path for issue #170)
+ * can run against the same binary the provider picked, without each
+ * caller reimplementing the priority chain.
+ */
+export function resolveProductionBinary(): string | undefined {
   const override = process.env.ASM_SKILLGRADE_BIN?.trim();
   if (override) return override;
   const bundled = resolveBundledSkillgradeBinary();


### PR DESCRIPTION
Closes #171
Closes #170

## Summary

Two related runtime-eval friction points resolved together because both
touch the same `applicable()` code path in the skillgrade provider.

- **#171 (error-message bug)** — The missing-`eval.yaml` hint used to
  say `asm eval --runtime init`. That form has no skill-path
  positional, so copy-pasting it dropped users into a second error
  (`no eval.yaml at ./skills/init/eval.yaml`) because the CLI treats
  the literal `init` as a missing skill path. The reason string now
  embeds `ctx.skillPath` so the suggestion works verbatim and matches
  the `--help` examples.

- **#170 (DX improvement)** — `asm eval <skill> --runtime` used to
  fail hard when `eval.yaml` was missing. It now auto-scaffolds via
  `skillgrade init` and continues with the evaluation, with a clear
  stdout announcement. Existing `eval.yaml` files are never touched.
  Under `--json` / `--machine` the announcement is suppressed so the
  output envelope stays clean.

## Approach

1. Fix the provider's reason string first (`applicable()` in
   `src/eval/providers/skillgrade/v1/index.ts`).
2. Layer auto-init into the CLI's `--runtime` branch. It calls
   `applicable()` normally; if the result is `ok:false` **and** the
   reason explicitly mentions "no eval.yaml", it shells out to
   `scaffoldEvalYaml()` and re-checks. This preserves the curated
   binary-missing and version-out-of-range hints.
3. Export `resolveProductionBinary` from the provider so the two
   scaffold call sites (explicit `--runtime init` and the new
   auto-init) reuse the same `ASM_SKILLGRADE_BIN` → bundled → PATH
   priority chain as the provider itself. Without this, the explicit
   init path had the same latent bug.

## Changes

| File | Change |
|------|--------|
| `src/eval/providers/skillgrade/v1/index.ts` | Reason string now includes skill path; export `resolveProductionBinary` |
| `src/eval/providers/skillgrade/v1/index.test.ts` | Updated assertion + regression guard against old hint |
| `src/cli.ts` | Auto-init logic in `--runtime` branch; both scaffold call sites pass the resolved binary |
| `src/cli.test.ts` | 4 new integration tests (auto-init success, `--json` envelope, scaffold-failure surfacing, #171 regression guard) |
| `docs/skillgrade-integration.md` | Documents the new auto-init behavior |

## Test Results

`bun test src/` — 1576 pass, 0 fail (4 new tests added). Full build
and typecheck clean. Manual end-to-end against a stub skillgrade
confirms: missing eval.yaml → auto-init → runtime eval runs to PASS.

## Acceptance Criteria

### #171
- [x] The "no eval.yaml at ..." error message recommends `asm eval <skill-path> --runtime init` (with skill path)
- [x] The recommended command reuses the skill path the user just invoked, so copy-pasting the suggestion works verbatim
- [x] Running the recommended command from the error message successfully scaffolds `eval.yaml` without producing another error
- [x] The `--help` examples and the error-message hint stay consistent (both use `asm eval <skill-path> --runtime init`)

### #170
- [x] Running `asm eval <path> --runtime` on a skill without `eval.yaml` auto-creates one using the same scaffold as `asm eval --runtime init`
- [x] After auto-init, the runtime evaluation proceeds without requiring a second command invocation
- [x] A clear message is printed indicating that `eval.yaml` was auto-initialized, including the file path
- [x] Existing `eval.yaml` files are never overwritten by the auto-init logic