### PR TITLE
fix(install): bundle skillgrade via bundledDependencies (#172)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "skillgrade": "^0.1.3",
     "yaml": "^2.8.3"
   },
+  "bundledDependencies": [
+    "skillgrade"
+  ],
   "engines": {
     "node": ">=18",
     "bun": ">=1.0.0"

--- a/tests/e2e/npm-install-e2e.test.ts
+++ b/tests/e2e/npm-install-e2e.test.ts
@@ -11,8 +11,9 @@ import { mkdtemp, rm, readFile, access } from "fs/promises";
 import { existsSync, readdirSync } from "fs";
 import { tmpdir } from "os";
 
-// npm pack + install can take a while
-setDefaultTimeout(60_000);
+// npm pack + install can take a while, and the runtime eval smoke
+// test spawns skillgrade (also slow on the first run).
+setDefaultTimeout(120_000);
 
 const ROOT = resolve(import.meta.dir, "..", "..");
 
@@ -166,6 +167,73 @@ describe("npm install: package structure", () => {
     const jsons = readdirSync(dataDir).filter((f) => f.endsWith(".json"));
     expect(jsons.length).toBeGreaterThanOrEqual(1);
   });
+
+  // Regression: issue #172 — reinstall must restore bundled skillgrade so
+  // `asm eval --runtime` works without a separate install step. The package
+  // declares `bundledDependencies: ["skillgrade"]`, so the tarball ships the
+  // full skillgrade tree under node_modules/ and npm preserves it on install.
+  //
+  // Note: this only asserts post-install reachability. A regular
+  // `dependencies` entry would also satisfy this — the discriminating test
+  // for `bundledDependencies` is the offline-install assertion below.
+  test("skillgrade/ bin is reachable after install (issue #172)", () => {
+    if (setupError) throw new Error(setupError);
+    const skillgradeBin = join(
+      installDir,
+      "lib",
+      "node_modules",
+      "agent-skill-manager",
+      "node_modules",
+      "skillgrade",
+      "bin",
+      "skillgrade.js",
+    );
+    expect(existsSync(skillgradeBin)).toBe(true);
+  });
+
+  // Discriminating test for `bundledDependencies` (issue #172): the packed
+  // tarball itself must contain skillgrade's files, so the package can be
+  // installed offline / into an air-gapped CI runner / onto a failing
+  // registry mirror. Without `bundledDependencies`, npm pack would omit
+  // node_modules/ and this check would fail.
+  test("tarball embeds skillgrade via bundledDependencies (issue #172)", async () => {
+    if (setupError) throw new Error(setupError);
+
+    // Re-pack to a throwaway directory so we can inspect the tarball
+    // contents without coupling to the shared install tarball's lifecycle.
+    const inspectDir = await mkdtemp(join(tmpdir(), "asm-npm-e2e-pack-"));
+    try {
+      const packProc = Bun.spawn(
+        ["npm", "pack", "--pack-destination", inspectDir, ROOT],
+        {
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      const packExit = await packProc.exited;
+      expect(packExit).toBe(0);
+
+      const [packed] = readdirSync(inspectDir).filter((f) =>
+        f.match(/^agent-skill-manager-.*\.tgz$/),
+      );
+      expect(packed).toBeTruthy();
+
+      const listProc = Bun.spawn(["tar", "-tzf", join(inspectDir, packed)], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const listing = await new Response(listProc.stdout).text();
+
+      // Both the entry point and package metadata must ship inside the
+      // tarball — simply having one could be a partial-match false positive.
+      expect(listing).toContain(
+        "package/node_modules/skillgrade/bin/skillgrade.js",
+      );
+      expect(listing).toContain("package/node_modules/skillgrade/package.json");
+    } finally {
+      await rm(inspectDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── Command tests via installed binary ─────────────────────────────────────
@@ -262,6 +330,60 @@ describe("npm install: asm init", () => {
     expect(exitCode).toBe(0);
     const content = await readFile(join(skillDir, "SKILL.md"), "utf-8");
     expect(content).toContain("name: test-skill");
+  });
+});
+
+// ─── Runtime eval flow (bundled skillgrade, issue #172) ─────────────────────
+//
+// Regression smoke test for issue #172 acceptance criterion 4: verifies that
+// a clean global install produces a working `asm eval --runtime` flow — no
+// separate skillgrade install required. `asm eval <skill> --runtime init`
+// is the cheapest exercise of the bundled binary: it scaffolds eval.yaml
+// without making LLM calls, so it's deterministic and CI-safe.
+
+describe("npm install: asm eval --runtime (bundled skillgrade)", () => {
+  let evalWorkspace: string;
+
+  beforeAll(async () => {
+    evalWorkspace = await mkdtemp(join(tmpdir(), "asm-npm-e2e-eval-"));
+  });
+
+  afterAll(async () => {
+    if (evalWorkspace) {
+      await rm(evalWorkspace, { recursive: true, force: true });
+    }
+  });
+
+  test("eval --runtime init scaffolds eval.yaml via bundled skillgrade", async () => {
+    if (setupError) throw new Error(setupError);
+
+    // Minimal SKILL.md fixture — skillgrade init reads this and drafts
+    // eval.yaml without invoking any LLM.
+    const skillDir = join(evalWorkspace, "bundled-skillgrade-skill");
+    const { exitCode: mkExit } = await runAsm(
+      "init",
+      "bundled-skillgrade-skill",
+      "--path",
+      skillDir,
+    );
+    expect(mkExit).toBe(0);
+
+    const { exitCode, stdout, stderr } = await runAsm(
+      "eval",
+      skillDir,
+      "--runtime",
+      "init",
+    );
+
+    // Assertion #1: the bundled skillgrade binary was reachable — the
+    // "skillgrade not installed" error path means bundling regressed.
+    const combined = `${stdout}\n${stderr}`;
+    expect(combined).not.toContain("skillgrade not installed");
+
+    // Assertion #2: scaffold succeeded.
+    expect(exitCode).toBe(0);
+    const evalYaml = join(skillDir, "eval.yaml");
+    expect(existsSync(evalYaml)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #172

## Summary

Reinstalling `agent-skill-manager` via `npm install -g` was leaving the bundled skillgrade dependency unreachable whenever the registry or local npm cache was unhealthy, which breaks the transparent-install contract promised by #165 — `asm eval --runtime init` keeps failing with "skillgrade not installed" after a reinstall.

Switches skillgrade from a plain `dependencies` entry to a `bundledDependencies` entry so it ships inside the packed tarball. Reinstalls (and offline / air-gapped / registry-flaky installs) now always land a working skillgrade copy.

## Approach

- Add `bundledDependencies: ["skillgrade"]` to `package.json`. npm now packs the resolved `node_modules/skillgrade/` tree into the tarball.
- Add three e2e regression tests in `tests/e2e/npm-install-e2e.test.ts` that guard the fix at different layers — post-install reachability, tarball contents (the discriminating test), and the `asm eval --runtime init` end-to-end flow.

**Tarball size trade-off:** packed size grows from 962kB -> 5.3MB (45 -> 2129 files). Intentional — skillgrade drives the `asm eval --runtime` contract, so it must ship with `asm` by default. `ASM_SKILLGRADE_BIN` still lets power users point at a system skillgrade.

## Changes

| File | Change |
|------|--------|
| `package.json` | Add `bundledDependencies: ["skillgrade"]` so npm pack embeds the skillgrade tree. |
| `tests/e2e/npm-install-e2e.test.ts` | Add three regression tests for issue #172; bump default timeout to 120s for the runtime-eval test. |

## Test Results

- `bun test tests/e2e/npm-install-e2e.test.ts` -> **18 pass, 0 fail** (15 existing + 3 new).
- `bun test src/` -> **1576 pass, 0 fail**.
- Unit tests for the skillgrade provider (`src/eval/providers/skillgrade/`) -> **87 pass, 0 fail**.
- Manually verified the discriminating `tarball embeds skillgrade via bundledDependencies` test **fails** without the `bundledDependencies` change and passes with it, confirming it actually guards the fix.
- Manually verified a fresh `npm install --global --prefix <tmp> --offline <tarball>` succeeds and `asm eval <skill> --runtime init` scaffolds `eval.yaml` without a separate skillgrade install.

## Acceptance Criteria

- [x] After a fresh `npm install -g agent-skill-manager`, `asm eval <skill> --runtime init` works without a separate skillgrade install step (**high**) — confirmed offline.
- [x] Reinstalling over an existing broken install restores skillgrade to a working state (**high**) — `bundledDependencies` guarantees the nested copy is always restored from the tarball.
- [ ] If installation/bundling of skillgrade fails, the install surfaces a clear, non-fatal warning telling the user how to install skillgrade manually (**high**) — out of scope for this PR; tracked separately via #173 which improves the runtime error message with the manual-install fallback.
- [x] A smoke test (CI or release check) verifies a clean global install produces a working `asm eval --runtime` flow (**medium**) — new e2e test `eval --runtime init scaffolds eval.yaml via bundled skillgrade` in `tests/e2e/npm-install-e2e.test.ts`.