### PR TITLE
refactor(eval): expand skillgrade-missing error with manual fallback (#173)

### DIFF
--- a/docs/skillgrade-integration.md
+++ b/docs/skillgrade-integration.md
@@ -169,15 +169,29 @@ The rendered diff shows score delta, verdict flips, category deltas, and added/r
 
 ## Troubleshooting
 
-### `skillgrade not installed or unreachable`
+### `skillgrade not installed` / `skillgrade not installed or unreachable`
 
-Skillgrade ships with `agent-skill-manager` — this message usually means the bundled copy inside `node_modules/skillgrade/` got corrupted or partially removed. Reinstall `asm` to restore it:
+Skillgrade ships with `agent-skill-manager` as a bundled dependency, so `asm eval --runtime` should work out of the box after a normal `npm install -g agent-skill-manager`. If you still see this error, the bundled copy inside `node_modules/skillgrade/` got corrupted, partially removed, or never shipped (offline install, registry proxy stripping `bundledDependencies`, custom deployment). The error now lists three fix paths — use whichever matches your situation:
+
+**Option 1 — Reinstall `agent-skill-manager` (bundled install).** Fastest for most users:
 
 ```bash
 npm install -g agent-skill-manager
 ```
 
-If you're using `ASM_SKILLGRADE_BIN` to point at a custom path, double-check the file exists and is executable (`ls -la "$ASM_SKILLGRADE_BIN"`).
+**Option 2 — Install `skillgrade` manually.** Use this if option 1 didn't restore the bundled binary (offline environment, corporate registry, bundling bug). The provider's binary-resolution chain falls back to `PATH`, so a globally-installed `skillgrade` is picked up automatically:
+
+```bash
+npm install -g skillgrade
+```
+
+**Option 3 — Point `ASM_SKILLGRADE_BIN` at a specific binary.** Use this for local development builds, custom deployments, or when you want to pin a specific skillgrade version without touching globals:
+
+```bash
+export ASM_SKILLGRADE_BIN=/path/to/skillgrade
+```
+
+If you're already using `ASM_SKILLGRADE_BIN` and hitting this error, double-check the file exists and is executable (`ls -la "$ASM_SKILLGRADE_BIN"`). Unset the env var to fall back to the bundled copy (option 1) or a global install (option 2).
 
 ### `skillgrade 0.0.x is outside the required range ^0.1.3`
 

--- a/src/eval/providers/skillgrade/v1/index.test.ts
+++ b/src/eval/providers/skillgrade/v1/index.test.ts
@@ -220,7 +220,7 @@ describe("classifyStderr", () => {
 // ─── applicable() ───────────────────────────────────────────────────────────
 
 describe("applicable() — binary", () => {
-  it("returns ok:false when skillgrade is not on PATH", async () => {
+  it("returns ok:false with a multi-option install hint when skillgrade is not on PATH", async () => {
     const p = createSkillgradeProvider({
       spawn: async () => {
         const e: any = new Error("ENOENT");
@@ -231,7 +231,19 @@ describe("applicable() — binary", () => {
     });
     const r = await p.applicable(CTX_WITH, {});
     expect(r.ok).toBe(false);
+    // Option 1 — reinstall agent-skill-manager (bundled path).
     expect(r.reason).toContain("npm install -g agent-skill-manager");
+    // Option 2 — manually install skillgrade (issue #173: second fix path).
+    expect(r.reason).toContain("npm install -g skillgrade");
+    // Option 3 — power-user escape hatch.
+    expect(r.reason).toContain("ASM_SKILLGRADE_BIN");
+    // Docs link (issue #173 acceptance criterion).
+    expect(r.reason).toContain(
+      "docs/skillgrade-integration.md#troubleshooting",
+    );
+    // Re-run hint preserves the user's skill path (CTX_WITH.skillPath)
+    // so copy-paste works verbatim (issue #173).
+    expect(r.reason).toContain(`asm eval ${CTX_WITH.skillPath} --runtime`);
   });
 
   it("returns ok:false when `skillgrade --version` exits non-zero", async () => {
@@ -249,7 +261,12 @@ describe("applicable() — binary", () => {
     });
     const r = await p.applicable(CTX_WITH, {});
     expect(r.ok).toBe(false);
+    // Headline keyword used by CLI-level regex assertions
+    // (`cli.test.ts::/skillgrade.*not installed or unreachable/i`).
     expect(r.reason).toMatch(/not installed or unreachable/i);
+    // Multi-option fix format (issue #173) — same format as the ENOENT
+    // path; both share `formatSkillgradeMissingMessage`.
+    expect(r.reason).toContain("npm install -g skillgrade");
   });
 });
 

--- a/src/eval/providers/skillgrade/v1/index.ts
+++ b/src/eval/providers/skillgrade/v1/index.ts
@@ -47,6 +47,7 @@ import { bunSpawn } from "./spawn";
 import { adaptSkillgradeReport, type SkillgradeReport } from "./adapter";
 import { satisfiesExternalRange } from "./semver-range";
 import { resolveBundledSkillgradeBinary } from "./resolve-binary";
+import { formatSkillgradeMissingMessage } from "./missing-binary-message";
 
 // ─── Identity constants ─────────────────────────────────────────────────────
 
@@ -309,8 +310,13 @@ export function createSkillgradeProvider(
     externalRequires: {
       binary,
       semverRange: externalRequires,
+      // Short hint surfaced by registry-level tooling. The full
+      // multi-option error (issue #173) is emitted at call time by
+      // `applicable()` / `scaffoldEvalYaml()` via
+      // `formatSkillgradeMissingMessage`; this string is a condensed
+      // recap pointing at the two primary fixes.
       installHint:
-        "skillgrade ships with agent-skill-manager — try reinstalling: npm install -g agent-skill-manager",
+        "skillgrade ships with agent-skill-manager — reinstall (npm install -g agent-skill-manager) or install skillgrade manually (npm install -g skillgrade)",
     },
 
     /**
@@ -323,11 +329,23 @@ export function createSkillgradeProvider(
       opts: EvalOpts,
     ): Promise<ApplicableResult> {
       // Stage 1: binary on PATH (and responsive to --version).
+      //
+      // The failure message lists three fix paths (reinstall, manual
+      // install, ASM_SKILLGRADE_BIN override) plus a docs link — see
+      // issue #173. We emit the shared multi-option format via
+      // `formatSkillgradeMissingMessage` so the scaffold path and the
+      // applicable() path stay in sync. The re-run hint preserves the
+      // user's skill path (`ctx.skillPath`) so copy-paste re-runs the
+      // exact `asm eval <skill> --runtime` command they just invoked.
       const detected = await detectVersion(spawn, binary, opts.signal);
       if (detected === null) {
         return {
           ok: false,
-          reason: `${binary} not installed or unreachable — reinstall agent-skill-manager to restore the bundled skillgrade: npm install -g agent-skill-manager`,
+          reason: formatSkillgradeMissingMessage({
+            headline: `${binary} not installed or unreachable`,
+            skillPath: ctx.skillPath,
+            rerunArgs: "--runtime",
+          }),
         };
       }
 

--- a/src/eval/providers/skillgrade/v1/missing-binary-message.test.ts
+++ b/src/eval/providers/skillgrade/v1/missing-binary-message.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the shared "skillgrade binary missing" formatter (issue #173).
+ *
+ * The formatter is the single source of truth for the multi-option fix
+ * message; both scaffold.ts (ENOENT path) and index.ts::applicable()
+ * (version-probe failure) render through it. Asserting the full shape
+ * here means the downstream tests only need to verify the headline +
+ * plumbing, not the body.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  formatSkillgradeMissingMessage,
+  SKILLGRADE_DOCS_URL,
+} from "./missing-binary-message";
+
+describe("formatSkillgradeMissingMessage", () => {
+  it("starts with the caller-provided headline on its own line", () => {
+    const msg = formatSkillgradeMissingMessage({
+      headline: "skillgrade not installed",
+      skillPath: "/tmp/skill",
+      rerunArgs: "--runtime init",
+    });
+    // Headline is the first line — important for CLI regexes that
+    // anchor on the short form (`/skillgrade.*not installed/i`).
+    expect(msg.split("\n")[0]).toBe("skillgrade not installed");
+  });
+
+  it("lists all three fix options with copy-paste commands", () => {
+    const msg = formatSkillgradeMissingMessage({
+      headline: "skillgrade not installed or unreachable",
+      skillPath: "/x",
+      rerunArgs: "--runtime",
+    });
+    // Option 1 — reinstall (bundled path).
+    expect(msg).toContain("Reinstall agent-skill-manager");
+    expect(msg).toContain("npm install -g agent-skill-manager");
+    // Option 2 — manual install (the primary fallback from #173).
+    expect(msg).toContain("Install skillgrade manually");
+    expect(msg).toContain("npm install -g skillgrade");
+    // Option 3 — env-var override for local dev builds / custom deploys.
+    expect(msg).toContain("ASM_SKILLGRADE_BIN");
+    expect(msg).toContain("export ASM_SKILLGRADE_BIN=");
+  });
+
+  it("includes the canonical docs link", () => {
+    const msg = formatSkillgradeMissingMessage({
+      headline: "h",
+      skillPath: "/x",
+      rerunArgs: "--runtime",
+    });
+    expect(msg).toContain(`Docs: ${SKILLGRADE_DOCS_URL}`);
+    expect(SKILLGRADE_DOCS_URL).toContain(
+      "docs/skillgrade-integration.md#troubleshooting",
+    );
+  });
+
+  it("reuses the skill path in the re-run hint so copy-paste works verbatim", () => {
+    const msg = formatSkillgradeMissingMessage({
+      headline: "h",
+      skillPath: "/home/user/my-skill",
+      rerunArgs: "--runtime init",
+    });
+    expect(msg).toContain("asm eval /home/user/my-skill --runtime init");
+  });
+
+  it("supports the applicable() re-run args (no `init` subcommand)", () => {
+    const msg = formatSkillgradeMissingMessage({
+      headline: "h",
+      skillPath: "/s",
+      rerunArgs: "--runtime",
+    });
+    expect(msg).toContain("asm eval /s --runtime");
+    // Guard: no accidental `init` leakage into the applicable() path.
+    // We check the hint segment specifically — `--runtime init` as a
+    // literal must not appear anywhere in the rendered message.
+    expect(msg).not.toContain("--runtime init");
+  });
+
+  it("renders the headline, fix options, docs, and re-run hint in order", () => {
+    const msg = formatSkillgradeMissingMessage({
+      headline: "H",
+      skillPath: "/s",
+      rerunArgs: "--runtime",
+    });
+    // Use indexOf to assert ordering without pinning exact whitespace —
+    // the formatter owns layout, the tests own intent.
+    const headlineAt = msg.indexOf("H");
+    const optionsAt = msg.indexOf("Fix options:");
+    const docsAt = msg.indexOf("Docs:");
+    const rerunAt = msg.indexOf("Then re-run:");
+    expect(headlineAt).toBeLessThan(optionsAt);
+    expect(optionsAt).toBeLessThan(docsAt);
+    expect(docsAt).toBeLessThan(rerunAt);
+  });
+});

--- a/src/eval/providers/skillgrade/v1/missing-binary-message.ts
+++ b/src/eval/providers/skillgrade/v1/missing-binary-message.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared formatter for the "skillgrade binary not reachable" error (issue #173).
+ *
+ * Two call sites surface this error with slightly different headlines:
+ *
+ *   - `scaffold.ts` spawns `skillgrade init` and catches ENOENT before any
+ *     version probe. Headline: `<binary> not installed`.
+ *   - `index.ts::applicable()` runs `<binary> --version` first; when that
+ *     fails for any reason (ENOENT, wrong exit code, unparseable output)
+ *     the headline becomes `<binary> not installed or unreachable`.
+ *
+ * Both paths share the same *fix options* — this module is the single
+ * source of truth so the error text, the docs link, and the re-run hint
+ * stay in sync.
+ *
+ * Shape (single string, newline-separated — one message, rendered verbatim
+ * by the CLI's plain-text output and embedded as-is inside JSON/machine
+ * envelopes):
+ *
+ *   <headline>
+ *
+ *     Fix options:
+ *       1. Reinstall agent-skill-manager (bundles skillgrade):
+ *            npm install -g agent-skill-manager
+ *       2. Install skillgrade manually:
+ *            npm install -g skillgrade
+ *       3. Point ASM_SKILLGRADE_BIN at a local skillgrade binary:
+ *            export ASM_SKILLGRADE_BIN=/path/to/skillgrade
+ *
+ *     Docs: <hosted troubleshooting URL>
+ *
+ *     Then re-run:
+ *       asm eval <skillPath> <rerunArgs>
+ *
+ * Acceptance criteria coverage (from issue #173):
+ *   - Lists at least two fix paths (reinstall + manual) → options 1 & 2.
+ *   - Exact copy-paste commands → `npm install -g …` on its own line.
+ *   - Docs link → `Docs:` line points at the hosted troubleshooting anchor.
+ *   - Re-run hint reuses the skill path the user invoked → rendered from
+ *     `opts.skillPath`.
+ */
+
+/**
+ * Canonical docs URL — kept as a constant so both the error text and
+ * any future call site reference the same anchor. We use the hosted
+ * GitHub URL rather than a relative path because the error is read in
+ * terminals where `docs/...` links don't click.
+ */
+export const SKILLGRADE_DOCS_URL =
+  "https://github.com/luongnv89/agent-skill-manager/blob/main/docs/skillgrade-integration.md#troubleshooting";
+
+/** Arguments accepted by {@link formatSkillgradeMissingMessage}. */
+export interface SkillgradeMissingMessageOptions {
+  /**
+   * Short one-line headline explaining what's wrong. The two canonical
+   * headlines are:
+   *   - `"<binary> not installed"` — used by scaffold (no version probe ran).
+   *   - `"<binary> not installed or unreachable"` — used by applicable()
+   *     (version probe ran and failed, so we can't tell whether the binary
+   *     is missing, non-executable, or misbehaving).
+   *
+   * Kept as a free-form string so callers control the exact wording and
+   * existing regex assertions (`/not installed or unreachable/i`) keep
+   * passing. The formatter only guarantees the headline is on its own
+   * line at the top of the rendered message.
+   */
+  headline: string;
+  /**
+   * Absolute skill path the user invoked (`ctx.skillPath` from the provider,
+   * `opts.skillPath` from the scaffold). Reused in the "Then re-run:" hint
+   * so copy-paste gives the user back the exact command they just ran.
+   */
+  skillPath: string;
+  /**
+   * Argv fragment appended after `asm eval <skillPath>` in the re-run hint.
+   * Examples: `"--runtime"` (applicable() case), `"--runtime init"`
+   * (scaffold case). Kept as a single string because the CLI renders it
+   * verbatim — we never need to quote or join array elements.
+   */
+  rerunArgs: string;
+}
+
+/**
+ * Render the shared multi-option error message.
+ *
+ * Pure function, no I/O. The returned string is suitable for:
+ *   - CLI stderr (rendered as-is by the runner's error-wrap path)
+ *   - `EvalResult.findings[].message` (embedded verbatim, no escaping)
+ *   - `ApplicableResult.reason` (same — the CLI prints it unmodified)
+ *
+ * Leading indent for options/docs/re-run is two spaces — matches the
+ * surrounding CLI output style (see DESIGN.md "content under section
+ * headers is indented two spaces"). A trailing newline is intentionally
+ * omitted; callers decide whether to append one.
+ */
+export function formatSkillgradeMissingMessage(
+  opts: SkillgradeMissingMessageOptions,
+): string {
+  return [
+    opts.headline,
+    "",
+    "  Fix options:",
+    "    1. Reinstall agent-skill-manager (bundles skillgrade):",
+    "         npm install -g agent-skill-manager",
+    "    2. Install skillgrade manually:",
+    "         npm install -g skillgrade",
+    "    3. Point ASM_SKILLGRADE_BIN at a local skillgrade binary:",
+    "         export ASM_SKILLGRADE_BIN=/path/to/skillgrade",
+    "",
+    `  Docs: ${SKILLGRADE_DOCS_URL}`,
+    "",
+    "  Then re-run:",
+    `    asm eval ${opts.skillPath} ${opts.rerunArgs}`,
+  ].join("\n");
+}

--- a/src/eval/providers/skillgrade/v1/scaffold.test.ts
+++ b/src/eval/providers/skillgrade/v1/scaffold.test.ts
@@ -73,7 +73,7 @@ describe("scaffoldEvalYaml", () => {
     expect(res.message).toMatch(/aborted/);
   });
 
-  it("surfaces ENOENT with an npm install hint", async () => {
+  it("surfaces ENOENT with a multi-option install hint", async () => {
     const res = await scaffoldEvalYaml({
       skillPath: "/tmp/skill",
       spawn: async () => {
@@ -83,8 +83,24 @@ describe("scaffoldEvalYaml", () => {
       },
     });
     expect(res.ok).toBe(false);
+    // Headline preserves the "not installed" keyword used by downstream
+    // regex matchers (cli.test.ts, operator dashboards, etc.).
     expect(res.message).toContain("not installed");
+    // Option 1 — reinstall agent-skill-manager (bundled path).
     expect(res.message).toContain("npm install -g agent-skill-manager");
+    // Option 2 — manually install skillgrade (issue #173 acceptance
+    // criterion: at least two fix paths, exact copy-paste command).
+    expect(res.message).toContain("npm install -g skillgrade");
+    // Option 3 — power-user escape hatch.
+    expect(res.message).toContain("ASM_SKILLGRADE_BIN");
+    // Docs link (issue #173 acceptance: reference docs explaining what
+    // skillgrade is and why it's needed).
+    expect(res.message).toContain(
+      "docs/skillgrade-integration.md#troubleshooting",
+    );
+    // Re-run hint preserves the user's skill path + the `init` subcommand
+    // so copy-paste re-runs the exact invocation (issue #173).
+    expect(res.message).toContain("asm eval /tmp/skill --runtime init");
   });
 
   it("surfaces non-ENOENT spawn failures verbatim", async () => {

--- a/src/eval/providers/skillgrade/v1/scaffold.ts
+++ b/src/eval/providers/skillgrade/v1/scaffold.ts
@@ -13,6 +13,7 @@
 
 import type { Spawner, SpawnResult } from "./spawn";
 import { bunSpawn } from "./spawn";
+import { formatSkillgradeMissingMessage } from "./missing-binary-message";
 
 /** Outcome of a scaffold attempt — consumed directly by the CLI. */
 export interface ScaffoldResult {
@@ -77,9 +78,18 @@ export async function scaffoldEvalYaml(
     });
   } catch (err: any) {
     // ENOENT / spawn failure — most commonly the binary is not on PATH.
+    // For ENOENT we emit a multi-option fix message (issue #173) so that
+    // users whose bundled install failed (offline, corrupted node_modules,
+    // custom deployment) have a manual fallback and know about the
+    // `ASM_SKILLGRADE_BIN` escape hatch. The re-run hint reuses the user's
+    // skill path so copy-paste re-runs the exact command they invoked.
     const message =
       err?.code === "ENOENT"
-        ? `${binary} not installed — reinstall agent-skill-manager to restore the bundled skillgrade: npm install -g agent-skill-manager`
+        ? formatSkillgradeMissingMessage({
+            headline: `${binary} not installed`,
+            skillPath: opts.skillPath,
+            rerunArgs: "--runtime init",
+          })
         : `failed to spawn ${binary}: ${err?.message ?? String(err)}`;
     return {
       ok: false,


### PR DESCRIPTION
Closes #173

## Summary

Reshapes the "skillgrade not installed" error into a three-option fix
message so users whose bundled install didn't land (offline,
registry-proxy strip, custom deployment, etc.) have a manual fallback
instead of just the reinstall suggestion. The two call sites (scaffold
ENOENT path and `applicable()` version-probe failure) now render
identical bodies while keeping their distinct headlines.

Companion to #172 (which fixed bundling so the reinstall path works for
most users). #173 covers the edge cases reinstall can't address.

## Approach

- New shared formatter `formatSkillgradeMissingMessage` — single source
  of truth for the multi-option body, so scaffold and `applicable()`
  stay in sync.
- Headlines stay distinct (`not installed` vs `not installed or
  unreachable`) because the failure modes differ: scaffold caught ENOENT
  before any probe, `applicable()` ran `--version` and couldn't tell
  ENOENT from a misbehaving binary.
- Re-run hint reuses `skillPath` from the appropriate source
  (`opts.skillPath` in scaffold → `--runtime init`, `ctx.skillPath` in
  `applicable()` → `--runtime`) so copy-paste re-runs the exact
  invocation the user just tried.
- Docs URL is the hosted GitHub anchor — error messages show up in
  terminals where relative paths don't click.

## Rendered message

```
skillgrade not installed or unreachable

  Fix options:
    1. Reinstall agent-skill-manager (bundles skillgrade):
         npm install -g agent-skill-manager
    2. Install skillgrade manually:
         npm install -g skillgrade
    3. Point ASM_SKILLGRADE_BIN at a local skillgrade binary:
         export ASM_SKILLGRADE_BIN=/path/to/skillgrade

  Docs: https://github.com/luongnv89/agent-skill-manager/blob/main/docs/skillgrade-integration.md#troubleshooting

  Then re-run:
    asm eval ./skills/skill-creator --runtime
```

## Changes

| File | Change |
|------|--------|
| `src/eval/providers/skillgrade/v1/missing-binary-message.ts` | New shared formatter + canonical docs URL |
| `src/eval/providers/skillgrade/v1/missing-binary-message.test.ts` | New unit tests for formatter shape, ordering, and args |
| `src/eval/providers/skillgrade/v1/scaffold.ts` | Route ENOENT message through formatter |
| `src/eval/providers/skillgrade/v1/index.ts` | Route `applicable()` binary-missing reason through formatter; broaden `installHint` to mention manual install |
| `src/eval/providers/skillgrade/v1/scaffold.test.ts` | Assert multi-option format + re-run hint |
| `src/eval/providers/skillgrade/v1/index.test.ts` | Assert multi-option format in both `applicable()` ENOENT and version-probe-fail branches |
| `docs/skillgrade-integration.md` | Update troubleshooting section to list the three fix paths |

## Test Results

- `bun test src/` — 1582 pass / 0 fail (new formatter tests added, existing assertions preserved)
- `bun test tests/e2e/npm-install-e2e.test.ts` — 18 pass / 0 fail (happy-path assertion `not.toContain("skillgrade not installed")` still holds — bundling isn't regressed, so the message never fires on that path)
- `bun run typecheck` — clean
- `bun run build` — clean

## Acceptance Criteria

- [x] Error lists at least two fix paths (reinstall asm + manual skillgrade install) — three provided
- [x] Includes exact copy-paste commands for the manual fallback (`npm install -g skillgrade`, `export ASM_SKILLGRADE_BIN=...`)
- [x] References a docs link explaining what skillgrade is and why it's needed — `docs/skillgrade-integration.md#troubleshooting`
- [x] Suggested re-run command reuses the skill path the user just invoked (both `--runtime` and `--runtime init` variants)