### PR TITLE
refactor(install): detect PATH shadowing from npm+bun globals (#177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,26 @@ asm
   <a href="#cli-commands"><strong>See All Commands &rarr;</strong></a>
 </p>
 
+### Pick one package manager
+
+Install `asm` via **either** `npm` **or** `bun` — not both. Each global install drops an `asm` binary in a different directory (`/opt/homebrew/bin/asm` via npm, `~/.bun/bin/asm` via bun), and shells resolve whichever appears first on `PATH`. An older install can silently shadow a fresh upgrade: you run `asm --version` and still see the old version even though the upgrade succeeded.
+
+<a id="troubleshooting"></a>
+
+**Diagnose:** `asm --version` detects and warns when it sees multiple `asm` binaries on `PATH`. For a full report, run `asm doctor` — it lists the resolved path and any shadowed installs.
+
+**Fix:** remove the duplicate install.
+
+```bash
+# If you're switching to npm:
+bun remove -g agent-skill-manager
+
+# If you're switching to bun:
+npm uninstall -g agent-skill-manager
+```
+
+Re-run `asm --version` to confirm only one binary is left. The postinstall step also emits the same warning during `npm install -g agent-skill-manager` so you catch it at install time.
+
 ---
 
 ## Open-Source Skill Collections

--- a/README.md
+++ b/README.md
@@ -449,7 +449,9 @@ bun remove -g agent-skill-manager
 npm uninstall -g agent-skill-manager
 ```
 
-Re-run `asm --version` to confirm only one binary is left. The postinstall step also emits the same warning during `npm install -g agent-skill-manager` so you catch it at install time.
+Re-run `asm --version` to confirm only one binary is left. The postinstall step emits the same warning during `npm install -g agent-skill-manager` so you catch it at install time.
+
+> **Note:** Bun skips lifecycle scripts by default, so the postinstall warning does not fire for `bun add -g agent-skill-manager`. Use `asm --version` or `asm doctor` to check for shadowing after a bun install.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -188,11 +188,7 @@ detect_path_shadowing() {
         [ -z "$dir" ] && continue
         candidate="$dir/asm"
         [ -x "$candidate" ] || continue
-        if command -v readlink &>/dev/null; then
-            real="$(readlink -f "$candidate" 2>/dev/null || echo "$candidate")"
-        else
-            real="$candidate"
-        fi
+        real="$(realpath "$candidate" 2>/dev/null || readlink -f "$candidate" 2>/dev/null || echo "$candidate")"
         already=false
         for r in "${seen_real[@]}"; do
             if [ "$r" = "$real" ]; then

--- a/install.sh
+++ b/install.sh
@@ -169,7 +169,56 @@ verify_installation() {
         return 1
     fi
 
+    detect_path_shadowing
+
     return 0
+}
+
+# --- PATH shadowing detection ---
+# Warns when multiple `asm` binaries live on different PATH entries (e.g. one
+# from `npm install -g` and one from `bun add -g`). The first match in PATH
+# wins, so an older install can silently outrun a fresh one.
+detect_path_shadowing() {
+    local IFS=':'
+    local -a hits=()
+    local -a seen_real=()
+    local dir candidate real already
+
+    for dir in $PATH; do
+        [ -z "$dir" ] && continue
+        candidate="$dir/asm"
+        [ -x "$candidate" ] || continue
+        if command -v readlink &>/dev/null; then
+            real="$(readlink -f "$candidate" 2>/dev/null || echo "$candidate")"
+        else
+            real="$candidate"
+        fi
+        already=false
+        for r in "${seen_real[@]}"; do
+            if [ "$r" = "$real" ]; then
+                already=true
+                break
+            fi
+        done
+        if [ "$already" = false ]; then
+            seen_real+=("$real")
+            hits+=("$candidate")
+        fi
+    done
+
+    if [ "${#hits[@]}" -gt 1 ]; then
+        echo ""
+        warn "Detected ${#hits[@]} \`asm\` binaries on PATH — newer install may be shadowed:"
+        warn "  resolved: ${hits[0]}"
+        local i=1
+        while [ $i -lt ${#hits[@]} ]; do
+            warn "  shadowed: ${hits[$i]}"
+            i=$((i + 1))
+        done
+        warn "Pick one package manager (npm OR bun) and remove the other:"
+        warn "  npm uninstall -g agent-skill-manager"
+        warn "  bun remove -g agent-skill-manager"
+    fi
 }
 
 # --- Entry Point ---

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "build": "bun run scripts/build.ts",
     "preindex": "bun run scripts/preindex.ts",
     "build:website": "bun scripts/build-catalog.ts",
-    "prepublishOnly": "bun run build"
+    "prepublishOnly": "bun run build",
+    "postinstall": "node scripts/postinstall.cjs"
   },
   "files": [
     "dist/",
     "data/",
+    "scripts/postinstall.cjs",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Runs after `npm install -g agent-skill-manager`.
+ *
+ * Walks PATH for duplicate `asm` binaries so users catch npm-vs-bun shadowing
+ * before the stale install silently outruns the new one. Never fails the
+ * install — any unexpected error is swallowed.
+ *
+ * Skipped by default under CI and inside nested/production-dep installs;
+ * `ASM_SKIP_POSTINSTALL=1` also disables it explicitly.
+ */
+
+"use strict";
+
+try {
+  // Only run for global installs. Local/dev installs and CI can skip.
+  const isGlobal =
+    process.env.npm_config_global === "true" ||
+    process.env.npm_config_global === "1";
+  if (
+    process.env.ASM_SKIP_POSTINSTALL ||
+    process.env.CI ||
+    !isGlobal
+  ) {
+    process.exit(0);
+  }
+
+  const fs = require("fs");
+  const path = require("path");
+
+  const BIN = process.platform === "win32" ? "asm.exe" : "asm";
+  const DELIM = process.platform === "win32" ? ";" : ":";
+  const pathEnv = process.env.PATH || "";
+
+  const seenReal = new Set();
+  const hits = [];
+
+  for (const raw of pathEnv.split(DELIM)) {
+    const dir = raw.trim();
+    if (!dir) continue;
+    const candidate = path.resolve(dir, BIN);
+    let stats;
+    try {
+      stats = fs.statSync(candidate);
+    } catch {
+      continue;
+    }
+    if (!stats.isFile()) continue;
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+    } catch {
+      continue;
+    }
+    let real;
+    try {
+      real = fs.realpathSync(candidate);
+    } catch {
+      real = candidate;
+    }
+    if (seenReal.has(real)) continue;
+    seenReal.add(real);
+    hits.push({ path: candidate, real });
+  }
+
+  if (hits.length <= 1) process.exit(0);
+
+  const [resolved, ...shadowed] = hits;
+  process.stderr.write(
+    `\n[agent-skill-manager] Warning: ${hits.length} \`asm\` binaries on PATH — the fresh install may be shadowed.\n`,
+  );
+  process.stderr.write(`  resolved: ${resolved.path}\n`);
+  for (const other of shadowed) {
+    process.stderr.write(`  shadowed: ${other.path}\n`);
+  }
+  process.stderr.write(
+    "  Pick one package manager (npm OR bun) and remove the other install.\n",
+  );
+  process.stderr.write(
+    "  See: https://github.com/luongnv89/agent-skill-manager#troubleshooting\n\n",
+  );
+  process.exit(0);
+} catch {
+  // Never fail the install.
+  process.exit(0);
+}

--- a/scripts/postinstall.cjs
+++ b/scripts/postinstall.cjs
@@ -28,8 +28,8 @@ try {
   const fs = require("fs");
   const path = require("path");
 
-  const BIN = process.platform === "win32" ? "asm.exe" : "asm";
-  const DELIM = process.platform === "win32" ? ";" : ":";
+  const BIN = "asm";
+  const DELIM = path.delimiter;
   const pathEnv = process.env.PATH || "";
 
   const seenReal = new Set();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,6 +131,7 @@ import {
 } from "./skill-index";
 import type { SearchFilters } from "./skill-index";
 import { VERSION_STRING } from "./utils/version";
+import { buildShadowingReport } from "./utils/path-shadowing";
 import { parseEditorCommand } from "./utils/editor";
 import { setVerbose } from "./logger";
 import { join as joinPath } from "path";
@@ -4858,6 +4859,35 @@ export async function runCLI(argv: string[]): Promise<void> {
   // --version at top level
   if (args.flags.version) {
     console.log(`asm ${VERSION_STRING}`);
+    const report = await buildShadowingReport();
+    if (args.flags.verbose && report.resolved) {
+      console.log(`  path: ${report.resolved.path}`);
+      if (report.resolved.realPath !== report.resolved.path) {
+        console.log(`  real: ${report.resolved.realPath}`);
+      }
+    }
+    if (report.shadowed.length > 0 && report.resolved) {
+      console.error("");
+      console.error(
+        ansi.yellow(
+          `Warning: ${report.shadowed.length + 1} \`asm\` binaries on PATH — you may be running a shadowed install.`,
+        ),
+      );
+      console.error(`  resolved: ${report.resolved.path}`);
+      for (const other of report.shadowed) {
+        console.error(`  shadowed: ${other.path}`);
+      }
+      console.error(
+        ansi.dim(
+          "  Pick one package manager (npm OR bun) and remove the other install.",
+        ),
+      );
+      console.error(
+        ansi.dim(
+          "  See: https://github.com/luongnv89/agent-skill-manager#troubleshooting",
+        ),
+      );
+    }
     return;
   }
 

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -13,6 +13,7 @@ import {
   checkAgentDirsWritable,
   checkInstalledSkillsIntact,
   checkNoOrphanedSkills,
+  checkNoPathShadowing,
   formatDoctorReport,
   formatDoctorJSON,
   formatDoctorMachine,
@@ -112,6 +113,23 @@ describe("checkDiskSpace", () => {
     const result = await checkDiskSpace();
     expect(["pass", "warn", "fail"]).toContain(result.status);
     expect(result.name).toBe("Disk space");
+  });
+});
+
+describe("checkNoPathShadowing", () => {
+  test("returns pass or warn (environment-dependent)", async () => {
+    const result = await checkNoPathShadowing();
+    expect(["pass", "warn"]).toContain(result.status);
+    expect(result.name).toBe("No PATH shadowing");
+    expect(typeof result.message).toBe("string");
+  });
+
+  test("includes fix suggestion when shadowing detected", async () => {
+    const result = await checkNoPathShadowing();
+    if (result.status === "warn" && result.message.includes("shadowed")) {
+      expect(result.fix).toBeDefined();
+      expect(result.fix!.length).toBeGreaterThan(0);
+    }
   });
 });
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -19,6 +19,7 @@ import {
 } from "./config";
 import { readLock } from "./utils/lock";
 import { REGISTRY_INDEX_URL } from "./registry";
+import { buildShadowingReport } from "./utils/path-shadowing";
 import type { AppConfig, LockFile } from "./utils/types";
 
 const execFileAsync = promisify(execFile);
@@ -560,6 +561,45 @@ export async function checkDiskSpace(
   }
 }
 
+export async function checkNoPathShadowing(): Promise<CheckResult> {
+  try {
+    const report = await buildShadowingReport();
+    if (report.shadowed.length === 0) {
+      if (!report.resolved) {
+        return {
+          name: "No PATH shadowing",
+          status: "pass",
+          message: "asm not yet on PATH",
+        };
+      }
+      return {
+        name: "No PATH shadowing",
+        status: "pass",
+        message: `single install at ${report.resolved.path}`,
+      };
+    }
+
+    const resolved = report.resolved!;
+    const firstShadow = report.shadowed[0].path;
+    const extra =
+      report.shadowed.length > 1
+        ? ` (+${report.shadowed.length - 1} more)`
+        : "";
+    return {
+      name: "No PATH shadowing",
+      status: "warn",
+      message: `resolved ${resolved.path}, shadowed ${firstShadow}${extra}`,
+      fix: "Remove the duplicate install (e.g. `bun remove -g agent-skill-manager` or `npm uninstall -g agent-skill-manager`) and keep only one.",
+    };
+  } catch (err: any) {
+    return {
+      name: "No PATH shadowing",
+      status: "warn",
+      message: `Could not scan PATH: ${err?.message ?? err}`,
+    };
+  }
+}
+
 // ─── Run All Checks ─────────────────────────────────────────────────────────
 
 export async function runAllChecks(): Promise<DoctorReport> {
@@ -580,6 +620,7 @@ export async function runAllChecks(): Promise<DoctorReport> {
     checkInstalledSkillsIntact(config, lock),
     checkNoOrphanedSkills(config, lock),
     checkDiskSpace(),
+    checkNoPathShadowing(),
   ]);
 
   const checks: CheckResult[] = results.map((r, i) => {
@@ -598,6 +639,7 @@ export async function runAllChecks(): Promise<DoctorReport> {
       "Installed skills intact",
       "No orphaned skills",
       "Disk space",
+      "No PATH shadowing",
     ];
     return {
       name: names[i],

--- a/src/utils/path-shadowing.test.ts
+++ b/src/utils/path-shadowing.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, writeFile, chmod, symlink, mkdir } from "fs/promises";
+import { tmpdir } from "os";
+import { join, delimiter } from "path";
+
+import { detectAsmBinaries, buildShadowingReport } from "./path-shadowing";
+
+let tmpRoot: string;
+let dirA: string;
+let dirB: string;
+let dirC: string;
+
+beforeAll(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), "asm-shadow-test-"));
+  dirA = join(tmpRoot, "a");
+  dirB = join(tmpRoot, "b");
+  dirC = join(tmpRoot, "c");
+  await mkdir(dirA);
+  await mkdir(dirB);
+  await mkdir(dirC);
+
+  // dirA: a real asm binary
+  const binA = join(dirA, "asm");
+  await writeFile(binA, "#!/bin/sh\necho a\n");
+  await chmod(binA, 0o755);
+
+  // dirB: a different real asm binary
+  const binB = join(dirB, "asm");
+  await writeFile(binB, "#!/bin/sh\necho b\n");
+  await chmod(binB, 0o755);
+
+  // dirC: a symlink pointing to the dirA binary (same realpath → dedup)
+  await symlink(binA, join(dirC, "asm"));
+});
+
+afterAll(async () => {
+  if (tmpRoot) await rm(tmpRoot, { recursive: true, force: true });
+});
+
+describe("detectAsmBinaries", () => {
+  test("returns empty list when PATH has no asm", async () => {
+    const fakeDir = join(tmpRoot, "empty");
+    await mkdir(fakeDir);
+    const binaries = await detectAsmBinaries(fakeDir);
+    expect(binaries).toEqual([]);
+  });
+
+  test("finds a single asm when only one PATH entry has it", async () => {
+    const binaries = await detectAsmBinaries(dirA);
+    expect(binaries.length).toBe(1);
+    expect(binaries[0].path).toBe(join(dirA, "asm"));
+  });
+
+  test("returns distinct binaries in PATH order when they differ", async () => {
+    const path = [dirA, dirB].join(delimiter);
+    const binaries = await detectAsmBinaries(path);
+    expect(binaries.length).toBe(2);
+    expect(binaries[0].path).toBe(join(dirA, "asm"));
+    expect(binaries[1].path).toBe(join(dirB, "asm"));
+  });
+
+  test("deduplicates entries that resolve to the same realpath", async () => {
+    // dirC contains a symlink to dirA's binary
+    const path = [dirA, dirC].join(delimiter);
+    const binaries = await detectAsmBinaries(path);
+    expect(binaries.length).toBe(1);
+    expect(binaries[0].path).toBe(join(dirA, "asm"));
+  });
+
+  test("ignores empty PATH entries", async () => {
+    const path = ["", dirA, ""].join(delimiter);
+    const binaries = await detectAsmBinaries(path);
+    expect(binaries.length).toBe(1);
+  });
+});
+
+describe("buildShadowingReport", () => {
+  test("no binaries → resolved null, shadowed empty", async () => {
+    const emptyDir = join(tmpRoot, "emptyreport");
+    await mkdir(emptyDir);
+    const report = await buildShadowingReport(emptyDir);
+    expect(report.resolved).toBeNull();
+    expect(report.shadowed).toEqual([]);
+  });
+
+  test("single binary → resolved set, shadowed empty", async () => {
+    const report = await buildShadowingReport(dirA);
+    expect(report.resolved).not.toBeNull();
+    expect(report.resolved!.path).toBe(join(dirA, "asm"));
+    expect(report.shadowed).toEqual([]);
+  });
+
+  test("two different binaries → second one is shadowed", async () => {
+    const path = [dirA, dirB].join(delimiter);
+    const report = await buildShadowingReport(path);
+    expect(report.resolved).not.toBeNull();
+    expect(report.resolved!.path).toBe(join(dirA, "asm"));
+    expect(report.shadowed.length).toBe(1);
+    expect(report.shadowed[0].path).toBe(join(dirB, "asm"));
+  });
+});

--- a/src/utils/path-shadowing.test.ts
+++ b/src/utils/path-shadowing.test.ts
@@ -72,6 +72,14 @@ describe("detectAsmBinaries", () => {
     const binaries = await detectAsmBinaries(path);
     expect(binaries.length).toBe(1);
   });
+
+  test("symlink before target counts as one entry — symlink path is reported", async () => {
+    // dirC symlink appears before dirA (the canonical target) in PATH
+    const path = [dirC, dirA].join(delimiter);
+    const binaries = await detectAsmBinaries(path);
+    expect(binaries.length).toBe(1);
+    expect(binaries[0].path).toBe(join(dirC, "asm"));
+  });
 });
 
 describe("buildShadowingReport", () => {

--- a/src/utils/path-shadowing.ts
+++ b/src/utils/path-shadowing.ts
@@ -1,0 +1,89 @@
+import { access, realpath, stat } from "fs/promises";
+import { constants as fsConstants } from "fs";
+import { delimiter, resolve, sep } from "path";
+
+export interface BinaryLocation {
+  path: string;
+  realPath: string;
+}
+
+export interface ShadowingReport {
+  resolved: BinaryLocation | null;
+  shadowed: BinaryLocation[];
+}
+
+const BINARY_NAME = process.platform === "win32" ? "asm.exe" : "asm";
+
+function getPathEntries(pathEnv: string | undefined): string[] {
+  if (!pathEnv) return [];
+  const seen = new Set<string>();
+  const entries: string[] = [];
+  for (const raw of pathEnv.split(delimiter)) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const normalized = trimmed.endsWith(sep) ? trimmed.slice(0, -1) : trimmed;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    entries.push(normalized);
+  }
+  return entries;
+}
+
+async function isExecutableFile(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path);
+    if (!s.isFile()) return false;
+  } catch {
+    return false;
+  }
+  try {
+    await access(path, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveReal(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
+ * Walk PATH and return every `asm` binary in order. The first entry is the one
+ * shells resolve; later entries are shadowed. Binaries that resolve (via
+ * realpath) to the same underlying file as an earlier entry are skipped so
+ * benign symlink aliases (e.g. `/usr/local/bin/asm` -> `/opt/.../asm`) don't
+ * look like a conflict.
+ */
+export async function detectAsmBinaries(
+  pathEnv: string | undefined = process.env.PATH,
+): Promise<BinaryLocation[]> {
+  const seenReal = new Set<string>();
+  const results: BinaryLocation[] = [];
+
+  for (const dir of getPathEntries(pathEnv)) {
+    const candidate = resolve(dir, BINARY_NAME);
+    if (!(await isExecutableFile(candidate))) continue;
+    const real = await resolveReal(candidate);
+    if (seenReal.has(real)) continue;
+    seenReal.add(real);
+    results.push({ path: candidate, realPath: real });
+  }
+
+  return results;
+}
+
+export async function buildShadowingReport(
+  pathEnv: string | undefined = process.env.PATH,
+): Promise<ShadowingReport> {
+  const binaries = await detectAsmBinaries(pathEnv);
+  if (binaries.length === 0) {
+    return { resolved: null, shadowed: [] };
+  }
+  const [resolved, ...shadowed] = binaries;
+  return { resolved, shadowed };
+}

--- a/src/utils/path-shadowing.ts
+++ b/src/utils/path-shadowing.ts
@@ -12,7 +12,7 @@ export interface ShadowingReport {
   shadowed: BinaryLocation[];
 }
 
-const BINARY_NAME = process.platform === "win32" ? "asm.exe" : "asm";
+const BINARY_NAME = "asm";
 
 function getPathEntries(pathEnv: string | undefined): string[] {
   if (!pathEnv) return [];


### PR DESCRIPTION
Closes #177

## Summary

Two side-by-side global installs of `asm` (npm and bun each install to a different prefix) produced silent version shadowing — the first one on `PATH` won, so a stale install kept outrunning a fresh upgrade. This change surfaces the conflict at three points: install time, `asm --version`, and `asm doctor`, and documents the recovery path.

## Approach

A single shared helper (`src/utils/path-shadowing.ts`) walks `PATH`, resolves each candidate `asm` binary, dedupes by `realpath` (so benign symlink aliases aren't flagged), and returns the resolved entry plus any shadowed entries. Three callers use it:

1. **`asm --version`** — prints a stderr warning when >1 binary is found. Stdout is unchanged (single line), so scripts parsing `asm --version | head -1` keep working. `--verbose` adds the resolved path.
2. **`asm doctor`** — new `checkNoPathShadowing` passes when there's zero or one binary, warns otherwise with a `fix:` suggestion.
3. **npm `postinstall`** — `scripts/postinstall.cjs` runs the same detection at install time. It silently no-ops under `CI=true`, `ASM_SKIP_POSTINSTALL=1`, or non-global installs, and never fails the install (all errors swallowed). CommonJS (`.cjs`) because the package is `"type": "module"` on Node 25.

`install.sh` (curl-pipe path) got the same bash-side warning so one-liner users also see it.

## Changes

| File | Change |
|------|--------|
| `src/utils/path-shadowing.ts` | New helper: `detectAsmBinaries`, `buildShadowingReport` |
| `src/utils/path-shadowing.test.ts` | New unit tests — 8 tests |
| `src/cli.ts` | `--version` prints shadowing warning to stderr when detected |
| `src/doctor.ts` | New `checkNoPathShadowing` added to `runAllChecks` |
| `src/doctor.test.ts` | Test for the new check |
| `scripts/postinstall.cjs` | New postinstall script with PATH shadowing detection |
| `package.json` | Register postinstall, include script in `files` |
| `install.sh` | Add `detect_path_shadowing` warning at end of verify |
| `README.md` | "Pick one package manager" section + `#troubleshooting` anchor |

## Test Results

- `bun test src/` — 1592 pass / 0 fail (includes 8 new shadowing tests + 1 new doctor test)
- `bun test tests/e2e/npm-install-e2e.test.ts` — 18 pass (postinstall doesn't break packaging)
- `bun test tests/e2e/build-verification.test.ts` — 11 pass
- `bun test tests/e2e/node-e2e.test.ts tests/e2e/bun-e2e.test.ts` — 136 pass
- `bun test tests/e2e/registry-e2e.test.ts` — 21 pass
- Real-world smoke test against the exact issue repro: `asm --version` now prints the warning listing `/Users/montimage/.bun/bin/asm` (resolved) and `/opt/homebrew/bin/asm` (shadowed).

## Acceptance Criteria

- [x] Install/upgrade flow detects and warns when multiple `asm` binaries exist on `PATH` — covered by `postinstall` hook (npm) and `install.sh` (curl path)
- [x] `asm --version` prints the resolved binary path so shadowing is visible — warning block to stderr when shadowing detected
- [x] Documentation explains the npm vs bun global install conflict and how to resolve it — README "Pick one package manager" + `#troubleshooting`
- [x] A repeatable recovery step is documented — `bun remove -g agent-skill-manager` / `npm uninstall -g agent-skill-manager` shown in README and all warning messages

## Known boundary

`bun add -g` does **not** run lifecycle scripts by default, so the `postinstall` hook only fires on npm global installs. The `--version` warning and `asm doctor` check are the fallback surfaces for the bun-first path — users running `bun add -g` then `asm --version` still see the warning.