### PR TITLE
feat(index): add heygen-com/hyperframes

### DIFF
--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-03-28T00:00:00Z",
+  "updatedAt": "2026-04-20T00:00:00Z",
   "repos": [
     {
       "source": "github:anthropics/skills",
@@ -215,6 +215,15 @@
       "repo": "academic-research-skills",
       "description": "Academic and research-oriented workflow skills for students and researchers",
       "maintainer": "@Imbad0202",
+      "enabled": true
+    },
+    {
+      "source": "github:heygen-com/hyperframes",
+      "url": "https://github.com/heygen-com/hyperframes",
+      "owner": "heygen-com",
+      "repo": "hyperframes",
+      "description": "Write HTML. Render video. Built for agents.",
+      "maintainer": "@heygen-com",
       "enabled": true
     }
   ]

--- a/data/skill-index/heygen-com_hyperframes.json
+++ b/data/skill-index/heygen-com_hyperframes.json
@@ -1,0 +1,69 @@
+{
+  "repoUrl": "https://github.com/heygen-com/hyperframes.git",
+  "owner": "heygen-com",
+  "repo": "hyperframes",
+  "updatedAt": "2026-04-20T06:25:42.873Z",
+  "skillCount": 5,
+  "skills": [
+    {
+      "name": "gsap",
+      "description": "GSAP animation reference for HyperFrames. Covers gsap.to(), from(), fromTo(), easing, stagger, defaults, timelines (gsap.timeline(), position parameter, labels, nesting, playback), and performance (transforms, will-change, quickTo). Use when writing GSAP animations in HyperFrames compositions.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:heygen-com/hyperframes:skills/gsap",
+      "relPath": "skills/gsap",
+      "verified": true
+    },
+    {
+      "name": "hyperframes",
+      "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For CLI commands (init, lint, preview, render, transcribe, tts) see the hyperframes-cli skill.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:heygen-com/hyperframes:skills/hyperframes",
+      "relPath": "skills/hyperframes",
+      "verified": true
+    },
+    {
+      "name": "hyperframes-cli",
+      "description": "HyperFrames CLI tool — hyperframes init, lint, preview, render, transcribe, tts, doctor, browser, info, upgrade, compositions, docs, benchmark. Use when scaffolding a project, linting or validating compositions, previewing in the studio, rendering to video, transcribing audio, generating TTS, or troubleshooting the HyperFrames environment.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-cli",
+      "relPath": "skills/hyperframes-cli",
+      "verified": true
+    },
+    {
+      "name": "hyperframes-registry",
+      "description": "Install and wire registry blocks and components into HyperFrames compositions. Use when running hyperframes add, installing a block or component, wiring an installed item into index.html, or working with hyperframes.json. Covers the add command, install locations, block sub-composition wiring, component snippet merging, and registry discovery.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-registry",
+      "relPath": "skills/hyperframes-registry",
+      "verified": true
+    },
+    {
+      "name": "website-to-hyperframes",
+      "description": "Capture a website and create a HyperFrames video from it. Use when: (1) a user provides a URL and wants a video, (2) someone says \"capture this site\", \"turn this into a video\", \"make a promo from my site\", (3) the user wants a social ad, product tour, or any video based on an existing website, (4) the user shares a link and asks for any kind of video content. Even if the user just pastes a URL — this is the skill to use.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:heygen-com/hyperframes:skills/website-to-hyperframes",
+      "relPath": "skills/website-to-hyperframes",
+      "verified": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added `heygen-com/hyperframes` to the curated skill index
- 5 new skills indexed

### New Repo
| Repo | Skills | Description |
|------|--------|-------------|
| [heygen-com/hyperframes](https://github.com/heygen-com/hyperframes) | 5 | Write HTML. Render video. Built for agents. |

### Skills Added
- `hyperframes` — HTML-based video compositions (animations, captions, voiceovers, transitions)
- `hyperframes-cli` — CLI commands (init, lint, preview, render, transcribe, tts, etc.)
- `hyperframes-registry` — Install and wire registry blocks and components
- `website-to-hyperframes` — Capture a website and turn it into a video
- `gsap` — GSAP animation reference for HyperFrames

### Audit Summary
All 5 skills passed the lightweight audit. Frontmatter complete (name + description present). No suspicious patterns detected (no shell exec, no credential patterns, no obfuscation).

## Test Plan
- [x] `data/skill-index-resources.json` is valid JSON and includes new entry
- [x] `data/skill-index/heygen-com_hyperframes.json` generated (5 skills)
- [x] Pre-commit unit tests pass
- [ ] CI passes
- [ ] `website/catalog.json` rebuilt on merge via deploy-website workflow