### PR TITLE
feat(skills): show est. token count + asm eval scores in website, TUI, CLI

### DIFF
--- a/data/skill-index/Affitor_affiliate-skills.json
+++ b/data/skill-index/Affitor_affiliate-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Affitor/affiliate-skills.git",
   "owner": "Affitor",
   "repo": "affiliate-skills",
-  "updatedAt": "2026-04-20T06:33:11.236Z",
+  "updatedAt": "2026-04-20T07:44:41.465Z",
   "skillCount": 53,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/analytics/ab-test-generator",
       "relPath": "skills/analytics/ab-test-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2731,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.386Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "affiliate-blog-builder",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/blog/affiliate-blog-builder",
       "relPath": "skills/blog/affiliate-blog-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4998,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.388Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "affiliate-program-search",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/research/affiliate-program-search",
       "relPath": "skills/research/affiliate-program-search",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2655,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.389Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "bio-link-deployer",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/distribution/bio-link-deployer",
       "relPath": "skills/distribution/bio-link-deployer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3823,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.390Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "bonus-stack-builder",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/landing/bonus-stack-builder",
       "relPath": "skills/landing/bonus-stack-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3133,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.391Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "category-designer",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/meta/category-designer",
       "relPath": "skills/meta/category-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3294,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.392Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "commission-calculator",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/research/commission-calculator",
       "relPath": "skills/research/commission-calculator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3984,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.393Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "comparison-post-writer",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/blog/comparison-post-writer",
       "relPath": "skills/blog/comparison-post-writer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4259,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.394Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "competitor-spy",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/research/competitor-spy",
       "relPath": "skills/research/competitor-spy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4243,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.395Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "compliance-checker",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/meta/compliance-checker",
       "relPath": "skills/meta/compliance-checker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3213,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.396Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "content-angle-ranker",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/research/content-angle-ranker",
       "relPath": "skills/research/content-angle-ranker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6022,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.398Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "content-decay-detector",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-decay-detector",
       "relPath": "skills/blog/content-decay-detector",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2430,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.399Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "content-moat-calculator",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/blog/content-moat-calculator",
       "relPath": "skills/blog/content-moat-calculator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2618,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.400Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "content-pillar-atomizer",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/content/content-pillar-atomizer",
       "relPath": "skills/content/content-pillar-atomizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3683,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.401Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "content-repurposer",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/automation/content-repurposer",
       "relPath": "skills/automation/content-repurposer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3171,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.402Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "content-research-brief",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/content/content-research-brief",
       "relPath": "skills/content/content-research-brief",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4860,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.403Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "conversion-tracker",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/analytics/conversion-tracker",
       "relPath": "skills/analytics/conversion-tracker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2434,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.404Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "email-automation-builder",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/automation/email-automation-builder",
       "relPath": "skills/automation/email-automation-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3786,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.405Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "email-drip-sequence",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/distribution/email-drip-sequence",
       "relPath": "skills/distribution/email-drip-sequence",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3768,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.406Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "funnel-planner",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/meta/funnel-planner",
       "relPath": "skills/meta/funnel-planner",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2889,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.407Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "github-pages-deployer",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/distribution/github-pages-deployer",
       "relPath": "skills/distribution/github-pages-deployer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4625,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.408Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "grand-slam-offer",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/landing/grand-slam-offer",
       "relPath": "skills/landing/grand-slam-offer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3230,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.409Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "guarantee-generator",
@@ -279,7 +1401,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/landing/guarantee-generator",
       "relPath": "skills/landing/guarantee-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2896,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.410Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "how-to-tutorial-writer",
@@ -291,7 +1464,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/blog/how-to-tutorial-writer",
       "relPath": "skills/blog/how-to-tutorial-writer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4400,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.412Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "infographic-generator",
@@ -303,7 +1527,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/content/infographic-generator",
       "relPath": "skills/content/infographic-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5190,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.413Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "internal-linking-optimizer",
@@ -315,7 +1590,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/analytics/internal-linking-optimizer",
       "relPath": "skills/analytics/internal-linking-optimizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2885,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.414Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "keyword-cluster-architect",
@@ -327,7 +1653,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/blog/keyword-cluster-architect",
       "relPath": "skills/blog/keyword-cluster-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2792,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.415Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "landing-page-creator",
@@ -339,7 +1716,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/landing/landing-page-creator",
       "relPath": "skills/landing/landing-page-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4256,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.416Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "list-affitor-program",
@@ -351,7 +1779,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/research/list-affitor-program",
       "relPath": "skills/research/list-affitor-program",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4631,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.418Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "list-affitor-skill",
@@ -363,7 +1842,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/meta/list-affitor-skill",
       "relPath": "skills/meta/list-affitor-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5077,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.419Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "listicle-generator",
@@ -375,7 +1905,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/blog/listicle-generator",
       "relPath": "skills/blog/listicle-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4116,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.420Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "monopoly-niche-finder",
@@ -387,7 +1968,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/research/monopoly-niche-finder",
       "relPath": "skills/research/monopoly-niche-finder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2763,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.421Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "multi-program-manager",
@@ -399,7 +2031,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/automation/multi-program-manager",
       "relPath": "skills/automation/multi-program-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2790,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.422Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "niche-opportunity-finder",
@@ -411,7 +2094,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/research/niche-opportunity-finder",
       "relPath": "skills/research/niche-opportunity-finder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3122,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.423Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "paid-ad-copy-writer",
@@ -423,7 +2157,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/automation/paid-ad-copy-writer",
       "relPath": "skills/automation/paid-ad-copy-writer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3728,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.424Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "performance-report",
@@ -435,7 +2220,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/analytics/performance-report",
       "relPath": "skills/analytics/performance-report",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2976,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.425Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "product-showcase-page",
@@ -447,7 +2283,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/landing/product-showcase-page",
       "relPath": "skills/landing/product-showcase-page",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4159,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.426Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "proprietary-data-generator",
@@ -459,7 +2346,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/automation/proprietary-data-generator",
       "relPath": "skills/automation/proprietary-data-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3352,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.427Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "purple-cow-audit",
@@ -471,7 +2409,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/research/purple-cow-audit",
       "relPath": "skills/research/purple-cow-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2887,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.428Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "reddit-post-writer",
@@ -483,7 +2472,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/content/reddit-post-writer",
       "relPath": "skills/content/reddit-post-writer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4949,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.429Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "self-improver",
@@ -495,7 +2535,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/meta/self-improver",
       "relPath": "skills/meta/self-improver",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3156,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.430Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "seo-audit",
@@ -507,7 +2598,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/analytics/seo-audit",
       "relPath": "skills/analytics/seo-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2985,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.431Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "skill-finder",
@@ -519,7 +2661,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/meta/skill-finder",
       "relPath": "skills/meta/skill-finder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2642,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.432Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "social-media-scheduler",
@@ -531,7 +2724,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/distribution/social-media-scheduler",
       "relPath": "skills/distribution/social-media-scheduler",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4400,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.433Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "squeeze-page-builder",
@@ -543,7 +2787,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/landing/squeeze-page-builder",
       "relPath": "skills/landing/squeeze-page-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4335,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.434Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "tiktok-script-writer",
@@ -555,7 +2850,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/content/tiktok-script-writer",
       "relPath": "skills/content/tiktok-script-writer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4547,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.436Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "traffic-analyzer",
@@ -567,7 +2913,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/research/traffic-analyzer",
       "relPath": "skills/research/traffic-analyzer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4342,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.437Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "trending-content-scout",
@@ -579,7 +2976,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/research/trending-content-scout",
       "relPath": "skills/research/trending-content-scout",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6286,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.439Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "twitter-thread-writer",
@@ -591,7 +3039,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/content/twitter-thread-writer",
       "relPath": "skills/content/twitter-thread-writer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4393,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.440Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "value-ladder-architect",
@@ -603,7 +3102,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/landing/value-ladder-architect",
       "relPath": "skills/landing/value-ladder-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3067,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.441Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "viral-post-writer",
@@ -615,7 +3165,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/content/viral-post-writer",
       "relPath": "skills/content/viral-post-writer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4488,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.442Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "webinar-registration-page",
@@ -627,7 +3228,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:skills/landing/webinar-registration-page",
       "relPath": "skills/landing/webinar-registration-page",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5185,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.443Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "your-skill-name",
@@ -639,7 +3291,58 @@
       "allowedTools": [],
       "installUrl": "github:Affitor/affiliate-skills:template",
       "relPath": "template",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1142,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:41.444Z",
+        "evaluatedVersion": "1.0"
+      }
     }
   ]
 }

--- a/data/skill-index/Eronred_aso-skills.json
+++ b/data/skill-index/Eronred_aso-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Eronred/aso-skills.git",
   "owner": "Eronred",
   "repo": "aso-skills",
-  "updatedAt": "2026-04-20T06:33:17.305Z",
+  "updatedAt": "2026-04-20T07:45:09.817Z",
   "skillCount": 30,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/ab-test-store-listing",
       "relPath": "skills/ab-test-store-listing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2263,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.791Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "android-aso",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/android-aso",
       "relPath": "skills/android-aso",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1937,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.791Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "app-analytics",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/app-analytics",
       "relPath": "skills/app-analytics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1939,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.792Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "app-clips",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/app-clips",
       "relPath": "skills/app-clips",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1847,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.793Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "app-icon-optimization",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/app-icon-optimization",
       "relPath": "skills/app-icon-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1871,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.793Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "app-launch",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/app-launch",
       "relPath": "skills/app-launch",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1796,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.794Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "app-marketing-context",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/app-marketing-context",
       "relPath": "skills/app-marketing-context",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1022,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.795Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "app-store-featured",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/app-store-featured",
       "relPath": "skills/app-store-featured",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2311,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.796Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "apple-search-ads",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/apple-search-ads",
       "relPath": "skills/apple-search-ads",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2291,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.796Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "asc-metrics",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/asc-metrics",
       "relPath": "skills/asc-metrics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1522,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.797Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "aso-audit",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/aso-audit",
       "relPath": "skills/aso-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1999,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.798Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "competitor-analysis",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/competitor-analysis",
       "relPath": "skills/competitor-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1799,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.798Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "competitor-tracking",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/competitor-tracking",
       "relPath": "skills/competitor-tracking",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1739,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.799Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "crash-analytics",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/crash-analytics",
       "relPath": "skills/crash-analytics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1711,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.799Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "in-app-events",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/in-app-events",
       "relPath": "skills/in-app-events",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2038,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.800Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "keyword-research",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/keyword-research",
       "relPath": "skills/keyword-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1495,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.801Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "localization",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/localization",
       "relPath": "skills/localization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1734,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.802Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "market-movers",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/market-movers",
       "relPath": "skills/market-movers",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1403,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.802Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "market-pulse",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/market-pulse",
       "relPath": "skills/market-pulse",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1567,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.803Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "metadata-optimization",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/metadata-optimization",
       "relPath": "skills/metadata-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1729,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.803Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "monetization-strategy",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/monetization-strategy",
       "relPath": "skills/monetization-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1962,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.804Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "onboarding-optimization",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/onboarding-optimization",
       "relPath": "skills/onboarding-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2055,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.804Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "press-and-pr",
@@ -279,7 +1401,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/press-and-pr",
       "relPath": "skills/press-and-pr",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2205,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.805Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "rating-prompt-strategy",
@@ -291,7 +1464,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/rating-prompt-strategy",
       "relPath": "skills/rating-prompt-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2032,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.806Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "retention-optimization",
@@ -303,7 +1527,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/retention-optimization",
       "relPath": "skills/retention-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1756,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.807Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "review-management",
@@ -315,7 +1590,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/review-management",
       "relPath": "skills/review-management",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1774,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.807Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "screenshot-optimization",
@@ -327,7 +1653,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/screenshot-optimization",
       "relPath": "skills/screenshot-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1580,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.808Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "seasonal-aso",
@@ -339,7 +1716,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/seasonal-aso",
       "relPath": "skills/seasonal-aso",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1616,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.808Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "subscription-lifecycle",
@@ -351,7 +1779,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/subscription-lifecycle",
       "relPath": "skills/subscription-lifecycle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2552,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.809Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ua-campaign",
@@ -363,7 +1842,58 @@
       "allowedTools": [],
       "installUrl": "github:Eronred/aso-skills:skills/ua-campaign",
       "relPath": "skills/ua-campaign",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2101,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:09.810Z",
+        "evaluatedVersion": "1.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/GPTomics_bioSkills.json
+++ b/data/skill-index/GPTomics_bioSkills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/GPTomics/bioSkills.git",
   "owner": "GPTomics",
   "repo": "bioSkills",
-  "updatedAt": "2026-04-20T06:33:29.401Z",
+  "updatedAt": "2026-04-20T07:45:07.898Z",
   "skillCount": 439,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chemoinformatics/admet-prediction",
       "relPath": "chemoinformatics/admet-prediction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1977,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.414Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-alignment-files-bam-statistics",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment-files/bam-statistics",
       "relPath": "alignment-files/bam-statistics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2507,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.414Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-alignment-filtering",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-filtering",
       "relPath": "alignment-files/alignment-filtering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2823,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.415Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-alignment-indexing",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-indexing",
       "relPath": "alignment-files/alignment-indexing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1692,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.416Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-alignment-io",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment/alignment-io",
       "relPath": "alignment/alignment-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3139,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.417Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-alignment-msa-parsing",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment/msa-parsing",
       "relPath": "alignment/msa-parsing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3672,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.418Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-alignment-msa-statistics",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment/msa-statistics",
       "relPath": "alignment/msa-statistics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4343,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.419Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-alignment-multiple",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment/multiple-alignment",
       "relPath": "alignment/multiple-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4169,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.420Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-alignment-pairwise",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment/pairwise-alignment",
       "relPath": "alignment/pairwise-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3742,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.422Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-alignment-sorting",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-sorting",
       "relPath": "alignment-files/alignment-sorting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2055,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.422Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-alignment-validation",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment-files/alignment-validation",
       "relPath": "alignment-files/alignment-validation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3112,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.423Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-atac-seq-atac-peak-calling",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:atac-seq/atac-peak-calling",
       "relPath": "atac-seq/atac-peak-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2027,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.424Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-atac-seq-atac-qc",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:atac-seq/atac-qc",
       "relPath": "atac-seq/atac-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2529,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.425Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-atac-seq-differential-accessibility",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:atac-seq/differential-accessibility",
       "relPath": "atac-seq/differential-accessibility",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1764,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.425Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-atac-seq-footprinting",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:atac-seq/footprinting",
       "relPath": "atac-seq/footprinting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1916,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.426Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-atac-seq-motif-deviation",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:atac-seq/motif-deviation",
       "relPath": "atac-seq/motif-deviation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2068,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.427Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-atac-seq-nucleosome-positioning",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:atac-seq/nucleosome-positioning",
       "relPath": "atac-seq/nucleosome-positioning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2299,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.427Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-basecalling",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/basecalling",
       "relPath": "long-read-sequencing/basecalling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2081,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.428Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-batch-downloads",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/batch-downloads",
       "relPath": "database-access/batch-downloads",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4078,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.429Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-batch-processing",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-io/batch-processing",
       "relPath": "sequence-io/batch-processing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2091,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.430Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-bedgraph-handling",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-intervals/bedgraph-handling",
       "relPath": "genome-intervals/bedgraph-handling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2041,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.431Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-blast-searches",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/blast-searches",
       "relPath": "database-access/blast-searches",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2932,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.432Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-causal-genomics-colocalization-analysis",
@@ -279,7 +1401,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:causal-genomics/colocalization-analysis",
       "relPath": "causal-genomics/colocalization-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2576,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.433Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-causal-genomics-fine-mapping",
@@ -291,7 +1464,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:causal-genomics/fine-mapping",
       "relPath": "causal-genomics/fine-mapping",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2583,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.433Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-causal-genomics-mediation-analysis",
@@ -303,7 +1527,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:causal-genomics/mediation-analysis",
       "relPath": "causal-genomics/mediation-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2718,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.435Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-causal-genomics-mendelian-randomization",
@@ -315,7 +1590,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:causal-genomics/mendelian-randomization",
       "relPath": "causal-genomics/mendelian-randomization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2185,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.435Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-causal-genomics-pleiotropy-detection",
@@ -327,7 +1653,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:causal-genomics/pleiotropy-detection",
       "relPath": "causal-genomics/pleiotropy-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2547,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.436Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-cfdna-preprocessing",
@@ -339,7 +1716,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/cfdna-preprocessing",
       "relPath": "liquid-biopsy/cfdna-preprocessing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1848,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.437Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-chipseq-differential-binding",
@@ -351,7 +1779,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chip-seq/differential-binding",
       "relPath": "chip-seq/differential-binding",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3094,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.438Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-chipseq-motif-analysis",
@@ -363,7 +1842,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chip-seq/motif-analysis",
       "relPath": "chip-seq/motif-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2699,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.439Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-chipseq-peak-annotation",
@@ -375,7 +1905,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chip-seq/peak-annotation",
       "relPath": "chip-seq/peak-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4701,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.440Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-chipseq-peak-calling",
@@ -387,7 +1968,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chip-seq/peak-calling",
       "relPath": "chip-seq/peak-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5817,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.442Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-chipseq-qc",
@@ -399,7 +2031,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chip-seq/chipseq-qc",
       "relPath": "chip-seq/chipseq-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3020,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.443Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-chipseq-super-enhancers",
@@ -411,7 +2094,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chip-seq/super-enhancers",
       "relPath": "chip-seq/super-enhancers",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2027,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.443Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-chipseq-visualization",
@@ -423,7 +2157,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chip-seq/chipseq-visualization",
       "relPath": "chip-seq/chipseq-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2366,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.444Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-biostatistics-categorical-tests",
@@ -435,7 +2220,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/categorical-tests",
       "relPath": "clinical-biostatistics/categorical-tests",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2514,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.445Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-biostatistics-cdisc-data",
@@ -447,7 +2283,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/cdisc-data-handling",
       "relPath": "clinical-biostatistics/cdisc-data-handling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2816,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.446Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-biostatistics-effect-measures",
@@ -459,7 +2346,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/effect-measures",
       "relPath": "clinical-biostatistics/effect-measures",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3248,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.447Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-biostatistics-logistic-regression",
@@ -471,7 +2409,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/logistic-regression",
       "relPath": "clinical-biostatistics/logistic-regression",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4065,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.448Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-biostatistics-subgroup-analysis",
@@ -483,7 +2472,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/subgroup-analysis",
       "relPath": "clinical-biostatistics/subgroup-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2738,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.449Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-biostatistics-trial-reporting",
@@ -495,7 +2535,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-biostatistics/trial-reporting",
       "relPath": "clinical-biostatistics/trial-reporting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3352,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.450Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-databases-clinvar-lookup",
@@ -507,7 +2598,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-databases/clinvar-lookup",
       "relPath": "clinical-databases/clinvar-lookup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1511,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.450Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-databases-dbsnp-queries",
@@ -519,7 +2661,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-databases/dbsnp-queries",
       "relPath": "clinical-databases/dbsnp-queries",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1230,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.451Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-databases-gnomad-frequencies",
@@ -531,7 +2724,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-databases/gnomad-frequencies",
       "relPath": "clinical-databases/gnomad-frequencies",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1888,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.451Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-databases-hla-typing",
@@ -543,7 +2787,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-databases/hla-typing",
       "relPath": "clinical-databases/hla-typing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2060,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.452Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-databases-myvariant-queries",
@@ -555,7 +2850,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-databases/myvariant-queries",
       "relPath": "clinical-databases/myvariant-queries",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1233,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.453Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-databases-pharmacogenomics",
@@ -567,7 +2913,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-databases/pharmacogenomics",
       "relPath": "clinical-databases/pharmacogenomics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2120,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.453Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-databases-polygenic-risk",
@@ -579,7 +2976,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-databases/polygenic-risk",
       "relPath": "clinical-databases/polygenic-risk",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2186,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.454Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-databases-somatic-signatures",
@@ -591,7 +3039,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-databases/somatic-signatures",
       "relPath": "clinical-databases/somatic-signatures",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2182,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.455Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-databases-tumor-mutational-burden",
@@ -603,7 +3102,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-databases/tumor-mutational-burden",
       "relPath": "clinical-databases/tumor-mutational-burden",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2919,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.456Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clinical-databases-variant-prioritization",
@@ -615,7 +3165,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clinical-databases/variant-prioritization",
       "relPath": "clinical-databases/variant-prioritization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2178,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.456Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clip-seq-binding-site-annotation",
@@ -627,7 +3228,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clip-seq/binding-site-annotation",
       "relPath": "clip-seq/binding-site-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 500,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.457Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clip-seq-clip-alignment",
@@ -639,7 +3291,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-alignment",
       "relPath": "clip-seq/clip-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 561,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.457Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clip-seq-clip-motif-analysis",
@@ -651,7 +3354,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-motif-analysis",
       "relPath": "clip-seq/clip-motif-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 459,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.457Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clip-seq-clip-peak-calling",
@@ -663,7 +3417,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-peak-calling",
       "relPath": "clip-seq/clip-peak-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2224,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.458Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-clip-seq-clip-preprocessing",
@@ -675,7 +3480,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:clip-seq/clip-preprocessing",
       "relPath": "clip-seq/clip-preprocessing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1191,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.458Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-codon-usage",
@@ -687,7 +3543,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/codon-usage",
       "relPath": "sequence-manipulation/codon-usage",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3096,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.459Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-comparative-genomics-ancestral-reconstruction",
@@ -699,7 +3606,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:comparative-genomics/ancestral-reconstruction",
       "relPath": "comparative-genomics/ancestral-reconstruction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4527,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.460Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-comparative-genomics-hgt-detection",
@@ -711,7 +3669,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:comparative-genomics/hgt-detection",
       "relPath": "comparative-genomics/hgt-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4559,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.462Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-comparative-genomics-ortholog-inference",
@@ -723,7 +3732,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:comparative-genomics/ortholog-inference",
       "relPath": "comparative-genomics/ortholog-inference",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4142,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.463Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-comparative-genomics-positive-selection",
@@ -735,7 +3795,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:comparative-genomics/positive-selection",
       "relPath": "comparative-genomics/positive-selection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5203,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.464Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-comparative-genomics-synteny-analysis",
@@ -747,7 +3858,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:comparative-genomics/synteny-analysis",
       "relPath": "comparative-genomics/synteny-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4833,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.465Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-compressed-files",
@@ -759,7 +3921,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-io/compressed-files",
       "relPath": "sequence-io/compressed-files",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2084,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.466Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-consensus-sequences",
@@ -771,7 +3984,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/consensus-sequences",
       "relPath": "variant-calling/consensus-sequences",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3134,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.467Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-copy-number-cnv-annotation",
@@ -783,7 +4047,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-annotation",
       "relPath": "copy-number/cnv-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2440,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.468Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-copy-number-cnv-visualization",
@@ -795,7 +4110,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:copy-number/cnv-visualization",
       "relPath": "copy-number/cnv-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2881,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.469Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-copy-number-cnvkit-analysis",
@@ -807,7 +4173,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:copy-number/cnvkit-analysis",
       "relPath": "copy-number/cnvkit-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2378,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.469Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-copy-number-gatk-cnv",
@@ -819,7 +4236,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:copy-number/gatk-cnv",
       "relPath": "copy-number/gatk-cnv",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1972,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.470Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-crispr-screens-base-editing-analysis",
@@ -831,7 +4299,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:crispr-screens/base-editing-analysis",
       "relPath": "crispr-screens/base-editing-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 881,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.470Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-crispr-screens-batch-correction",
@@ -843,7 +4362,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:crispr-screens/batch-correction",
       "relPath": "crispr-screens/batch-correction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2721,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.471Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-crispr-screens-crispresso-editing",
@@ -855,7 +4425,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:crispr-screens/crispresso-editing",
       "relPath": "crispr-screens/crispresso-editing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1502,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.472Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-crispr-screens-hit-calling",
@@ -867,7 +4488,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:crispr-screens/hit-calling",
       "relPath": "crispr-screens/hit-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2225,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.472Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-crispr-screens-jacks-analysis",
@@ -879,7 +4551,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:crispr-screens/jacks-analysis",
       "relPath": "crispr-screens/jacks-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2183,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.474Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-crispr-screens-library-design",
@@ -891,7 +4614,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:crispr-screens/library-design",
       "relPath": "crispr-screens/library-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4228,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.475Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-crispr-screens-mageck-analysis",
@@ -903,7 +4677,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:crispr-screens/mageck-analysis",
       "relPath": "crispr-screens/mageck-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1739,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.476Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-crispr-screens-screen-qc",
@@ -915,7 +4740,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:crispr-screens/screen-qc",
       "relPath": "crispr-screens/screen-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2003,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.476Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ctdna-mutation-detection",
@@ -927,7 +4803,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/ctdna-mutation-detection",
       "relPath": "liquid-biopsy/ctdna-mutation-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2335,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.477Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-circos-plots",
@@ -939,7 +4866,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/circos-plots",
       "relPath": "data-visualization/circos-plots",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2601,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.478Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-color-palettes",
@@ -951,7 +4929,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/color-palettes",
       "relPath": "data-visualization/color-palettes",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1260,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.478Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-genome-browser-tracks",
@@ -963,7 +4992,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/genome-browser-tracks",
       "relPath": "data-visualization/genome-browser-tracks",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1980,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.479Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-genome-tracks",
@@ -975,7 +5055,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/genome-tracks",
       "relPath": "data-visualization/genome-tracks",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1876,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.480Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-ggplot2-fundamentals",
@@ -987,7 +5118,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/ggplot2-fundamentals",
       "relPath": "data-visualization/ggplot2-fundamentals",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2183,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.480Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-heatmaps-clustering",
@@ -999,7 +5181,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/heatmaps-clustering",
       "relPath": "data-visualization/heatmaps-clustering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1773,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.481Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-interactive-visualization",
@@ -1011,7 +5244,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/interactive-visualization",
       "relPath": "data-visualization/interactive-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1486,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.482Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-multipanel-figures",
@@ -1023,7 +5307,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/multipanel-figures",
       "relPath": "data-visualization/multipanel-figures",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1811,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.482Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-network-visualization",
@@ -1035,7 +5370,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/network-visualization",
       "relPath": "data-visualization/network-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3990,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.484Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-specialized-omics-plots",
@@ -1047,7 +5433,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/specialized-omics-plots",
       "relPath": "data-visualization/specialized-omics-plots",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2556,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.484Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-upset-plots",
@@ -1059,7 +5496,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/upset-plots",
       "relPath": "data-visualization/upset-plots",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1873,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.485Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-data-visualization-volcano-customization",
@@ -1071,7 +5559,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:data-visualization/volcano-customization",
       "relPath": "data-visualization/volcano-customization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2018,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.486Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-de-deseq2-basics",
@@ -1083,7 +5622,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:differential-expression/deseq2-basics",
       "relPath": "differential-expression/deseq2-basics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4265,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.487Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-de-edger-basics",
@@ -1095,7 +5685,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:differential-expression/edger-basics",
       "relPath": "differential-expression/edger-basics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3995,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.488Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-de-results",
@@ -1107,7 +5748,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:differential-expression/de-results",
       "relPath": "differential-expression/de-results",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4083,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.490Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-de-visualization",
@@ -1119,7 +5811,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:differential-expression/de-visualization",
       "relPath": "differential-expression/de-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3987,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.491Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-differential-expression-batch-correction",
@@ -1131,7 +5874,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:differential-expression/batch-correction",
       "relPath": "differential-expression/batch-correction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2698,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.492Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-differential-expression-timeseries-de",
@@ -1143,7 +5937,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:differential-expression/timeseries-de",
       "relPath": "differential-expression/timeseries-de",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2823,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.493Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-differential-splicing",
@@ -1155,7 +6000,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alternative-splicing/differential-splicing",
       "relPath": "alternative-splicing/differential-splicing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1427,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.493Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-duplicate-handling",
@@ -1167,7 +6063,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment-files/duplicate-handling",
       "relPath": "alignment-files/duplicate-handling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2049,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.494Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ecological-genomics-biodiversity-metrics",
@@ -1179,7 +6126,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ecological-genomics/biodiversity-metrics",
       "relPath": "ecological-genomics/biodiversity-metrics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2288,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.495Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ecological-genomics-community-ecology",
@@ -1191,7 +6189,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ecological-genomics/community-ecology",
       "relPath": "ecological-genomics/community-ecology",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2441,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.496Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ecological-genomics-conservation-genetics",
@@ -1203,7 +6252,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ecological-genomics/conservation-genetics",
       "relPath": "ecological-genomics/conservation-genetics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2900,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.497Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ecological-genomics-edna-metabarcoding",
@@ -1215,7 +6315,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ecological-genomics/edna-metabarcoding",
       "relPath": "ecological-genomics/edna-metabarcoding",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2672,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.497Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ecological-genomics-landscape-genomics",
@@ -1227,7 +6378,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ecological-genomics/landscape-genomics",
       "relPath": "ecological-genomics/landscape-genomics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2877,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.499Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ecological-genomics-species-delimitation",
@@ -1239,7 +6441,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ecological-genomics/species-delimitation",
       "relPath": "ecological-genomics/species-delimitation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2949,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.500Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-entrez-fetch",
@@ -1251,7 +6504,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/entrez-fetch",
       "relPath": "database-access/entrez-fetch",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2362,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.501Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-entrez-link",
@@ -1263,7 +6567,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/entrez-link",
       "relPath": "database-access/entrez-link",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2850,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.501Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-entrez-search",
@@ -1275,7 +6630,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/entrez-search",
       "relPath": "database-access/entrez-search",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2638,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.502Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-epidemiological-genomics-amr-surveillance",
@@ -1287,7 +6693,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:epidemiological-genomics/amr-surveillance",
       "relPath": "epidemiological-genomics/amr-surveillance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1989,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.503Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-epidemiological-genomics-pathogen-typing",
@@ -1299,7 +6756,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:epidemiological-genomics/pathogen-typing",
       "relPath": "epidemiological-genomics/pathogen-typing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1674,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.503Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-epidemiological-genomics-phylodynamics",
@@ -1311,7 +6819,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:epidemiological-genomics/phylodynamics",
       "relPath": "epidemiological-genomics/phylodynamics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1836,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.504Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-epidemiological-genomics-transmission-inference",
@@ -1323,7 +6882,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:epidemiological-genomics/transmission-inference",
       "relPath": "epidemiological-genomics/transmission-inference",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2289,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.505Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-epidemiological-genomics-variant-surveillance",
@@ -1335,7 +6945,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:epidemiological-genomics/variant-surveillance",
       "relPath": "epidemiological-genomics/variant-surveillance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1936,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.505Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-epitranscriptomics-m6a-differential",
@@ -1347,7 +7008,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:epitranscriptomics/m6a-differential",
       "relPath": "epitranscriptomics/m6a-differential",
-      "verified": true
+      "verified": true,
+      "tokenCount": 662,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.506Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-epitranscriptomics-m6a-peak-calling",
@@ -1359,7 +7071,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:epitranscriptomics/m6a-peak-calling",
       "relPath": "epitranscriptomics/m6a-peak-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 681,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.506Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-epitranscriptomics-m6anet-analysis",
@@ -1371,7 +7134,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:epitranscriptomics/m6anet-analysis",
       "relPath": "epitranscriptomics/m6anet-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 662,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.506Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-epitranscriptomics-merip-preprocessing",
@@ -1383,7 +7197,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:epitranscriptomics/merip-preprocessing",
       "relPath": "epitranscriptomics/merip-preprocessing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 657,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.506Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-epitranscriptomics-modification-visualization",
@@ -1395,7 +7260,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:epitranscriptomics/modification-visualization",
       "relPath": "epitranscriptomics/modification-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 693,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.507Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-experimental-design-batch-design",
@@ -1407,7 +7323,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:experimental-design/batch-design",
       "relPath": "experimental-design/batch-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 883,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.507Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-experimental-design-multiple-testing",
@@ -1419,7 +7386,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:experimental-design/multiple-testing",
       "relPath": "experimental-design/multiple-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 892,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.507Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-experimental-design-power-analysis",
@@ -1431,7 +7449,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:experimental-design/power-analysis",
       "relPath": "experimental-design/power-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 843,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.508Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-experimental-design-sample-size",
@@ -1443,7 +7512,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:experimental-design/sample-size",
       "relPath": "experimental-design/sample-size",
-      "verified": true
+      "verified": true,
+      "tokenCount": 866,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.508Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-expression-matrix-counts-ingest",
@@ -1455,7 +7575,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:expression-matrix/counts-ingest",
       "relPath": "expression-matrix/counts-ingest",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3265,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.509Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-expression-matrix-gene-id-mapping",
@@ -1467,7 +7638,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:expression-matrix/gene-id-mapping",
       "relPath": "expression-matrix/gene-id-mapping",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3436,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.510Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-expression-matrix-metadata-joins",
@@ -1479,7 +7701,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:expression-matrix/metadata-joins",
       "relPath": "expression-matrix/metadata-joins",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3350,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.511Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-expression-matrix-normalization",
@@ -1491,7 +7764,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:expression-matrix/normalization",
       "relPath": "expression-matrix/normalization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4364,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.512Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-expression-matrix-sparse-handling",
@@ -1503,7 +7827,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:expression-matrix/sparse-handling",
       "relPath": "expression-matrix/sparse-handling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2269,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.513Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-fastq-quality",
@@ -1515,7 +7890,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-io/fastq-quality",
       "relPath": "sequence-io/fastq-quality",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2308,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.514Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-filter-sequences",
@@ -1527,7 +7953,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-io/filter-sequences",
       "relPath": "sequence-io/filter-sequences",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1828,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.515Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-flow-cytometry-bead-normalization",
@@ -1539,7 +8016,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:flow-cytometry/bead-normalization",
       "relPath": "flow-cytometry/bead-normalization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2821,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.516Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-flow-cytometry-clustering-phenotyping",
@@ -1551,7 +8079,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:flow-cytometry/clustering-phenotyping",
       "relPath": "flow-cytometry/clustering-phenotyping",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1908,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.517Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-flow-cytometry-compensation-transformation",
@@ -1563,7 +8142,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:flow-cytometry/compensation-transformation",
       "relPath": "flow-cytometry/compensation-transformation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1447,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.517Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-flow-cytometry-cytometry-qc",
@@ -1575,7 +8205,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:flow-cytometry/cytometry-qc",
       "relPath": "flow-cytometry/cytometry-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3507,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.518Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-flow-cytometry-differential-analysis",
@@ -1587,7 +8268,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:flow-cytometry/differential-analysis",
       "relPath": "flow-cytometry/differential-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1506,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.519Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-flow-cytometry-doublet-detection",
@@ -1599,7 +8331,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:flow-cytometry/doublet-detection",
       "relPath": "flow-cytometry/doublet-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2121,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.520Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-flow-cytometry-fcs-handling",
@@ -1611,7 +8394,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:flow-cytometry/fcs-handling",
       "relPath": "flow-cytometry/fcs-handling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1289,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.520Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-flow-cytometry-gating-analysis",
@@ -1623,7 +8457,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:flow-cytometry/gating-analysis",
       "relPath": "flow-cytometry/gating-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1172,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.520Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-format-conversion",
@@ -1635,7 +8520,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-io/format-conversion",
       "relPath": "sequence-io/format-conversion",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1443,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.521Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-fragment-analysis",
@@ -1647,7 +8583,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/fragment-analysis",
       "relPath": "liquid-biopsy/fragment-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2010,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.522Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-gatk-variant-calling",
@@ -1659,7 +8646,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/gatk-variant-calling",
       "relPath": "variant-calling/gatk-variant-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4624,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.523Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-gene-regulatory-networks-coexpression-networks",
@@ -1671,7 +8709,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/coexpression-networks",
       "relPath": "gene-regulatory-networks/coexpression-networks",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2329,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.524Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-gene-regulatory-networks-differential-networks",
@@ -1683,7 +8772,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/differential-networks",
       "relPath": "gene-regulatory-networks/differential-networks",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2611,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.525Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-gene-regulatory-networks-multiomics-grn",
@@ -1695,7 +8835,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/multiomics-grn",
       "relPath": "gene-regulatory-networks/multiomics-grn",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1923,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.525Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-gene-regulatory-networks-perturbation-simulation",
@@ -1707,7 +8898,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/perturbation-simulation",
       "relPath": "gene-regulatory-networks/perturbation-simulation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1894,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.526Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-gene-regulatory-networks-scenic-regulons",
@@ -1719,7 +8961,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:gene-regulatory-networks/scenic-regulons",
       "relPath": "gene-regulatory-networks/scenic-regulons",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2040,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.527Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-annotation-annotation-transfer",
@@ -1731,7 +9024,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-annotation/annotation-transfer",
       "relPath": "genome-annotation/annotation-transfer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2863,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.528Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-annotation-eukaryotic-gene-prediction",
@@ -1743,7 +9087,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-annotation/eukaryotic-gene-prediction",
       "relPath": "genome-annotation/eukaryotic-gene-prediction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2226,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.528Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-annotation-functional-annotation",
@@ -1755,7 +9150,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-annotation/functional-annotation",
       "relPath": "genome-annotation/functional-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2503,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.529Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-annotation-ncrna-annotation",
@@ -1767,7 +9213,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-annotation/ncrna-annotation",
       "relPath": "genome-annotation/ncrna-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3109,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.530Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-annotation-prokaryotic-annotation",
@@ -1779,7 +9276,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-annotation/prokaryotic-annotation",
       "relPath": "genome-annotation/prokaryotic-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2003,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.530Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-annotation-repeat-annotation",
@@ -1791,7 +9339,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-annotation/repeat-annotation",
       "relPath": "genome-annotation/repeat-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2774,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.531Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-assembly-assembly-polishing",
@@ -1803,7 +9402,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-assembly/assembly-polishing",
       "relPath": "genome-assembly/assembly-polishing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2066,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.532Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-assembly-assembly-qc",
@@ -1815,7 +9465,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-assembly/assembly-qc",
       "relPath": "genome-assembly/assembly-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2335,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.533Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-assembly-contamination-detection",
@@ -1827,7 +9528,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-assembly/contamination-detection",
       "relPath": "genome-assembly/contamination-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1640,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.533Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-assembly-hifi-assembly",
@@ -1839,7 +9591,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-assembly/hifi-assembly",
       "relPath": "genome-assembly/hifi-assembly",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1753,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.534Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-assembly-long-read-assembly",
@@ -1851,7 +9654,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-assembly/long-read-assembly",
       "relPath": "genome-assembly/long-read-assembly",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1837,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.535Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-assembly-metagenome-assembly",
@@ -1863,7 +9717,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-assembly/metagenome-assembly",
       "relPath": "genome-assembly/metagenome-assembly",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2106,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.535Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-assembly-scaffolding",
@@ -1875,7 +9780,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-assembly/scaffolding",
       "relPath": "genome-assembly/scaffolding",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1721,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.536Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-assembly-short-read-assembly",
@@ -1887,7 +9843,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-assembly/short-read-assembly",
       "relPath": "genome-assembly/short-read-assembly",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1818,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.536Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-engineering-base-editing-design",
@@ -1899,7 +9906,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-engineering/base-editing-design",
       "relPath": "genome-engineering/base-editing-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3158,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.537Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-engineering-grna-design",
@@ -1911,7 +9969,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-engineering/grna-design",
       "relPath": "genome-engineering/grna-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2454,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.538Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-engineering-hdr-template-design",
@@ -1923,7 +10032,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-engineering/hdr-template-design",
       "relPath": "genome-engineering/hdr-template-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2588,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.539Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-engineering-off-target-prediction",
@@ -1935,7 +10095,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-engineering/off-target-prediction",
       "relPath": "genome-engineering/off-target-prediction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2392,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.539Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-engineering-prime-editing-design",
@@ -1947,7 +10158,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-engineering/prime-editing-design",
       "relPath": "genome-engineering/prime-editing-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3307,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.540Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-intervals-bed-file-basics",
@@ -1959,7 +10221,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-intervals/bed-file-basics",
       "relPath": "genome-intervals/bed-file-basics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2277,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.541Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-intervals-bigwig-tracks",
@@ -1971,7 +10284,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-intervals/bigwig-tracks",
       "relPath": "genome-intervals/bigwig-tracks",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2182,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.542Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-intervals-coverage-analysis",
@@ -1983,7 +10347,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-intervals/coverage-analysis",
       "relPath": "genome-intervals/coverage-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2130,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.542Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-intervals-gtf-gff-handling",
@@ -1995,7 +10410,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-intervals/gtf-gff-handling",
       "relPath": "genome-intervals/gtf-gff-handling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2297,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.543Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-intervals-interval-arithmetic",
@@ -2007,7 +10473,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-intervals/interval-arithmetic",
       "relPath": "genome-intervals/interval-arithmetic",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3043,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.544Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-genome-intervals-proximity-operations",
@@ -2019,7 +10536,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:genome-intervals/proximity-operations",
       "relPath": "genome-intervals/proximity-operations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2280,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.545Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-geo-data",
@@ -2031,7 +10599,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/geo-data",
       "relPath": "database-access/geo-data",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2772,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.546Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-hi-c-analysis-compartment-analysis",
@@ -2043,7 +10662,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/compartment-analysis",
       "relPath": "hi-c-analysis/compartment-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1651,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.546Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-hi-c-analysis-contact-pairs",
@@ -2055,7 +10725,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/contact-pairs",
       "relPath": "hi-c-analysis/contact-pairs",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1785,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.547Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-hi-c-analysis-hic-data-io",
@@ -2067,7 +10788,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/hic-data-io",
       "relPath": "hi-c-analysis/hic-data-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1475,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.547Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-hi-c-analysis-hic-differential",
@@ -2079,7 +10851,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/hic-differential",
       "relPath": "hi-c-analysis/hic-differential",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2496,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.548Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-hi-c-analysis-hic-visualization",
@@ -2091,7 +10914,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/hic-visualization",
       "relPath": "hi-c-analysis/hic-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1986,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.549Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-hi-c-analysis-loop-calling",
@@ -2103,7 +10977,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/loop-calling",
       "relPath": "hi-c-analysis/loop-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2186,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.550Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-hi-c-analysis-matrix-operations",
@@ -2115,7 +11040,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/matrix-operations",
       "relPath": "hi-c-analysis/matrix-operations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1869,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.550Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-hi-c-analysis-tad-detection",
@@ -2127,7 +11103,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:hi-c-analysis/tad-detection",
       "relPath": "hi-c-analysis/tad-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1644,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.551Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-imaging-mass-cytometry-cell-segmentation",
@@ -2139,7 +11166,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/cell-segmentation",
       "relPath": "imaging-mass-cytometry/cell-segmentation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1631,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.551Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-imaging-mass-cytometry-data-preprocessing",
@@ -2151,7 +11229,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/data-preprocessing",
       "relPath": "imaging-mass-cytometry/data-preprocessing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2008,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.552Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-imaging-mass-cytometry-interactive-annotation",
@@ -2163,7 +11292,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/interactive-annotation",
       "relPath": "imaging-mass-cytometry/interactive-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2596,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.553Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-imaging-mass-cytometry-phenotyping",
@@ -2175,7 +11355,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/phenotyping",
       "relPath": "imaging-mass-cytometry/phenotyping",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1481,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.554Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-imaging-mass-cytometry-quality-metrics",
@@ -2187,7 +11418,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/quality-metrics",
       "relPath": "imaging-mass-cytometry/quality-metrics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2734,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.555Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-imaging-mass-cytometry-spatial-analysis",
@@ -2199,7 +11481,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:imaging-mass-cytometry/spatial-analysis",
       "relPath": "imaging-mass-cytometry/spatial-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1626,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.555Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-immunoinformatics-epitope-prediction",
@@ -2211,7 +11544,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:immunoinformatics/epitope-prediction",
       "relPath": "immunoinformatics/epitope-prediction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2329,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.556Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-immunoinformatics-immunogenicity-scoring",
@@ -2223,7 +11607,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:immunoinformatics/immunogenicity-scoring",
       "relPath": "immunoinformatics/immunogenicity-scoring",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2564,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.557Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-immunoinformatics-mhc-binding-prediction",
@@ -2235,7 +11670,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:immunoinformatics/mhc-binding-prediction",
       "relPath": "immunoinformatics/mhc-binding-prediction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2387,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.558Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-immunoinformatics-neoantigen-prediction",
@@ -2247,7 +11733,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:immunoinformatics/neoantigen-prediction",
       "relPath": "immunoinformatics/neoantigen-prediction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2764,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.558Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-immunoinformatics-tcr-epitope-binding",
@@ -2259,7 +11796,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:immunoinformatics/tcr-epitope-binding",
       "relPath": "immunoinformatics/tcr-epitope-binding",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2670,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.559Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-interaction-databases",
@@ -2271,7 +11859,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/interaction-databases",
       "relPath": "database-access/interaction-databases",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2269,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.560Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-isoform-switching",
@@ -2283,7 +11922,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alternative-splicing/isoform-switching",
       "relPath": "alternative-splicing/isoform-switching",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1378,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.560Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-liquid-biopsy-pipeline",
@@ -2295,7 +11985,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/liquid-biopsy-pipeline",
       "relPath": "workflows/liquid-biopsy-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2636,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.561Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-local-blast",
@@ -2307,7 +12048,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/local-blast",
       "relPath": "database-access/local-blast",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3047,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.562Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-long-read-sequencing-clair3-variants",
@@ -2319,7 +12111,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/clair3-variants",
       "relPath": "long-read-sequencing/clair3-variants",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1845,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.563Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-long-read-sequencing-isoseq-analysis",
@@ -2331,7 +12174,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/isoseq-analysis",
       "relPath": "long-read-sequencing/isoseq-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2251,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.563Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-long-read-sequencing-nanopore-methylation",
@@ -2343,7 +12237,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/nanopore-methylation",
       "relPath": "long-read-sequencing/nanopore-methylation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 781,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.564Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-longitudinal-monitoring",
@@ -2355,7 +12300,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/longitudinal-monitoring",
       "relPath": "liquid-biopsy/longitudinal-monitoring",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2403,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.564Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-longread-alignment",
@@ -2367,7 +12363,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/long-read-alignment",
       "relPath": "long-read-sequencing/long-read-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1646,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.565Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-longread-medaka",
@@ -2379,7 +12426,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/medaka-polishing",
       "relPath": "long-read-sequencing/medaka-polishing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1340,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.565Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-longread-qc",
@@ -2391,7 +12489,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/long-read-qc",
       "relPath": "long-read-sequencing/long-read-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1883,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.566Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-longread-structural-variants",
@@ -2403,7 +12552,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:long-read-sequencing/structural-variants",
       "relPath": "long-read-sequencing/structural-variants",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1654,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.566Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-machine-learning-atlas-mapping",
@@ -2415,7 +12615,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:machine-learning/atlas-mapping",
       "relPath": "machine-learning/atlas-mapping",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1166,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.567Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-machine-learning-biomarker-discovery",
@@ -2427,7 +12678,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:machine-learning/biomarker-discovery",
       "relPath": "machine-learning/biomarker-discovery",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1213,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.567Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-machine-learning-model-validation",
@@ -2439,7 +12741,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:machine-learning/model-validation",
       "relPath": "machine-learning/model-validation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1397,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.568Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-machine-learning-omics-classifiers",
@@ -2451,7 +12804,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:machine-learning/omics-classifiers",
       "relPath": "machine-learning/omics-classifiers",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1222,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.568Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-machine-learning-prediction-explanation",
@@ -2463,7 +12867,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:machine-learning/prediction-explanation",
       "relPath": "machine-learning/prediction-explanation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 920,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.569Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-machine-learning-survival-analysis",
@@ -2475,7 +12930,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:machine-learning/survival-analysis",
       "relPath": "machine-learning/survival-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1463,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.569Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metabolomics-lipidomics",
@@ -2487,7 +12993,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metabolomics/lipidomics",
       "relPath": "metabolomics/lipidomics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1771,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.570Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metabolomics-metabolite-annotation",
@@ -2499,7 +13056,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metabolomics/metabolite-annotation",
       "relPath": "metabolomics/metabolite-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1921,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.570Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metabolomics-msdial-preprocessing",
@@ -2511,7 +13119,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metabolomics/msdial-preprocessing",
       "relPath": "metabolomics/msdial-preprocessing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2258,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.571Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metabolomics-normalization-qc",
@@ -2523,7 +13182,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metabolomics/normalization-qc",
       "relPath": "metabolomics/normalization-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2502,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.572Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metabolomics-pathway-mapping",
@@ -2535,7 +13245,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metabolomics/pathway-mapping",
       "relPath": "metabolomics/pathway-mapping",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1533,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.573Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metabolomics-statistical-analysis",
@@ -2547,7 +13308,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metabolomics/statistical-analysis",
       "relPath": "metabolomics/statistical-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4868,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.574Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metabolomics-targeted-analysis",
@@ -2559,7 +13371,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metabolomics/targeted-analysis",
       "relPath": "metabolomics/targeted-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2616,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.575Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metabolomics-xcms-preprocessing",
@@ -2571,7 +13434,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metabolomics/xcms-preprocessing",
       "relPath": "metabolomics/xcms-preprocessing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2107,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.576Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metagenomics-abundance",
@@ -2583,7 +13497,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metagenomics/abundance-estimation",
       "relPath": "metagenomics/abundance-estimation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1768,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.576Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metagenomics-amr-detection",
@@ -2595,7 +13560,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metagenomics/amr-detection",
       "relPath": "metagenomics/amr-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1752,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.577Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metagenomics-functional-profiling",
@@ -2607,7 +13623,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metagenomics/functional-profiling",
       "relPath": "metagenomics/functional-profiling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1960,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.578Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metagenomics-kraken",
@@ -2619,7 +13686,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metagenomics/kraken-classification",
       "relPath": "metagenomics/kraken-classification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1673,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.578Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metagenomics-metaphlan",
@@ -2631,7 +13749,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metagenomics/metaphlan-profiling",
       "relPath": "metagenomics/metaphlan-profiling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1522,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.579Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metagenomics-strain-tracking",
@@ -2643,7 +13812,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metagenomics/strain-tracking",
       "relPath": "metagenomics/strain-tracking",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1737,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.579Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-metagenomics-visualization",
@@ -2655,7 +13875,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:metagenomics/metagenome-visualization",
       "relPath": "metagenomics/metagenome-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1481,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.580Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-methylation-based-detection",
@@ -2667,7 +13938,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/methylation-based-detection",
       "relPath": "liquid-biopsy/methylation-based-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1938,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.580Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-methylation-bismark-alignment",
@@ -2679,7 +14001,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:methylation-analysis/bismark-alignment",
       "relPath": "methylation-analysis/bismark-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1426,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.581Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-methylation-calling",
@@ -2691,7 +14064,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:methylation-analysis/methylation-calling",
       "relPath": "methylation-analysis/methylation-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1780,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.581Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-methylation-differential-cpg",
@@ -2703,7 +14127,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:methylation-analysis/differential-cpg-testing",
       "relPath": "methylation-analysis/differential-cpg-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4558,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.583Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-methylation-dmr-detection",
@@ -2715,7 +14190,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:methylation-analysis/dmr-detection",
       "relPath": "methylation-analysis/dmr-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1534,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.583Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-methylation-methylkit",
@@ -2727,7 +14253,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:methylation-analysis/methylkit-analysis",
       "relPath": "methylation-analysis/methylkit-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1574,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.584Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-microbiome-amplicon-processing",
@@ -2739,7 +14316,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:microbiome/amplicon-processing",
       "relPath": "microbiome/amplicon-processing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1303,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.584Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-microbiome-differential-abundance",
@@ -2751,7 +14379,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:microbiome/differential-abundance",
       "relPath": "microbiome/differential-abundance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1287,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.585Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-microbiome-diversity-analysis",
@@ -2763,7 +14442,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:microbiome/diversity-analysis",
       "relPath": "microbiome/diversity-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1376,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.585Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-microbiome-functional-prediction",
@@ -2775,7 +14505,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:microbiome/functional-prediction",
       "relPath": "microbiome/functional-prediction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1125,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.585Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-microbiome-qiime2-workflow",
@@ -2787,7 +14568,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:microbiome/qiime2-workflow",
       "relPath": "microbiome/qiime2-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1446,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.586Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-microbiome-taxonomy-assignment",
@@ -2799,7 +14631,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:microbiome/taxonomy-assignment",
       "relPath": "microbiome/taxonomy-assignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1319,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.586Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-molecular-descriptors",
@@ -2811,7 +14694,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chemoinformatics/molecular-descriptors",
       "relPath": "chemoinformatics/molecular-descriptors",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1592,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.587Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-molecular-io",
@@ -2823,7 +14757,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chemoinformatics/molecular-io",
       "relPath": "chemoinformatics/molecular-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1474,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.587Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-motif-search",
@@ -2835,7 +14820,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/motif-search",
       "relPath": "sequence-manipulation/motif-search",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2881,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.588Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-multi-omics-data-harmonization",
@@ -2847,7 +14883,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:multi-omics-integration/data-harmonization",
       "relPath": "multi-omics-integration/data-harmonization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1796,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.589Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-multi-omics-mixomics-analysis",
@@ -2859,7 +14946,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:multi-omics-integration/mixomics-analysis",
       "relPath": "multi-omics-integration/mixomics-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2013,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.590Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-multi-omics-mofa-integration",
@@ -2871,7 +15009,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:multi-omics-integration/mofa-integration",
       "relPath": "multi-omics-integration/mofa-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1770,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.590Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-multi-omics-similarity-network",
@@ -2883,7 +15072,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:multi-omics-integration/similarity-network",
       "relPath": "multi-omics-integration/similarity-network",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1796,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.591Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-paired-end-fastq",
@@ -2895,7 +15135,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-io/paired-end-fastq",
       "relPath": "sequence-io/paired-end-fastq",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2836,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.592Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pathway-enrichment-visualization",
@@ -2907,7 +15198,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:pathway-analysis/enrichment-visualization",
       "relPath": "pathway-analysis/enrichment-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2525,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.593Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pathway-go-enrichment",
@@ -2919,7 +15261,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:pathway-analysis/go-enrichment",
       "relPath": "pathway-analysis/go-enrichment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3023,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.594Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pathway-gsea",
@@ -2931,7 +15324,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:pathway-analysis/gsea",
       "relPath": "pathway-analysis/gsea",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3009,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.595Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pathway-kegg-pathways",
@@ -2943,7 +15387,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:pathway-analysis/kegg-pathways",
       "relPath": "pathway-analysis/kegg-pathways",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2767,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.596Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pathway-reactome",
@@ -2955,7 +15450,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:pathway-analysis/reactome-pathways",
       "relPath": "pathway-analysis/reactome-pathways",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1986,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.597Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pathway-wikipathways",
@@ -2967,7 +15513,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:pathway-analysis/wikipathways",
       "relPath": "pathway-analysis/wikipathways",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1936,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.598Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pdb-geometric-analysis",
@@ -2979,7 +15576,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:structural-biology/geometric-analysis",
       "relPath": "structural-biology/geometric-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2765,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.599Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pdb-structure-io",
@@ -2991,7 +15639,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:structural-biology/structure-io",
       "relPath": "structural-biology/structure-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1627,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.600Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pdb-structure-modification",
@@ -3003,7 +15702,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:structural-biology/structure-modification",
       "relPath": "structural-biology/structure-modification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2513,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.600Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pdb-structure-navigation",
@@ -3015,7 +15765,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:structural-biology/structure-navigation",
       "relPath": "structural-biology/structure-navigation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2337,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.601Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phasing-imputation-genotype-imputation",
@@ -3027,7 +15828,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phasing-imputation/genotype-imputation",
       "relPath": "phasing-imputation/genotype-imputation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1568,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.602Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phasing-imputation-haplotype-phasing",
@@ -3039,7 +15891,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phasing-imputation/haplotype-phasing",
       "relPath": "phasing-imputation/haplotype-phasing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1392,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.602Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phasing-imputation-imputation-qc",
@@ -3051,7 +15954,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phasing-imputation/imputation-qc",
       "relPath": "phasing-imputation/imputation-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2132,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.603Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phasing-imputation-reference-panels",
@@ -3063,7 +16017,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phasing-imputation/reference-panels",
       "relPath": "phasing-imputation/reference-panels",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1293,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.603Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phylo-bayesian-inference",
@@ -3075,7 +16080,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phylogenetics/bayesian-inference",
       "relPath": "phylogenetics/bayesian-inference",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4557,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.605Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phylo-distance-calculations",
@@ -3087,7 +16143,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phylogenetics/distance-calculations",
       "relPath": "phylogenetics/distance-calculations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2422,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.605Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phylo-divergence-dating",
@@ -3099,7 +16206,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phylogenetics/divergence-dating",
       "relPath": "phylogenetics/divergence-dating",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4458,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.607Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phylo-modern-tree-inference",
@@ -3111,7 +16269,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phylogenetics/modern-tree-inference",
       "relPath": "phylogenetics/modern-tree-inference",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3288,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.608Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phylo-species-trees",
@@ -3123,7 +16332,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phylogenetics/species-trees",
       "relPath": "phylogenetics/species-trees",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3286,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.608Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phylo-tree-io",
@@ -3135,7 +16395,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phylogenetics/tree-io",
       "relPath": "phylogenetics/tree-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1519,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.609Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phylo-tree-manipulation",
@@ -3147,7 +16458,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phylogenetics/tree-manipulation",
       "relPath": "phylogenetics/tree-manipulation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2762,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.610Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-phylo-tree-visualization",
@@ -3159,7 +16521,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:phylogenetics/tree-visualization",
       "relPath": "phylogenetics/tree-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1974,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.611Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-pileup-generation",
@@ -3171,7 +16584,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment-files/pileup-generation",
       "relPath": "alignment-files/pileup-generation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3208,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.612Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-population-genetics-association-testing",
@@ -3183,7 +16647,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:population-genetics/association-testing",
       "relPath": "population-genetics/association-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1810,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.612Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-population-genetics-linkage-disequilibrium",
@@ -3195,7 +16710,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:population-genetics/linkage-disequilibrium",
       "relPath": "population-genetics/linkage-disequilibrium",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1705,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.613Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-population-genetics-plink-basics",
@@ -3207,7 +16773,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:population-genetics/plink-basics",
       "relPath": "population-genetics/plink-basics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2254,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.613Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-population-genetics-population-structure",
@@ -3219,7 +16836,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:population-genetics/population-structure",
       "relPath": "population-genetics/population-structure",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2352,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.614Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-population-genetics-scikit-allel-analysis",
@@ -3231,7 +16899,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:population-genetics/scikit-allel-analysis",
       "relPath": "population-genetics/scikit-allel-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1396,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.615Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-population-genetics-selection-statistics",
@@ -3243,7 +16962,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:population-genetics/selection-statistics",
       "relPath": "population-genetics/selection-statistics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1964,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.615Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-primer-design-primer-basics",
@@ -3255,7 +17025,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:primer-design/primer-basics",
       "relPath": "primer-design/primer-basics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2280,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.616Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-primer-design-primer-validation",
@@ -3267,7 +17088,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:primer-design/primer-validation",
       "relPath": "primer-design/primer-validation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2677,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.617Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-primer-design-qpcr-primers",
@@ -3279,7 +17151,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:primer-design/qpcr-primers",
       "relPath": "primer-design/qpcr-primers",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2324,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.618Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-proteomics-data-import",
@@ -3291,7 +17214,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:proteomics/data-import",
       "relPath": "proteomics/data-import",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1077,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.619Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-proteomics-dia-analysis",
@@ -3303,7 +17277,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:proteomics/dia-analysis",
       "relPath": "proteomics/dia-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1993,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.619Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-proteomics-differential-abundance",
@@ -3315,7 +17340,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:proteomics/differential-abundance",
       "relPath": "proteomics/differential-abundance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3047,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.620Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-proteomics-peptide-identification",
@@ -3327,7 +17403,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:proteomics/peptide-identification",
       "relPath": "proteomics/peptide-identification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 925,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.620Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-proteomics-protein-inference",
@@ -3339,7 +17466,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:proteomics/protein-inference",
       "relPath": "proteomics/protein-inference",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1549,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.621Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-proteomics-proteomics-qc",
@@ -3351,7 +17529,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:proteomics/proteomics-qc",
       "relPath": "proteomics/proteomics-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1713,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.622Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-proteomics-ptm-analysis",
@@ -3363,7 +17592,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:proteomics/ptm-analysis",
       "relPath": "proteomics/ptm-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1325,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.622Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-proteomics-quantification",
@@ -3375,7 +17655,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:proteomics/quantification",
       "relPath": "proteomics/quantification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1200,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.622Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-proteomics-spectral-libraries",
@@ -3387,7 +17718,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:proteomics/spectral-libraries",
       "relPath": "proteomics/spectral-libraries",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1611,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.623Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-reaction-enumeration",
@@ -3399,7 +17781,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chemoinformatics/reaction-enumeration",
       "relPath": "chemoinformatics/reaction-enumeration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2375,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.624Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-alignment-bowtie2-alignment",
@@ -3411,7 +17844,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-alignment/bowtie2-alignment",
       "relPath": "read-alignment/bowtie2-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1468,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.624Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-alignment-bwa-alignment",
@@ -3423,7 +17907,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-alignment/bwa-alignment",
       "relPath": "read-alignment/bwa-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1450,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.625Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-alignment-hisat2-alignment",
@@ -3435,7 +17970,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-alignment/hisat2-alignment",
       "relPath": "read-alignment/hisat2-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1636,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.625Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-alignment-star-alignment",
@@ -3447,7 +18033,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-alignment/star-alignment",
       "relPath": "read-alignment/star-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1474,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.626Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-qc-adapter-trimming",
@@ -3459,7 +18096,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-qc/adapter-trimming",
       "relPath": "read-qc/adapter-trimming",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1528,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.626Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-qc-contamination-screening",
@@ -3471,7 +18159,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-qc/contamination-screening",
       "relPath": "read-qc/contamination-screening",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1524,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.627Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-qc-fastp-workflow",
@@ -3483,7 +18222,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-qc/fastp-workflow",
       "relPath": "read-qc/fastp-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1859,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.627Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-qc-quality-filtering",
@@ -3495,7 +18285,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-qc/quality-filtering",
       "relPath": "read-qc/quality-filtering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1708,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.628Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-qc-quality-reports",
@@ -3507,7 +18348,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-qc/quality-reports",
       "relPath": "read-qc/quality-reports",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1378,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.628Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-qc-umi-processing",
@@ -3519,7 +18411,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-qc/umi-processing",
       "relPath": "read-qc/umi-processing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2552,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.629Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-read-sequences",
@@ -3531,7 +18474,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-io/read-sequences",
       "relPath": "sequence-io/read-sequences",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2732,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.630Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-reference-operations",
@@ -3543,7 +18537,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment-files/reference-operations",
       "relPath": "alignment-files/reference-operations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2079,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.631Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-reporting-automated-qc-reports",
@@ -3555,7 +18600,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:reporting/automated-qc-reports",
       "relPath": "reporting/automated-qc-reports",
-      "verified": true
+      "verified": true,
+      "tokenCount": 667,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.631Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-reporting-figure-export",
@@ -3567,7 +18663,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:reporting/figure-export",
       "relPath": "reporting/figure-export",
-      "verified": true
+      "verified": true,
+      "tokenCount": 795,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.631Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-reporting-jupyter-reports",
@@ -3579,7 +18726,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:reporting/jupyter-reports",
       "relPath": "reporting/jupyter-reports",
-      "verified": true
+      "verified": true,
+      "tokenCount": 611,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.631Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-reporting-quarto-reports",
@@ -3591,7 +18789,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:reporting/quarto-reports",
       "relPath": "reporting/quarto-reports",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1058,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.632Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-reporting-rmarkdown-reports",
@@ -3603,7 +18852,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:reporting/rmarkdown-reports",
       "relPath": "reporting/rmarkdown-reports",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1235,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.632Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-restriction-enzyme-selection",
@@ -3615,7 +18915,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:restriction-analysis/enzyme-selection",
       "relPath": "restriction-analysis/enzyme-selection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2340,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.633Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-restriction-fragment-analysis",
@@ -3627,7 +18978,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:restriction-analysis/fragment-analysis",
       "relPath": "restriction-analysis/fragment-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2028,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.634Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-restriction-mapping",
@@ -3639,7 +19041,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:restriction-analysis/restriction-mapping",
       "relPath": "restriction-analysis/restriction-mapping",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1826,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.634Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-restriction-sites",
@@ -3651,7 +19104,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:restriction-analysis/restriction-sites",
       "relPath": "restriction-analysis/restriction-sites",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1324,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.635Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-reverse-complement",
@@ -3663,7 +19167,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/reverse-complement",
       "relPath": "sequence-manipulation/reverse-complement",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1821,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.636Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ribo-seq-orf-detection",
@@ -3675,7 +19230,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ribo-seq/orf-detection",
       "relPath": "ribo-seq/orf-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2642,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.636Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ribo-seq-riboseq-preprocessing",
@@ -3687,7 +19293,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ribo-seq/riboseq-preprocessing",
       "relPath": "ribo-seq/riboseq-preprocessing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1426,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.637Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ribo-seq-ribosome-periodicity",
@@ -3699,7 +19356,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ribo-seq/ribosome-periodicity",
       "relPath": "ribo-seq/ribosome-periodicity",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1671,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.637Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ribo-seq-ribosome-stalling",
@@ -3711,7 +19419,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ribo-seq/ribosome-stalling",
       "relPath": "ribo-seq/ribosome-stalling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2138,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.638Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-ribo-seq-translation-efficiency",
@@ -3723,7 +19482,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:ribo-seq/translation-efficiency",
       "relPath": "ribo-seq/translation-efficiency",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1631,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.638Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-rna-quantification-alignment-free-quant",
@@ -3735,7 +19545,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:rna-quantification/alignment-free-quant",
       "relPath": "rna-quantification/alignment-free-quant",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1666,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.639Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-rna-quantification-count-matrix-qc",
@@ -3747,7 +19608,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:rna-quantification/count-matrix-qc",
       "relPath": "rna-quantification/count-matrix-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1649,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.640Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-rna-quantification-featurecounts-counting",
@@ -3759,7 +19671,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:rna-quantification/featurecounts-counting",
       "relPath": "rna-quantification/featurecounts-counting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1462,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.640Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-rna-quantification-tximport-workflow",
@@ -3771,7 +19734,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:rna-quantification/tximport-workflow",
       "relPath": "rna-quantification/tximport-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1470,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.641Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-rna-structure-ncrna-search",
@@ -3783,7 +19797,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:rna-structure/ncrna-search",
       "relPath": "rna-structure/ncrna-search",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2565,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.642Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-rna-structure-secondary-structure-prediction",
@@ -3795,7 +19860,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:rna-structure/secondary-structure-prediction",
       "relPath": "rna-structure/secondary-structure-prediction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2069,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.642Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-rna-structure-structure-probing",
@@ -3807,7 +19923,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:rna-structure/structure-probing",
       "relPath": "rna-structure/structure-probing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3340,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.643Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-rnaseq-qc",
@@ -3819,7 +19986,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:read-qc/rnaseq-qc",
       "relPath": "read-qc/rnaseq-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2325,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.644Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-sam-bam-basics",
@@ -3831,7 +20049,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alignment-files/sam-bam-basics",
       "relPath": "alignment-files/sam-bam-basics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2115,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.645Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-sashimi-plots",
@@ -3843,7 +20112,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alternative-splicing/sashimi-plots",
       "relPath": "alternative-splicing/sashimi-plots",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1574,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.645Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-seq-objects",
@@ -3855,7 +20175,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/seq-objects",
       "relPath": "sequence-manipulation/seq-objects",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1829,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.646Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-sequence-properties",
@@ -3867,7 +20238,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/sequence-properties",
       "relPath": "sequence-manipulation/sequence-properties",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2928,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.647Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-sequence-similarity",
@@ -3879,7 +20301,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/sequence-similarity",
       "relPath": "database-access/sequence-similarity",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2431,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.648Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-sequence-slicing",
@@ -3891,7 +20364,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/sequence-slicing",
       "relPath": "sequence-manipulation/sequence-slicing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1648,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.648Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-sequence-statistics",
@@ -3903,7 +20427,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-io/sequence-statistics",
       "relPath": "sequence-io/sequence-statistics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2372,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.649Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-similarity-searching",
@@ -3915,7 +20490,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chemoinformatics/similarity-searching",
       "relPath": "chemoinformatics/similarity-searching",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1849,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.650Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-batch-integration",
@@ -3927,7 +20553,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/batch-integration",
       "relPath": "single-cell/batch-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2294,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.650Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-cell-annotation",
@@ -3939,7 +20616,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/cell-annotation",
       "relPath": "single-cell/cell-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1652,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.651Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-cell-communication",
@@ -3951,7 +20679,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/cell-communication",
       "relPath": "single-cell/cell-communication",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1793,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.652Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-clustering",
@@ -3963,7 +20742,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/clustering",
       "relPath": "single-cell/clustering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1752,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.653Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-data-io",
@@ -3975,7 +20805,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/data-io",
       "relPath": "single-cell/data-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1871,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.653Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-doublet-detection",
@@ -3987,7 +20868,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/doublet-detection",
       "relPath": "single-cell/doublet-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2144,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.654Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-lineage-tracing",
@@ -3999,7 +20931,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/lineage-tracing",
       "relPath": "single-cell/lineage-tracing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1773,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.655Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-markers-annotation",
@@ -4011,7 +20994,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/markers-annotation",
       "relPath": "single-cell/markers-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1969,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.656Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-metabolite-communication",
@@ -4023,7 +21057,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/metabolite-communication",
       "relPath": "single-cell/metabolite-communication",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1975,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.656Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-multimodal-integration",
@@ -4035,7 +21120,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/multimodal-integration",
       "relPath": "single-cell/multimodal-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1704,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.657Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-perturb-seq",
@@ -4047,7 +21183,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/perturb-seq",
       "relPath": "single-cell/perturb-seq",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1572,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.658Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-preprocessing",
@@ -4059,7 +21246,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/preprocessing",
       "relPath": "single-cell/preprocessing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2049,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.658Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-scatac-analysis",
@@ -4071,7 +21309,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/scatac-analysis",
       "relPath": "single-cell/scatac-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2358,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.659Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-splicing",
@@ -4083,7 +21372,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alternative-splicing/single-cell-splicing",
       "relPath": "alternative-splicing/single-cell-splicing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1527,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.660Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-single-cell-trajectory-inference",
@@ -4095,7 +21435,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:single-cell/trajectory-inference",
       "relPath": "single-cell/trajectory-inference",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1461,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.661Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-small-rna-seq-differential-mirna",
@@ -4107,7 +21498,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:small-rna-seq/differential-mirna",
       "relPath": "small-rna-seq/differential-mirna",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1205,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.661Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-small-rna-seq-mirdeep2-analysis",
@@ -4119,7 +21561,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:small-rna-seq/mirdeep2-analysis",
       "relPath": "small-rna-seq/mirdeep2-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1513,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.662Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-small-rna-seq-mirge3-analysis",
@@ -4131,7 +21624,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:small-rna-seq/mirge3-analysis",
       "relPath": "small-rna-seq/mirge3-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1518,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.662Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-small-rna-seq-smrna-preprocessing",
@@ -4143,7 +21687,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:small-rna-seq/smrna-preprocessing",
       "relPath": "small-rna-seq/smrna-preprocessing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1429,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.663Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-small-rna-seq-target-prediction",
@@ -4155,7 +21750,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:small-rna-seq/target-prediction",
       "relPath": "small-rna-seq/target-prediction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2196,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.663Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-image-analysis",
@@ -4167,7 +21813,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/image-analysis",
       "relPath": "spatial-transcriptomics/image-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1755,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.664Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-spatial-communication",
@@ -4179,7 +21876,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/spatial-communication",
       "relPath": "spatial-transcriptomics/spatial-communication",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2065,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.665Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-spatial-data-io",
@@ -4191,7 +21939,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/spatial-data-io",
       "relPath": "spatial-transcriptomics/spatial-data-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1748,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.666Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-spatial-deconvolution",
@@ -4203,7 +22002,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/spatial-deconvolution",
       "relPath": "spatial-transcriptomics/spatial-deconvolution",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2261,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.666Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-spatial-domains",
@@ -4215,7 +22065,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/spatial-domains",
       "relPath": "spatial-transcriptomics/spatial-domains",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1832,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.667Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-spatial-multiomics",
@@ -4227,7 +22128,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/spatial-multiomics",
       "relPath": "spatial-transcriptomics/spatial-multiomics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1331,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.668Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-spatial-neighbors",
@@ -4239,7 +22191,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/spatial-neighbors",
       "relPath": "spatial-transcriptomics/spatial-neighbors",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1256,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.668Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-spatial-preprocessing",
@@ -4251,7 +22254,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/spatial-preprocessing",
       "relPath": "spatial-transcriptomics/spatial-preprocessing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1556,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.669Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-spatial-proteomics",
@@ -4263,7 +22317,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/spatial-proteomics",
       "relPath": "spatial-transcriptomics/spatial-proteomics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 858,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.669Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-spatial-statistics",
@@ -4275,7 +22380,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/spatial-statistics",
       "relPath": "spatial-transcriptomics/spatial-statistics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1493,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.670Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-spatial-transcriptomics-spatial-visualization",
@@ -4287,7 +22443,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:spatial-transcriptomics/spatial-visualization",
       "relPath": "spatial-transcriptomics/spatial-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1646,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.670Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-splicing-pipeline",
@@ -4299,7 +22506,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/splicing-pipeline",
       "relPath": "workflows/splicing-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2090,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.671Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-splicing-qc",
@@ -4311,7 +22569,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alternative-splicing/splicing-qc",
       "relPath": "alternative-splicing/splicing-qc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1781,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.672Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-splicing-quantification",
@@ -4323,7 +22632,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:alternative-splicing/splicing-quantification",
       "relPath": "alternative-splicing/splicing-quantification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1322,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.672Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-sra-data",
@@ -4335,7 +22695,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/sra-data",
       "relPath": "database-access/sra-data",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2500,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.673Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-structural-biology-alphafold-predictions",
@@ -4347,7 +22758,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:structural-biology/alphafold-predictions",
       "relPath": "structural-biology/alphafold-predictions",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2047,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.674Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-structural-biology-modern-structure-prediction",
@@ -4359,7 +22821,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:structural-biology/modern-structure-prediction",
       "relPath": "structural-biology/modern-structure-prediction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2740,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.674Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-substructure-search",
@@ -4371,7 +22884,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chemoinformatics/substructure-search",
       "relPath": "chemoinformatics/substructure-search",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1670,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.675Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-systems-biology-context-specific-models",
@@ -4383,7 +22947,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:systems-biology/context-specific-models",
       "relPath": "systems-biology/context-specific-models",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2362,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.676Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-systems-biology-flux-balance-analysis",
@@ -4395,7 +23010,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:systems-biology/flux-balance-analysis",
       "relPath": "systems-biology/flux-balance-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1497,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.676Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-systems-biology-gene-essentiality",
@@ -4407,7 +23073,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:systems-biology/gene-essentiality",
       "relPath": "systems-biology/gene-essentiality",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2278,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.677Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-systems-biology-metabolic-reconstruction",
@@ -4419,7 +23136,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:systems-biology/metabolic-reconstruction",
       "relPath": "systems-biology/metabolic-reconstruction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1636,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.678Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-systems-biology-model-curation",
@@ -4431,7 +23199,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:systems-biology/model-curation",
       "relPath": "systems-biology/model-curation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2190,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.678Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-tcr-bcr-analysis-immcantation-analysis",
@@ -4443,7 +23262,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:tcr-bcr-analysis/immcantation-analysis",
       "relPath": "tcr-bcr-analysis/immcantation-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1433,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.679Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-tcr-bcr-analysis-mixcr-analysis",
@@ -4455,7 +23325,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:tcr-bcr-analysis/mixcr-analysis",
       "relPath": "tcr-bcr-analysis/mixcr-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1287,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.679Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-tcr-bcr-analysis-repertoire-visualization",
@@ -4467,7 +23388,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:tcr-bcr-analysis/repertoire-visualization",
       "relPath": "tcr-bcr-analysis/repertoire-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1597,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.680Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-tcr-bcr-analysis-scirpy-analysis",
@@ -4479,7 +23451,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:tcr-bcr-analysis/scirpy-analysis",
       "relPath": "tcr-bcr-analysis/scirpy-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 951,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.680Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-tcr-bcr-analysis-vdjtools-analysis",
@@ -4491,7 +23514,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:tcr-bcr-analysis/vdjtools-analysis",
       "relPath": "tcr-bcr-analysis/vdjtools-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1442,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.680Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-temporal-genomics-circadian-rhythms",
@@ -4503,7 +23577,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:temporal-genomics/circadian-rhythms",
       "relPath": "temporal-genomics/circadian-rhythms",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2098,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.681Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-temporal-genomics-periodicity-detection",
@@ -4515,7 +23640,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:temporal-genomics/periodicity-detection",
       "relPath": "temporal-genomics/periodicity-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2381,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.682Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-temporal-genomics-temporal-clustering",
@@ -4527,7 +23703,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:temporal-genomics/temporal-clustering",
       "relPath": "temporal-genomics/temporal-clustering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2132,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.683Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-temporal-genomics-temporal-grn",
@@ -4539,7 +23766,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:temporal-genomics/temporal-grn",
       "relPath": "temporal-genomics/temporal-grn",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2598,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.684Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-temporal-genomics-trajectory-modeling",
@@ -4551,7 +23829,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:temporal-genomics/trajectory-modeling",
       "relPath": "temporal-genomics/trajectory-modeling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2523,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.685Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-transcription-translation",
@@ -4563,7 +23892,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-manipulation/transcription-translation",
       "relPath": "sequence-manipulation/transcription-translation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2052,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.686Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-tumor-fraction-estimation",
@@ -4575,7 +23955,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:liquid-biopsy/tumor-fraction-estimation",
       "relPath": "liquid-biopsy/tumor-fraction-estimation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1931,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.686Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-uniprot-access",
@@ -4587,7 +24018,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:database-access/uniprot-access",
       "relPath": "database-access/uniprot-access",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1873,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.687Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-variant-annotation",
@@ -4599,7 +24081,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/variant-annotation",
       "relPath": "variant-calling/variant-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4242,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.688Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-variant-calling",
@@ -4611,7 +24144,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/variant-calling",
       "relPath": "variant-calling/variant-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2942,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.689Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-variant-calling-clinical-interpretation",
@@ -4623,7 +24207,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/clinical-interpretation",
       "relPath": "variant-calling/clinical-interpretation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4347,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.691Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-variant-calling-deepvariant",
@@ -4635,7 +24270,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/deepvariant",
       "relPath": "variant-calling/deepvariant",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3088,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.691Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-variant-calling-filtering-best-practices",
@@ -4647,7 +24333,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/filtering-best-practices",
       "relPath": "variant-calling/filtering-best-practices",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4840,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.693Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-variant-calling-joint-calling",
@@ -4659,7 +24396,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/joint-calling",
       "relPath": "variant-calling/joint-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3937,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.694Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-variant-calling-structural-variant-calling",
@@ -4671,7 +24459,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/structural-variant-calling",
       "relPath": "variant-calling/structural-variant-calling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3253,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.695Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-variant-normalization",
@@ -4683,7 +24522,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/variant-normalization",
       "relPath": "variant-calling/variant-normalization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3914,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.696Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-vcf-basics",
@@ -4695,7 +24585,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/vcf-basics",
       "relPath": "variant-calling/vcf-basics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3533,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.697Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-vcf-manipulation",
@@ -4707,7 +24648,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/vcf-manipulation",
       "relPath": "variant-calling/vcf-manipulation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3422,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.698Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-vcf-statistics",
@@ -4719,7 +24711,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:variant-calling/vcf-statistics",
       "relPath": "variant-calling/vcf-statistics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3783,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.699Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-virtual-screening",
@@ -4731,7 +24774,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:chemoinformatics/virtual-screening",
       "relPath": "chemoinformatics/virtual-screening",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2723,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.700Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflow-management-cwl-workflows",
@@ -4743,7 +24837,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflow-management/cwl-workflows",
       "relPath": "workflow-management/cwl-workflows",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2027,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.701Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflow-management-nextflow-pipelines",
@@ -4755,7 +24900,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflow-management/nextflow-pipelines",
       "relPath": "workflow-management/nextflow-pipelines",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2061,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.701Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflow-management-snakemake-workflows",
@@ -4767,7 +24963,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflow-management/snakemake-workflows",
       "relPath": "workflow-management/snakemake-workflows",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2353,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.702Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflow-management-wdl-workflows",
@@ -4779,7 +25026,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflow-management/wdl-workflows",
       "relPath": "workflow-management/wdl-workflows",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3895,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.703Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-atacseq-pipeline",
@@ -4791,7 +25089,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/atacseq-pipeline",
       "relPath": "workflows/atacseq-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2826,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.704Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-biomarker-pipeline",
@@ -4803,7 +25152,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/biomarker-pipeline",
       "relPath": "workflows/biomarker-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2009,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.704Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-causal-genomics-pipeline",
@@ -4815,7 +25215,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/causal-genomics-pipeline",
       "relPath": "workflows/causal-genomics-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4646,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.706Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-chipseq-pipeline",
@@ -4827,7 +25278,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/chipseq-pipeline",
       "relPath": "workflows/chipseq-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2559,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.707Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-clinical-trial-pipeline",
@@ -4839,7 +25341,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/clinical-trial-pipeline",
       "relPath": "workflows/clinical-trial-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2715,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.708Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-clip-pipeline",
@@ -4851,7 +25404,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/clip-pipeline",
       "relPath": "workflows/clip-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1892,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.708Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-cnv-pipeline",
@@ -4863,7 +25467,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/cnv-pipeline",
       "relPath": "workflows/cnv-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2168,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.709Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-crispr-editing-pipeline",
@@ -4875,7 +25530,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/crispr-editing-pipeline",
       "relPath": "workflows/crispr-editing-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4799,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.710Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-crispr-screen-pipeline",
@@ -4887,7 +25593,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/crispr-screen-pipeline",
       "relPath": "workflows/crispr-screen-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2281,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.711Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-cytometry-pipeline",
@@ -4899,7 +25656,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/cytometry-pipeline",
       "relPath": "workflows/cytometry-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3280,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.712Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-edna-pipeline",
@@ -4911,7 +25719,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/edna-pipeline",
       "relPath": "workflows/edna-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4392,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.713Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-expression-to-pathways",
@@ -4923,7 +25782,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/expression-to-pathways",
       "relPath": "workflows/expression-to-pathways",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3710,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.714Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-fastq-to-variants",
@@ -4935,7 +25845,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/fastq-to-variants",
       "relPath": "workflows/fastq-to-variants",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3209,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.715Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-genome-annotation-pipeline",
@@ -4947,7 +25908,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/genome-annotation-pipeline",
       "relPath": "workflows/genome-annotation-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4336,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.717Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-genome-assembly-pipeline",
@@ -4959,7 +25971,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/genome-assembly-pipeline",
       "relPath": "workflows/genome-assembly-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1925,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.717Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-grn-pipeline",
@@ -4971,7 +26034,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/grn-pipeline",
       "relPath": "workflows/grn-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3636,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.718Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-gwas-pipeline",
@@ -4983,7 +26097,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/gwas-pipeline",
       "relPath": "workflows/gwas-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2112,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.719Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-hic-pipeline",
@@ -4995,7 +26160,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/hic-pipeline",
       "relPath": "workflows/hic-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1795,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.719Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-imc-pipeline",
@@ -5007,7 +26223,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/imc-pipeline",
       "relPath": "workflows/imc-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2430,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.720Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-longread-sv-pipeline",
@@ -5019,7 +26286,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/longread-sv-pipeline",
       "relPath": "workflows/longread-sv-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1885,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.721Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-merip-pipeline",
@@ -5031,7 +26349,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/merip-pipeline",
       "relPath": "workflows/merip-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1441,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.721Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-metabolic-modeling-pipeline",
@@ -5043,7 +26412,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/metabolic-modeling-pipeline",
       "relPath": "workflows/metabolic-modeling-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3346,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.722Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-metabolomics-pipeline",
@@ -5055,7 +26475,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/metabolomics-pipeline",
       "relPath": "workflows/metabolomics-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2751,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.723Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-metagenomics-pipeline",
@@ -5067,7 +26538,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/metagenomics-pipeline",
       "relPath": "workflows/metagenomics-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2107,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.724Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-methylation-pipeline",
@@ -5079,7 +26601,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/methylation-pipeline",
       "relPath": "workflows/methylation-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2047,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.725Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-microbiome-pipeline",
@@ -5091,7 +26664,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/microbiome-pipeline",
       "relPath": "workflows/microbiome-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2108,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.725Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-multi-omics-pipeline",
@@ -5103,7 +26727,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/multi-omics-pipeline",
       "relPath": "workflows/multi-omics-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3637,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.727Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-multiome-pipeline",
@@ -5115,7 +26790,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/multiome-pipeline",
       "relPath": "workflows/multiome-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2068,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.727Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-neoantigen-pipeline",
@@ -5127,7 +26853,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/neoantigen-pipeline",
       "relPath": "workflows/neoantigen-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2532,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.728Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-outbreak-pipeline",
@@ -5139,7 +26916,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/outbreak-pipeline",
       "relPath": "workflows/outbreak-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2620,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.730Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-proteomics-pipeline",
@@ -5151,7 +26979,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/proteomics-pipeline",
       "relPath": "workflows/proteomics-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2265,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.730Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-riboseq-pipeline",
@@ -5163,7 +27042,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/riboseq-pipeline",
       "relPath": "workflows/riboseq-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 583,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.731Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-rnaseq-to-de",
@@ -5175,7 +27105,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/rnaseq-to-de",
       "relPath": "workflows/rnaseq-to-de",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2635,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.731Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-scrnaseq-pipeline",
@@ -5187,7 +27168,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/scrnaseq-pipeline",
       "relPath": "workflows/scrnaseq-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2377,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.732Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-smrna-pipeline",
@@ -5199,7 +27231,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/smrna-pipeline",
       "relPath": "workflows/smrna-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 560,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.733Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-somatic-variant-pipeline",
@@ -5211,7 +27294,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/somatic-variant-pipeline",
       "relPath": "workflows/somatic-variant-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2330,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.733Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-spatial-pipeline",
@@ -5223,7 +27357,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/spatial-pipeline",
       "relPath": "workflows/spatial-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1315,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.734Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-tcr-pipeline",
@@ -5235,7 +27420,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/tcr-pipeline",
       "relPath": "workflows/tcr-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 499,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.734Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-workflows-timecourse-pipeline",
@@ -5247,7 +27483,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:workflows/timecourse-pipeline",
       "relPath": "workflows/timecourse-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3802,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.736Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bio-write-sequences",
@@ -5259,7 +27546,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:sequence-io/write-sequences",
       "relPath": "sequence-io/write-sequences",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1412,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.736Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bioskills",
@@ -5271,7 +27609,58 @@
       "allowedTools": [],
       "installUrl": "github:GPTomics/bioSkills:bioskills-installer",
       "relPath": "bioskills-installer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 600,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:07.736Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/Galaxy-Dawn_claude-scholar.json
+++ b/data/skill-index/Galaxy-Dawn_claude-scholar.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Galaxy-Dawn/claude-scholar.git",
   "owner": "Galaxy-Dawn",
   "repo": "claude-scholar",
-  "updatedAt": "2026-04-20T06:33:22.507Z",
+  "updatedAt": "2026-04-20T07:45:59.937Z",
   "skillCount": 48,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/agent-identifier",
       "relPath": "skills/agent-identifier",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2674,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.860Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "architecture-design",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/architecture-design",
       "relPath": "skills/architecture-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2619,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.861Z",
+        "evaluatedVersion": "1.2.0"
+      }
     },
     {
       "name": "bug-detective",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/bug-detective",
       "relPath": "skills/bug-detective",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2506,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.862Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "citation-verification",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/citation-verification",
       "relPath": "skills/citation-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1891,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.862Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "code-review-excellence",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/code-review-excellence",
       "relPath": "skills/code-review-excellence",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4013,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.863Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "command-development",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/command-development",
       "relPath": "skills/command-development",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4421,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.865Z",
+        "evaluatedVersion": "0.2.0"
+      }
     },
     {
       "name": "daily-coding",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/daily-coding",
       "relPath": "skills/daily-coding",
-      "verified": true
+      "verified": true,
+      "tokenCount": 631,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.865Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "daily-paper-generator",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/daily-paper-generator",
       "relPath": "skills/daily-paper-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2225,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.866Z",
+        "evaluatedVersion": "0.4.0"
+      }
     },
     {
       "name": "defuddle",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/defuddle",
       "relPath": "skills/defuddle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 307,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.866Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "doc-coauthoring",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/doc-coauthoring",
       "relPath": "skills/doc-coauthoring",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4843,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.867Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "frontend-design",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/frontend-design",
       "relPath": "skills/frontend-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1139,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.868Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "git-workflow",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/git-workflow",
       "relPath": "skills/git-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3171,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.869Z",
+        "evaluatedVersion": "1.2.0"
+      }
     },
     {
       "name": "hook-development",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/hook-development",
       "relPath": "skills/hook-development",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4462,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.870Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "json-canvas",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/json-canvas",
       "relPath": "skills/json-canvas",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2344,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.871Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kaggle-learner",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/kaggle-learner",
       "relPath": "skills/kaggle-learner",
-      "verified": true
+      "verified": true,
+      "tokenCount": 932,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.871Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "latex-conference-template-organizer",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/latex-conference-template-organizer",
       "relPath": "skills/latex-conference-template-organizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3380,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.872Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "mcp-integration",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/mcp-integration",
       "relPath": "skills/mcp-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3149,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.873Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "ml-paper-writing",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ml-paper-writing",
       "relPath": "skills/ml-paper-writing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 11347,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.876Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "obsidian-bases",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-bases",
       "relPath": "skills/obsidian-bases",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3986,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.877Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-cli",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-cli",
       "relPath": "skills/obsidian-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 848,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.878Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-experiment-log",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-experiment-log",
       "relPath": "skills/obsidian-experiment-log",
-      "verified": true
+      "verified": true,
+      "tokenCount": 593,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.878Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-link-graph",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-link-graph",
       "relPath": "skills/obsidian-link-graph",
-      "verified": true
+      "verified": true,
+      "tokenCount": 378,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.878Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-literature-workflow",
@@ -279,7 +1401,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-literature-workflow",
       "relPath": "skills/obsidian-literature-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1066,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.878Z",
+        "evaluatedVersion": "0.5.0"
+      }
     },
     {
       "name": "obsidian-markdown",
@@ -291,7 +1464,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-markdown",
       "relPath": "skills/obsidian-markdown",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1472,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.879Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-project-bootstrap",
@@ -303,7 +1527,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-project-bootstrap",
       "relPath": "skills/obsidian-project-bootstrap",
-      "verified": true
+      "verified": true,
+      "tokenCount": 687,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.879Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-project-lifecycle",
@@ -315,7 +1590,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-project-lifecycle",
       "relPath": "skills/obsidian-project-lifecycle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 351,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.879Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-project-memory",
@@ -327,7 +1653,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-project-memory",
       "relPath": "skills/obsidian-project-memory",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2502,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.880Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-research-log",
@@ -339,7 +1716,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-research-log",
       "relPath": "skills/obsidian-research-log",
-      "verified": true
+      "verified": true,
+      "tokenCount": 408,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.881Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-synthesis-map",
@@ -351,7 +1779,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/obsidian-synthesis-map",
       "relPath": "skills/obsidian-synthesis-map",
-      "verified": true
+      "verified": true,
+      "tokenCount": 306,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.881Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "paper-self-review",
@@ -363,7 +1842,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/paper-self-review",
       "relPath": "skills/paper-self-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1322,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.882Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "planning-with-files",
@@ -375,7 +1905,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/planning-with-files",
       "relPath": "skills/planning-with-files",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1117,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.882Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "plugin-structure",
@@ -387,7 +1968,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/plugin-structure",
       "relPath": "skills/plugin-structure",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3344,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.883Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "post-acceptance",
@@ -399,7 +2031,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/post-acceptance",
       "relPath": "skills/post-acceptance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1295,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.884Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "publication-chart-skill",
@@ -411,7 +2094,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/publication-chart-skill",
       "relPath": "skills/publication-chart-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3332,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.885Z",
+        "evaluatedVersion": "0.2.0"
+      }
     },
     {
       "name": "research-ideation",
@@ -423,7 +2157,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/research-ideation",
       "relPath": "skills/research-ideation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2074,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.886Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "results-analysis",
@@ -435,7 +2220,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/results-analysis",
       "relPath": "skills/results-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1769,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.886Z",
+        "evaluatedVersion": "0.2.0"
+      }
     },
     {
       "name": "results-report",
@@ -447,7 +2283,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/results-report",
       "relPath": "skills/results-report",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1387,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.887Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "review-response",
@@ -459,7 +2346,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/review-response",
       "relPath": "skills/review-response",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1231,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.887Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "skill-development",
@@ -471,7 +2409,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-development",
       "relPath": "skills/skill-development",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1327,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.888Z",
+        "evaluatedVersion": "0.2.0"
+      }
     },
     {
       "name": "skill-improver",
@@ -483,7 +2472,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-improver",
       "relPath": "skills/skill-improver",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1688,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.888Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "skill-quality-reviewer",
@@ -495,7 +2535,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/skill-quality-reviewer",
       "relPath": "skills/skill-quality-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3165,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.889Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "ui-ux-pro-max",
@@ -507,7 +2598,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/ui-ux-pro-max",
       "relPath": "skills/ui-ux-pro-max",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1008,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.890Z",
+        "evaluatedVersion": "0.2.0"
+      }
     },
     {
       "name": "uv-package-manager",
@@ -519,7 +2661,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/uv-package-manager",
       "relPath": "skills/uv-package-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4461,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.891Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "verification-loop",
@@ -531,7 +2724,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/verification-loop",
       "relPath": "skills/verification-loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 999,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.892Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "web-design-reviewer",
@@ -543,7 +2787,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/web-design-reviewer",
       "relPath": "skills/web-design-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3050,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.892Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "webapp-testing",
@@ -555,7 +2850,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/webapp-testing",
       "relPath": "skills/webapp-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1106,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.893Z",
+        "evaluatedVersion": "0.1.0"
+      }
     },
     {
       "name": "writing-anti-ai",
@@ -567,7 +2913,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/writing-anti-ai",
       "relPath": "skills/writing-anti-ai",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2195,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.894Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "zotero-obsidian-bridge",
@@ -579,7 +2976,58 @@
       "allowedTools": [],
       "installUrl": "github:Galaxy-Dawn/claude-scholar:skills/zotero-obsidian-bridge",
       "relPath": "skills/zotero-obsidian-bridge",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1656,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:59.894Z",
+        "evaluatedVersion": "0.2.0"
+      }
     }
   ]
 }

--- a/data/skill-index/Imbad0202_academic-research-skills.json
+++ b/data/skill-index/Imbad0202_academic-research-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Imbad0202/academic-research-skills.git",
   "owner": "Imbad0202",
   "repo": "academic-research-skills",
-  "updatedAt": "2026-04-20T06:33:48.827Z",
+  "updatedAt": "2026-04-20T07:45:11.170Z",
   "skillCount": 4,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:Imbad0202/academic-research-skills:academic-paper",
       "relPath": "academic-paper",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5022,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:11.150Z",
+        "evaluatedVersion": "3.0.2"
+      }
     },
     {
       "name": "academic-paper-reviewer",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:Imbad0202/academic-research-skills:academic-paper-reviewer",
       "relPath": "academic-paper-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5714,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:11.152Z",
+        "evaluatedVersion": "1.8.1"
+      }
     },
     {
       "name": "academic-pipeline",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:Imbad0202/academic-research-skills:academic-pipeline",
       "relPath": "academic-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7656,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:11.154Z",
+        "evaluatedVersion": "3.2.2"
+      }
     },
     {
       "name": "deep-research",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:Imbad0202/academic-research-skills:deep-research",
       "relPath": "deep-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6968,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:11.156Z",
+        "evaluatedVersion": "2.8.1"
+      }
     }
   ]
 }

--- a/data/skill-index/K-Dense-AI_claude-scientific-skills.json
+++ b/data/skill-index/K-Dense-AI_claude-scientific-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/K-Dense-AI/claude-scientific-skills.git",
   "owner": "K-Dense-AI",
   "repo": "claude-scientific-skills",
-  "updatedAt": "2026-04-20T06:33:34.006Z",
+  "updatedAt": "2026-04-20T07:45:04.155Z",
   "skillCount": 134,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/adaptyv",
       "relPath": "scientific-skills/adaptyv",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1861,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.881Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "aeon",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/aeon",
       "relPath": "scientific-skills/aeon",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1927,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.882Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "anndata",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/anndata",
       "relPath": "scientific-skills/anndata",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2210,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.883Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arboreto",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/arboreto",
       "relPath": "scientific-skills/arboreto",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1557,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.883Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "astropy",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/astropy",
       "relPath": "scientific-skills/astropy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2678,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.884Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "benchling-integration",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/benchling-integration",
       "relPath": "scientific-skills/benchling-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3150,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.885Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bgpt-paper-search",
@@ -87,7 +393,58 @@
       "allowedTools": ["Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bgpt-paper-search",
       "relPath": "scientific-skills/bgpt-paper-search",
-      "verified": true
+      "verified": true,
+      "tokenCount": 653,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.885Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "biopython",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/biopython",
       "relPath": "scientific-skills/biopython",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3188,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.887Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bioservices",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/bioservices",
       "relPath": "scientific-skills/bioservices",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2257,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.887Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cellxgene-census",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cellxgene-census",
       "relPath": "scientific-skills/cellxgene-census",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3720,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.889Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cirq",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cirq",
       "relPath": "scientific-skills/cirq",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2691,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.890Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "citation-management",
@@ -147,7 +708,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/citation-management",
       "relPath": "scientific-skills/citation-management",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8101,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.892Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "clinical-decision-support",
@@ -159,7 +771,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-decision-support",
       "relPath": "scientific-skills/clinical-decision-support",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6176,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.894Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "clinical-reports",
@@ -171,7 +834,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/clinical-reports",
       "relPath": "scientific-skills/clinical-reports",
-      "verified": true
+      "verified": true,
+      "tokenCount": 9915,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.897Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cobrapy",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/cobrapy",
       "relPath": "scientific-skills/cobrapy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2705,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.898Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "consciousness-council",
@@ -195,7 +960,58 @@
       "allowedTools": ["Read", "Write"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/consciousness-council",
       "relPath": "scientific-skills/consciousness-council",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2834,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.899Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dask",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dask",
       "relPath": "scientific-skills/dask",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3445,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.900Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "database-lookup",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/database-lookup",
       "relPath": "scientific-skills/database-lookup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8356,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.903Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "datamol",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/datamol",
       "relPath": "scientific-skills/datamol",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4342,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.905Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "deepchem",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/deepchem",
       "relPath": "scientific-skills/deepchem",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3882,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.907Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "deeptools",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/deeptools",
       "relPath": "scientific-skills/deeptools",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4137,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.908Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "depmap",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/depmap",
       "relPath": "scientific-skills/depmap",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2873,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.909Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dhdna-profiler",
@@ -279,7 +1401,58 @@
       "allowedTools": ["Read", "Write"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dhdna-profiler",
       "relPath": "scientific-skills/dhdna-profiler",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3179,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.910Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "diffdock",
@@ -291,7 +1464,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/diffdock",
       "relPath": "scientific-skills/diffdock",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3596,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.911Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dnanexus-integration",
@@ -303,7 +1527,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/dnanexus-integration",
       "relPath": "scientific-skills/dnanexus-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2577,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.912Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "docx",
@@ -315,7 +1590,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/docx",
       "relPath": "scientific-skills/docx",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5560,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.914Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "esm",
@@ -327,7 +1653,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/esm",
       "relPath": "scientific-skills/esm",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2210,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.915Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "etetoolkit",
@@ -339,7 +1716,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/etetoolkit",
       "relPath": "scientific-skills/etetoolkit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4383,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.916Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "exploratory-data-analysis",
@@ -351,7 +1779,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/exploratory-data-analysis",
       "relPath": "scientific-skills/exploratory-data-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3526,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.917Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowio",
@@ -363,7 +1842,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/flowio",
       "relPath": "scientific-skills/flowio",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4075,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.919Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "fluidsim",
@@ -375,7 +1905,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/fluidsim",
       "relPath": "scientific-skills/fluidsim",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1806,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.919Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "generate-image",
@@ -387,7 +1968,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/generate-image",
       "relPath": "scientific-skills/generate-image",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1714,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.920Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "geniml",
@@ -399,7 +2031,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geniml",
       "relPath": "scientific-skills/geniml",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2313,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.921Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "geomaster",
@@ -411,7 +2094,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geomaster",
       "relPath": "scientific-skills/geomaster",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2793,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.922Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "geopandas",
@@ -423,7 +2157,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geopandas",
       "relPath": "scientific-skills/geopandas",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1436,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.923Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "get-available-resources",
@@ -435,7 +2220,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/get-available-resources",
       "relPath": "scientific-skills/get-available-resources",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2538,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.924Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gget",
@@ -447,7 +2283,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gget",
       "relPath": "scientific-skills/gget",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5604,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.926Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ginkgo-cloud-lab",
@@ -459,7 +2346,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/ginkgo-cloud-lab",
       "relPath": "scientific-skills/ginkgo-cloud-lab",
-      "verified": true
+      "verified": true,
+      "tokenCount": 801,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.926Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "glycoengineering",
@@ -471,7 +2409,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/glycoengineering",
       "relPath": "scientific-skills/glycoengineering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3561,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.927Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtars",
@@ -483,7 +2472,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gtars",
       "relPath": "scientific-skills/gtars",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1760,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.928Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "histolab",
@@ -495,7 +2535,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/histolab",
       "relPath": "scientific-skills/histolab",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4350,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.930Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "hypogenic",
@@ -507,7 +2598,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypogenic",
       "relPath": "scientific-skills/hypogenic",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4969,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.931Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "hypothesis-generation",
@@ -519,7 +2661,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hypothesis-generation",
       "relPath": "scientific-skills/hypothesis-generation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3440,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.933Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "imaging-data-commons",
@@ -531,7 +2724,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/imaging-data-commons",
       "relPath": "scientific-skills/imaging-data-commons",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8842,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.935Z",
+        "evaluatedVersion": "1.4.0"
+      }
     },
     {
       "name": "infographics",
@@ -543,7 +2787,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/infographics",
       "relPath": "scientific-skills/infographics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4621,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.937Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "iso-13485-certification",
@@ -555,7 +2850,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/iso-13485-certification",
       "relPath": "scientific-skills/iso-13485-certification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6408,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.939Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "labarchive-integration",
@@ -567,7 +2913,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/labarchive-integration",
       "relPath": "scientific-skills/labarchive-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2121,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.939Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "lamindb",
@@ -579,7 +2976,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/lamindb",
       "relPath": "scientific-skills/lamindb",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3252,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.940Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "latchbio-integration",
@@ -591,7 +3039,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latchbio-integration",
       "relPath": "scientific-skills/latchbio-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2352,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.941Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "latex-posters",
@@ -603,7 +3102,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latex-posters",
       "relPath": "scientific-skills/latex-posters",
-      "verified": true
+      "verified": true,
+      "tokenCount": 16680,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.946Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "literature-review",
@@ -615,7 +3165,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/literature-review",
       "relPath": "scientific-skills/literature-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7228,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.948Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "markdown-mermaid-writing",
@@ -627,7 +3228,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markdown-mermaid-writing",
       "relPath": "scientific-skills/markdown-mermaid-writing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4031,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.950Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "market-research-reports",
@@ -639,7 +3291,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/market-research-reports",
       "relPath": "scientific-skills/market-research-reports",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7067,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.952Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "markitdown",
@@ -651,7 +3354,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/markitdown",
       "relPath": "scientific-skills/markitdown",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3111,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.953Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "matchms",
@@ -663,7 +3417,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matchms",
       "relPath": "scientific-skills/matchms",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1422,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.954Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "matlab",
@@ -675,7 +3480,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matlab",
       "relPath": "scientific-skills/matlab",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2590,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.954Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "matplotlib",
@@ -687,7 +3543,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/matplotlib",
       "relPath": "scientific-skills/matplotlib",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2580,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.955Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "medchem",
@@ -699,7 +3606,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/medchem",
       "relPath": "scientific-skills/medchem",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2239,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.956Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "modal",
@@ -711,7 +3669,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/modal",
       "relPath": "scientific-skills/modal",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3068,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.957Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "molecular-dynamics",
@@ -723,7 +3732,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/molecular-dynamics",
       "relPath": "scientific-skills/molecular-dynamics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4062,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.959Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "molfeat",
@@ -735,7 +3795,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/molfeat",
       "relPath": "scientific-skills/molfeat",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3098,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.960Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "networkx",
@@ -747,7 +3858,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/networkx",
       "relPath": "scientific-skills/networkx",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2625,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.961Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "neurokit2",
@@ -759,7 +3921,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/neurokit2",
       "relPath": "scientific-skills/neurokit2",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2513,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.962Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "neuropixels-analysis",
@@ -771,7 +3984,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/neuropixels-analysis",
       "relPath": "scientific-skills/neuropixels-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2415,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.963Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "omero-integration",
@@ -783,7 +4047,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/omero-integration",
       "relPath": "scientific-skills/omero-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1925,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.963Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "open-notebook",
@@ -795,7 +4110,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/open-notebook",
       "relPath": "scientific-skills/open-notebook",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2408,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.964Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "opentrons-integration",
@@ -807,7 +4173,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/opentrons-integration",
       "relPath": "scientific-skills/opentrons-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3339,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.965Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "optimize-for-gpu",
@@ -819,7 +4236,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/optimize-for-gpu",
       "relPath": "scientific-skills/optimize-for-gpu",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8868,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.968Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "paper-lookup",
@@ -831,7 +4299,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paper-lookup",
       "relPath": "scientific-skills/paper-lookup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3010,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.969Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "paperzilla",
@@ -843,7 +4362,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/paperzilla",
       "relPath": "scientific-skills/paperzilla",
-      "verified": true
+      "verified": true,
+      "tokenCount": 919,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.970Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "parallel-web",
@@ -855,7 +4425,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/parallel-web",
       "relPath": "scientific-skills/parallel-web",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1700,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.970Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pathml",
@@ -867,7 +4488,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pathml",
       "relPath": "scientific-skills/pathml",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1661,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.971Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pdf",
@@ -879,7 +4551,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pdf",
       "relPath": "scientific-skills/pdf",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2015,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.972Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "peer-review",
@@ -891,7 +4614,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/peer-review",
       "relPath": "scientific-skills/peer-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5917,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.974Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pennylane",
@@ -903,7 +4677,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pennylane",
       "relPath": "scientific-skills/pennylane",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1644,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.974Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "phylogenetics",
@@ -915,7 +4740,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/phylogenetics",
       "relPath": "scientific-skills/phylogenetics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4248,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.976Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "polars",
@@ -927,7 +4803,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/polars",
       "relPath": "scientific-skills/polars",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2105,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.976Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "polars-bio",
@@ -939,7 +4866,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/polars-bio",
       "relPath": "scientific-skills/polars-bio",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3335,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.978Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pptx",
@@ -951,7 +4929,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pptx",
       "relPath": "scientific-skills/pptx",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2666,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.978Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pptx-posters",
@@ -963,7 +4992,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pptx-posters",
       "relPath": "scientific-skills/pptx-posters",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3947,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.980Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "primekg",
@@ -975,7 +5055,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/primekg",
       "relPath": "scientific-skills/primekg",
-      "verified": true
+      "verified": true,
+      "tokenCount": 865,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.980Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "protocolsio-integration",
@@ -987,7 +5118,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/protocolsio-integration",
       "relPath": "scientific-skills/protocolsio-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3647,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.981Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pufferlib",
@@ -999,7 +5181,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pufferlib",
       "relPath": "scientific-skills/pufferlib",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3189,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.982Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pydeseq2",
@@ -1011,7 +5244,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pydeseq2",
       "relPath": "scientific-skills/pydeseq2",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3488,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.983Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pydicom",
@@ -1023,7 +5307,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pydicom",
       "relPath": "scientific-skills/pydicom",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2807,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.984Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pyhealth",
@@ -1035,7 +5370,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyhealth",
       "relPath": "scientific-skills/pyhealth",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3907,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.986Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pylabrobot",
@@ -1047,7 +5433,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pylabrobot",
       "relPath": "scientific-skills/pylabrobot",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1780,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.987Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pymatgen",
@@ -1059,7 +5496,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pymatgen",
       "relPath": "scientific-skills/pymatgen",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3991,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.988Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pymc",
@@ -1071,7 +5559,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pymc",
       "relPath": "scientific-skills/pymc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3602,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.990Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pymoo",
@@ -1083,7 +5622,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pymoo",
       "relPath": "scientific-skills/pymoo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3758,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.991Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pyopenms",
@@ -1095,7 +5685,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyopenms",
       "relPath": "scientific-skills/pyopenms",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1148,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.992Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pysam",
@@ -1107,7 +5748,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pysam",
       "relPath": "scientific-skills/pysam",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2392,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.993Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pytdc",
@@ -1119,7 +5811,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pytdc",
       "relPath": "scientific-skills/pytdc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2759,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.994Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pytorch-lightning",
@@ -1131,7 +5874,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pytorch-lightning",
       "relPath": "scientific-skills/pytorch-lightning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1538,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.994Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pyzotero",
@@ -1143,7 +5937,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyzotero",
       "relPath": "scientific-skills/pyzotero",
-      "verified": true
+      "verified": true,
+      "tokenCount": 905,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.995Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qiskit",
@@ -1155,7 +6000,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/qiskit",
       "relPath": "scientific-skills/qiskit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2012,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.995Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qutip",
@@ -1167,7 +6063,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/qutip",
       "relPath": "scientific-skills/qutip",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2120,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.996Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rdkit",
@@ -1179,7 +6126,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/rdkit",
       "relPath": "scientific-skills/rdkit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4364,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:03.998Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "research-grants",
@@ -1191,7 +6189,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-grants",
       "relPath": "scientific-skills/research-grants",
-      "verified": true
+      "verified": true,
+      "tokenCount": 9017,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.000Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "research-lookup",
@@ -1203,7 +6252,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/research-lookup",
       "relPath": "scientific-skills/research-lookup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5480,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.002Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rowan",
@@ -1215,7 +6315,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/rowan",
       "relPath": "scientific-skills/rowan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8991,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.005Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scanpy",
@@ -1227,7 +6378,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scanpy",
       "relPath": "scientific-skills/scanpy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2464,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.006Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scholar-evaluation",
@@ -1239,7 +6441,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scholar-evaluation",
       "relPath": "scientific-skills/scholar-evaluation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3046,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.007Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scientific-brainstorming",
@@ -1251,7 +6504,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-brainstorming",
       "relPath": "scientific-skills/scientific-brainstorming",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2165,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.008Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scientific-critical-thinking",
@@ -1263,7 +6567,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-critical-thinking",
       "relPath": "scientific-skills/scientific-critical-thinking",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6319,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.009Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scientific-schematics",
@@ -1275,7 +6630,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-schematics",
       "relPath": "scientific-skills/scientific-schematics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6187,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.011Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scientific-slides",
@@ -1287,7 +6693,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-slides",
       "relPath": "scientific-skills/scientific-slides",
-      "verified": true
+      "verified": true,
+      "tokenCount": 12128,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.015Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scientific-visualization",
@@ -1299,7 +6756,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-visualization",
       "relPath": "scientific-skills/scientific-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5977,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.017Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scientific-writing",
@@ -1311,7 +6819,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scientific-writing",
       "relPath": "scientific-skills/scientific-writing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8171,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.020Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scikit-bio",
@@ -1323,7 +6882,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-bio",
       "relPath": "scientific-skills/scikit-bio",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3250,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.021Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scikit-learn",
@@ -1335,7 +6945,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-learn",
       "relPath": "scientific-skills/scikit-learn",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3264,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.022Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scikit-survival",
@@ -1347,7 +7008,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-survival",
       "relPath": "scientific-skills/scikit-survival",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3163,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.023Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scvelo",
@@ -1359,7 +7071,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scvelo",
       "relPath": "scientific-skills/scvelo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2473,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.024Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scvi-tools",
@@ -1371,7 +7134,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scvi-tools",
       "relPath": "scientific-skills/scvi-tools",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1516,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.025Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "seaborn",
@@ -1383,7 +7197,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/seaborn",
       "relPath": "scientific-skills/seaborn",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4614,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.027Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "shap",
@@ -1395,7 +7260,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/shap",
       "relPath": "scientific-skills/shap",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4282,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.028Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "simpy",
@@ -1407,7 +7323,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/simpy",
       "relPath": "scientific-skills/simpy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2945,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.029Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "stable-baselines3",
@@ -1419,7 +7386,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/stable-baselines3",
       "relPath": "scientific-skills/stable-baselines3",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2011,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.030Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "statistical-analysis",
@@ -1431,7 +7449,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/statistical-analysis",
       "relPath": "scientific-skills/statistical-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4846,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.032Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "statsmodels",
@@ -1443,7 +7512,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/statsmodels",
       "relPath": "scientific-skills/statsmodels",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4399,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.033Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sympy",
@@ -1455,7 +7575,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/sympy",
       "relPath": "scientific-skills/sympy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3448,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.035Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tiledbvcf",
@@ -1467,7 +7638,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/tiledbvcf",
       "relPath": "scientific-skills/tiledbvcf",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3424,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.036Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "timesfm-forecasting",
@@ -1479,7 +7701,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/timesfm-forecasting",
       "relPath": "scientific-skills/timesfm-forecasting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7909,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.038Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "torch-geometric",
@@ -1491,7 +7764,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/torch-geometric",
       "relPath": "scientific-skills/torch-geometric",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4243,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.040Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "torchdrug",
@@ -1503,7 +7827,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/torchdrug",
       "relPath": "scientific-skills/torchdrug",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3096,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.041Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "transformers",
@@ -1515,7 +7890,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/transformers",
       "relPath": "scientific-skills/transformers",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1101,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.041Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "treatment-plans",
@@ -1527,7 +7953,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/treatment-plans",
       "relPath": "scientific-skills/treatment-plans",
-      "verified": true
+      "verified": true,
+      "tokenCount": 12479,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.045Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "umap-learn",
@@ -1539,7 +8016,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/umap-learn",
       "relPath": "scientific-skills/umap-learn",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3334,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.046Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "usfiscaldata",
@@ -1551,7 +8079,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/usfiscaldata",
       "relPath": "scientific-skills/usfiscaldata",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1414,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.047Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "vaex",
@@ -1563,7 +8142,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/vaex",
       "relPath": "scientific-skills/vaex",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1621,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.047Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "venue-templates",
@@ -1575,7 +8205,58 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/venue-templates",
       "relPath": "scientific-skills/venue-templates",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5501,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.049Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "what-if-oracle",
@@ -1587,7 +8268,58 @@
       "allowedTools": ["Read", "Write"],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/what-if-oracle",
       "relPath": "scientific-skills/what-if-oracle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3122,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.050Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "xlsx",
@@ -1599,7 +8331,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/xlsx",
       "relPath": "scientific-skills/xlsx",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3146,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.051Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "zarr-python",
@@ -1611,7 +8394,58 @@
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/zarr-python",
       "relPath": "scientific-skills/zarr-python",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5043,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:04.053Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/Leonxlnx_taste-skill.json
+++ b/data/skill-index/Leonxlnx_taste-skill.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Leonxlnx/taste-skill.git",
   "owner": "Leonxlnx",
   "repo": "taste-skill",
-  "updatedAt": "2026-04-20T06:33:09.978Z",
+  "updatedAt": "2026-04-20T07:46:06.449Z",
   "skillCount": 8,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:Leonxlnx/taste-skill:skills/taste-skill",
       "relPath": "skills/taste-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5705,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:06.435Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "full-output-enforcement",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:Leonxlnx/taste-skill:skills/output-skill",
       "relPath": "skills/output-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 792,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:06.435Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gpt-taste",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:Leonxlnx/taste-skill:skills/gpt-tasteskill",
       "relPath": "skills/gpt-tasteskill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2213,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:06.436Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "high-end-visual-design",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:Leonxlnx/taste-skill:skills/soft-skill",
       "relPath": "skills/soft-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2845,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:06.437Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "industrial-brutalist-ui",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:Leonxlnx/taste-skill:skills/brutalist-skill",
       "relPath": "skills/brutalist-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2197,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:06.438Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "minimalist-ui",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:Leonxlnx/taste-skill:skills/minimalist-skill",
       "relPath": "skills/minimalist-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2138,
+      "evalSummary": {
+        "overallScore": 47,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:06.439Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "redesign-existing-projects",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:Leonxlnx/taste-skill:skills/redesign-skill",
       "relPath": "skills/redesign-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4277,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:06.441Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "stitch-design-taste",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:Leonxlnx/taste-skill:skills/stitch-skill",
       "relPath": "skills/stitch-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3169,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:06.442Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/Master-cai_Research-Paper-Writing-Skills.json
+++ b/data/skill-index/Master-cai_Research-Paper-Writing-Skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Master-cai/Research-Paper-Writing-Skills.git",
   "owner": "Master-cai",
   "repo": "Research-Paper-Writing-Skills",
-  "updatedAt": "2026-04-20T06:33:24.398Z",
+  "updatedAt": "2026-04-20T07:45:12.061Z",
   "skillCount": 1,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:Master-cai/Research-Paper-Writing-Skills:research-paper-writing",
       "relPath": "research-paper-writing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1233,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:12.054Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/MiniMax-AI_skills.json
+++ b/data/skill-index/MiniMax-AI_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/MiniMax-AI/skills.git",
   "owner": "MiniMax-AI",
   "repo": "skills",
-  "updatedAt": "2026-04-20T06:33:14.195Z",
+  "updatedAt": "2026-04-20T07:44:23.431Z",
   "skillCount": 23,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/android-native-dev",
       "relPath": "skills/android-native-dev",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8395,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.377Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "buddy-sings",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/buddy-sings",
       "relPath": "skills/buddy-sings",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5089,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.378Z",
+        "evaluatedVersion": "1.1"
+      }
     },
     {
       "name": "color-font-skill",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/color-font-skill",
       "relPath": "plugins/pptx-plugin/skills/color-font-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1915,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.379Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "design-style-skill",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/design-style-skill",
       "relPath": "plugins/pptx-plugin/skills/design-style-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1737,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.379Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flutter-dev",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/flutter-dev",
       "relPath": "skills/flutter-dev",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1333,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.380Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "frontend-dev",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/frontend-dev",
       "relPath": "skills/frontend-dev",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5907,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.381Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "fullstack-dev",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/fullstack-dev",
       "relPath": "skills/fullstack-dev",
-      "verified": true
+      "verified": true,
+      "tokenCount": 9697,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.384Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "gif-sticker-maker",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/gif-sticker-maker",
       "relPath": "skills/gif-sticker-maker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1175,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.385Z",
+        "evaluatedVersion": "1.2"
+      }
     },
     {
       "name": "ios-application-dev",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/ios-application-dev",
       "relPath": "skills/ios-application-dev",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1941,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.385Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "minimax-docx",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/minimax-docx",
       "relPath": "skills/minimax-docx",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3961,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.386Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "minimax-music-gen",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/minimax-music-gen",
       "relPath": "skills/minimax-music-gen",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3972,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.388Z",
+        "evaluatedVersion": "1.1"
+      }
     },
     {
       "name": "minimax-music-playlist",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/minimax-music-playlist",
       "relPath": "skills/minimax-music-playlist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3667,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.389Z",
+        "evaluatedVersion": "2.0"
+      }
     },
     {
       "name": "minimax-pdf",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/minimax-pdf",
       "relPath": "skills/minimax-pdf",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2494,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.390Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "minimax-xlsx",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/minimax-xlsx",
       "relPath": "skills/minimax-xlsx",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2272,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.390Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "mmx-cli",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/minimax-multimodal-toolkit",
       "relPath": "skills/minimax-multimodal-toolkit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3235,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.391Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ppt-editing-skill",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/ppt-editing-skill",
       "relPath": "plugins/pptx-plugin/skills/ppt-editing-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1906,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.392Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ppt-orchestra-skill",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/ppt-orchestra-skill",
       "relPath": "plugins/pptx-plugin/skills/ppt-orchestra-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1777,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.393Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pptx-generator",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/pptx-generator",
       "relPath": "skills/pptx-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2091,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.394Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "pr-review",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:.claude/skills/pr-review",
       "relPath": ".claude/skills/pr-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 656,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.394Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "react-native-dev",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/react-native-dev",
       "relPath": "skills/react-native-dev",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1807,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.395Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "shader-dev",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/shader-dev",
       "relPath": "skills/shader-dev",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4157,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.396Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "slide-making-skill",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:plugins/pptx-plugin/skills/slide-making-skill",
       "relPath": "plugins/pptx-plugin/skills/slide-making-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1998,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.397Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "vision-analysis",
@@ -279,7 +1401,58 @@
       "allowedTools": [],
       "installUrl": "github:MiniMax-AI/skills:skills/vision-analysis",
       "relPath": "skills/vision-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1510,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:23.398Z",
+        "evaluatedVersion": "1.0"
+      }
     }
   ]
 }

--- a/data/skill-index/affaan-m_everything-claude-code.json
+++ b/data/skill-index/affaan-m_everything-claude-code.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/affaan-m/everything-claude-code.git",
   "owner": "affaan-m",
   "repo": "everything-claude-code",
-  "updatedAt": "2026-04-20T06:32:51.845Z",
+  "updatedAt": "2026-04-20T07:44:59.876Z",
   "skillCount": 459,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/accessibility",
       "relPath": "skills/accessibility",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1736,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.381Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-eval",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/agent-eval",
       "relPath": "docs/zh-CN/skills/agent-eval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 700,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.381Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-eval",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/agent-eval",
       "relPath": "skills/agent-eval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1209,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.382Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-harness-construction",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/agent-harness-construction",
       "relPath": "docs/zh-CN/skills/agent-harness-construction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 167,
+      "evalSummary": {
+        "overallScore": 37,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.382Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-harness-construction",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/agent-harness-construction",
       "relPath": "skills/agent-harness-construction",
-      "verified": true
+      "verified": true,
+      "tokenCount": 527,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.382Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-introspection-debugging",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/agent-introspection-debugging",
       "relPath": ".agents/skills/agent-introspection-debugging",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1644,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.383Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-introspection-debugging",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/agent-introspection-debugging",
       "relPath": "skills/agent-introspection-debugging",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1644,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.383Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-payment-x402",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/agent-payment-x402",
       "relPath": "skills/agent-payment-x402",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2068,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.384Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-sort",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/agent-sort",
       "relPath": ".agents/skills/agent-sort",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1765,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.384Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-sort",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/agent-sort",
       "relPath": "skills/agent-sort",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1765,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.385Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agentic-engineering",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/agentic-engineering",
       "relPath": "docs/zh-CN/skills/agentic-engineering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 129,
+      "evalSummary": {
+        "overallScore": 33,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.385Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agentic-engineering",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/agentic-engineering",
       "relPath": ".kiro/skills/agentic-engineering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1051,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.385Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agentic-engineering",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/agentic-engineering",
       "relPath": "skills/agentic-engineering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 455,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.386Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ai-first-engineering",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/ai-first-engineering",
       "relPath": "docs/zh-CN/skills/ai-first-engineering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 93,
+      "evalSummary": {
+        "overallScore": 30,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.386Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ai-first-engineering",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/ai-first-engineering",
       "relPath": "skills/ai-first-engineering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 335,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.386Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ai-regression-testing",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/ai-regression-testing",
       "relPath": "docs/zh-CN/skills/ai-regression-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2421,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.387Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ai-regression-testing",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/ai-regression-testing",
       "relPath": "skills/ai-regression-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3429,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.388Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "android-clean-architecture",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/android-clean-architecture",
       "relPath": "docs/zh-CN/skills/android-clean-architecture",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2013,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.388Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "android-clean-architecture",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/android-clean-architecture",
       "relPath": "skills/android-clean-architecture",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2419,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.389Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "api-connector-builder",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/api-connector-builder",
       "relPath": "skills/api-connector-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 767,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.390Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "api-design",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/api-design",
       "relPath": ".agents/skills/api-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3667,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.391Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "api-design",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/api-design",
       "relPath": "docs/zh-CN/skills/api-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2907,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.392Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "api-design",
@@ -279,7 +1401,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/api-design",
       "relPath": "docs/tr/skills/api-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3683,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.393Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "api-design",
@@ -291,7 +1464,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/api-design",
       "relPath": ".kiro/skills/api-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3673,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.394Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "api-design",
@@ -303,7 +1527,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/api-design",
       "relPath": "skills/api-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3667,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.395Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "architecture-decision-records",
@@ -315,7 +1590,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/architecture-decision-records",
       "relPath": "docs/zh-CN/skills/architecture-decision-records",
-      "verified": true
+      "verified": true,
+      "tokenCount": 861,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.396Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "architecture-decision-records",
@@ -327,7 +1653,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/architecture-decision-records",
       "relPath": "skills/architecture-decision-records",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2025,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.396Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "article-writing",
@@ -339,7 +1716,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.cursor/skills/article-writing",
       "relPath": ".cursor/skills/article-writing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 905,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.397Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "article-writing",
@@ -351,7 +1779,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/article-writing",
       "relPath": ".agents/skills/article-writing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 839,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.397Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "article-writing",
@@ -363,7 +1842,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/article-writing",
       "relPath": "docs/zh-CN/skills/article-writing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 193,
+      "evalSummary": {
+        "overallScore": 39,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.397Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "article-writing",
@@ -375,7 +1905,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/article-writing",
       "relPath": "skills/article-writing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 839,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.397Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "automation-audit-ops",
@@ -387,7 +1968,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/automation-audit-ops",
       "relPath": "skills/automation-audit-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1286,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.398Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "autonomous-agent-harness",
@@ -399,7 +2031,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/autonomous-agent-harness",
       "relPath": "skills/autonomous-agent-harness",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3072,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.399Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "autonomous-loops",
@@ -411,7 +2094,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/autonomous-loops",
       "relPath": "docs/zh-CN/skills/autonomous-loops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4674,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.400Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "autonomous-loops",
@@ -423,7 +2157,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/autonomous-loops",
       "relPath": "skills/autonomous-loops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7141,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.401Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "backend-patterns",
@@ -435,7 +2220,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/backend-patterns",
       "relPath": ".agents/skills/backend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3906,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.403Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "backend-patterns",
@@ -447,7 +2283,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/backend-patterns",
       "relPath": "docs/ja-JP/skills/backend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3461,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.404Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "backend-patterns",
@@ -459,7 +2346,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/backend-patterns",
       "relPath": "docs/zh-CN/skills/backend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3686,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.405Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "backend-patterns",
@@ -471,7 +2409,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/backend-patterns",
       "relPath": "docs/zh-TW/skills/backend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3515,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.407Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "backend-patterns",
@@ -483,7 +2472,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/backend-patterns",
       "relPath": "docs/ko-KR/skills/backend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3941,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.408Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "backend-patterns",
@@ -495,7 +2535,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/backend-patterns",
       "relPath": "docs/tr/skills/backend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3910,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.409Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "backend-patterns",
@@ -507,7 +2598,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/backend-patterns",
       "relPath": ".kiro/skills/backend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3912,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.410Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "backend-patterns",
@@ -519,7 +2661,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/backend-patterns",
       "relPath": "skills/backend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3906,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.411Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "benchmark",
@@ -531,7 +2724,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/benchmark",
       "relPath": "skills/benchmark",
-      "verified": true
+      "verified": true,
+      "tokenCount": 739,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.412Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "blueprint",
@@ -543,7 +2787,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/blueprint",
       "relPath": "docs/zh-CN/skills/blueprint",
-      "verified": true
+      "verified": true,
+      "tokenCount": 451,
+      "evalSummary": {
+        "overallScore": 41,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.412Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "blueprint",
@@ -555,7 +2850,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/blueprint",
       "relPath": "skills/blueprint",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1529,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.412Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "brand-voice",
@@ -567,7 +2913,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/brand-voice",
       "relPath": ".agents/skills/brand-voice",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1080,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.413Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "brand-voice",
@@ -579,7 +2976,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/brand-voice",
       "relPath": "skills/brand-voice",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1080,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.413Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "browser-qa",
@@ -591,7 +3039,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/browser-qa",
       "relPath": "docs/zh-CN/skills/browser-qa",
-      "verified": false
+      "verified": false,
+      "tokenCount": 347,
+      "evalSummary": {
+        "overallScore": 26,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.413Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "browser-qa",
@@ -603,7 +3102,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/browser-qa",
       "relPath": "skills/browser-qa",
-      "verified": true
+      "verified": true,
+      "tokenCount": 768,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.414Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bun-runtime",
@@ -615,7 +3165,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.cursor/skills/bun-runtime",
       "relPath": ".cursor/skills/bun-runtime",
-      "verified": true
+      "verified": true,
+      "tokenCount": 724,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.414Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bun-runtime",
@@ -627,7 +3228,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/bun-runtime",
       "relPath": ".agents/skills/bun-runtime",
-      "verified": true
+      "verified": true,
+      "tokenCount": 724,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.414Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bun-runtime",
@@ -639,7 +3291,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/bun-runtime",
       "relPath": "docs/zh-CN/skills/bun-runtime",
-      "verified": true
+      "verified": true,
+      "tokenCount": 426,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.414Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bun-runtime",
@@ -651,7 +3354,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/bun-runtime",
       "relPath": "skills/bun-runtime",
-      "verified": true
+      "verified": true,
+      "tokenCount": 724,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.415Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "canary-watch",
@@ -663,7 +3417,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/canary-watch",
       "relPath": "skills/canary-watch",
-      "verified": true
+      "verified": true,
+      "tokenCount": 765,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.415Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "carrier-relationship-management",
@@ -675,7 +3480,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/carrier-relationship-management",
       "relPath": "docs/zh-CN/skills/carrier-relationship-management",
-      "verified": true
+      "verified": true,
+      "tokenCount": 994,
+      "evalSummary": {
+        "overallScore": 39,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.415Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "carrier-relationship-management",
@@ -687,7 +3543,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/carrier-relationship-management",
       "relPath": "skills/carrier-relationship-management",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6829,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.417Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ck",
@@ -699,7 +3606,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/ck",
       "relPath": "skills/ck",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1186,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.417Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "claude-api",
@@ -711,7 +3669,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/claude-api",
       "relPath": ".agents/skills/claude-api",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2429,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.418Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "claude-api",
@@ -723,7 +3732,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/claude-api",
       "relPath": "docs/zh-CN/skills/claude-api",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2179,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.419Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "claude-api",
@@ -735,7 +3795,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/claude-api",
       "relPath": "skills/claude-api",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2445,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.420Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "claude-devfleet",
@@ -747,7 +3858,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/claude-devfleet",
       "relPath": "docs/zh-CN/skills/claude-devfleet",
-      "verified": true
+      "verified": true,
+      "tokenCount": 608,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.420Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "claude-devfleet",
@@ -759,7 +3921,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/claude-devfleet",
       "relPath": "skills/claude-devfleet",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1424,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.421Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "click-path-audit",
@@ -771,7 +3984,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/click-path-audit",
       "relPath": "skills/click-path-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2339,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.421Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "clickhouse-io",
@@ -783,7 +4047,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/clickhouse-io",
       "relPath": "docs/ja-JP/skills/clickhouse-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2129,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.422Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "clickhouse-io",
@@ -795,7 +4110,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/clickhouse-io",
       "relPath": "docs/zh-CN/skills/clickhouse-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2353,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.423Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "clickhouse-io",
@@ -807,7 +4173,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/clickhouse-io",
       "relPath": "docs/zh-TW/skills/clickhouse-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2163,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.424Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "clickhouse-io",
@@ -819,7 +4236,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/clickhouse-io",
       "relPath": "docs/ko-KR/skills/clickhouse-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2719,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.425Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "clickhouse-io",
@@ -831,7 +4299,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/clickhouse-io",
       "relPath": "skills/clickhouse-io",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2705,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.426Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "code-tour",
@@ -843,7 +4362,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/code-tour",
       "relPath": "skills/code-tour",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2147,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.427Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "codebase-onboarding",
@@ -855,7 +4425,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/codebase-onboarding",
       "relPath": "docs/zh-CN/skills/codebase-onboarding",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1029,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.427Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "codebase-onboarding",
@@ -867,7 +4488,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/codebase-onboarding",
       "relPath": "skills/codebase-onboarding",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2345,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.428Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "coding-standards",
@@ -879,7 +4551,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/coding-standards",
       "relPath": ".agents/skills/coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3654,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.429Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "coding-standards",
@@ -891,7 +4614,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/coding-standards",
       "relPath": "docs/ja-JP/skills/coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3016,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.430Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "coding-standards",
@@ -903,7 +4677,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/coding-standards",
       "relPath": "docs/zh-CN/skills/coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3056,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.431Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "coding-standards",
@@ -915,7 +4740,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/coding-standards",
       "relPath": "docs/zh-TW/skills/coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2722,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.432Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "coding-standards",
@@ -927,7 +4803,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/coding-standards",
       "relPath": "docs/ko-KR/skills/coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3438,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.433Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "coding-standards",
@@ -939,7 +4866,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/coding-standards",
       "relPath": "docs/tr/skills/coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3466,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.434Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "coding-standards",
@@ -951,7 +4929,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/coding-standards",
       "relPath": ".kiro/skills/coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3434,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.435Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "coding-standards",
@@ -963,7 +4992,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/coding-standards",
       "relPath": "skills/coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3654,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.436Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "compose-multiplatform-patterns",
@@ -975,7 +5055,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/compose-multiplatform-patterns",
       "relPath": "docs/zh-CN/skills/compose-multiplatform-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2041,
+      "evalSummary": {
+        "overallScore": 44,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.437Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "compose-multiplatform-patterns",
@@ -987,7 +5118,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/compose-multiplatform-patterns",
       "relPath": "skills/compose-multiplatform-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2361,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.438Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "configure-ecc",
@@ -999,7 +5181,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/configure-ecc",
       "relPath": "docs/ja-JP/skills/configure-ecc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1442,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.439Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "configure-ecc",
@@ -1011,7 +5244,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/configure-ecc",
       "relPath": "docs/zh-CN/skills/configure-ecc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1873,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.440Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "configure-ecc",
@@ -1023,7 +5307,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/configure-ecc",
       "relPath": "skills/configure-ecc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4021,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.441Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "connections-optimizer",
@@ -1035,7 +5370,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/connections-optimizer",
       "relPath": "skills/connections-optimizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1553,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.441Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "content-engine",
@@ -1047,7 +5433,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.cursor/skills/content-engine",
       "relPath": ".cursor/skills/content-engine",
-      "verified": true
+      "verified": true,
+      "tokenCount": 750,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.442Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "content-engine",
@@ -1059,7 +5496,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/content-engine",
       "relPath": ".agents/skills/content-engine",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1294,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.442Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "content-engine",
@@ -1071,7 +5559,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/content-engine",
       "relPath": "docs/zh-CN/skills/content-engine",
-      "verified": true
+      "verified": true,
+      "tokenCount": 218,
+      "evalSummary": {
+        "overallScore": 39,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.442Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "content-engine",
@@ -1083,7 +5622,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/content-engine",
       "relPath": "skills/content-engine",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1294,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.443Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "content-hash-cache-pattern",
@@ -1095,7 +5685,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/content-hash-cache-pattern",
       "relPath": "docs/zh-CN/skills/content-hash-cache-pattern",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1034,
+      "evalSummary": {
+        "overallScore": 44,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.443Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "content-hash-cache-pattern",
@@ -1107,7 +5748,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/content-hash-cache-pattern",
       "relPath": "skills/content-hash-cache-pattern",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1566,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.444Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "context-budget",
@@ -1119,7 +5811,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/context-budget",
       "relPath": "docs/zh-CN/skills/context-budget",
-      "verified": true
+      "verified": true,
+      "tokenCount": 715,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.444Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "context-budget",
@@ -1131,7 +5874,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/context-budget",
       "relPath": "skills/context-budget",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1587,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.445Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "continuous-agent-loop",
@@ -1143,7 +5937,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/continuous-agent-loop",
       "relPath": "docs/zh-CN/skills/continuous-agent-loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 157,
+      "evalSummary": {
+        "overallScore": 36,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.445Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "continuous-agent-loop",
@@ -1155,7 +6000,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/continuous-agent-loop",
       "relPath": "skills/continuous-agent-loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 285,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.445Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "continuous-learning",
@@ -1167,7 +6063,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/continuous-learning",
       "relPath": "docs/ja-JP/skills/continuous-learning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 456,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.445Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "continuous-learning",
@@ -1179,7 +6126,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/continuous-learning",
       "relPath": "docs/zh-CN/skills/continuous-learning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 521,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.446Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "continuous-learning",
@@ -1191,7 +6189,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/continuous-learning",
       "relPath": "docs/zh-TW/skills/continuous-learning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 540,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.446Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "continuous-learning",
@@ -1203,7 +6252,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/continuous-learning",
       "relPath": "docs/ko-KR/skills/continuous-learning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1001,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.446Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "continuous-learning",
@@ -1215,7 +6315,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/continuous-learning",
       "relPath": "docs/tr/skills/continuous-learning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 903,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.447Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "continuous-learning",
@@ -1227,7 +6378,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/continuous-learning",
       "relPath": "skills/continuous-learning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1005,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.447Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "continuous-learning-v2",
@@ -1239,7 +6441,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/continuous-learning-v2",
       "relPath": "docs/ja-JP/skills/continuous-learning-v2",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1545,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.447Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "continuous-learning-v2",
@@ -1251,7 +6504,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/continuous-learning-v2",
       "relPath": "docs/zh-CN/skills/continuous-learning-v2",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2586,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.448Z",
+        "evaluatedVersion": "2.1.0"
+      }
     },
     {
       "name": "continuous-learning-v2",
@@ -1263,7 +6567,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/continuous-learning-v2",
       "relPath": "docs/zh-TW/skills/continuous-learning-v2",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1564,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.449Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "continuous-learning-v2",
@@ -1275,7 +6630,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/continuous-learning-v2",
       "relPath": "docs/ko-KR/skills/continuous-learning-v2",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3508,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.449Z",
+        "evaluatedVersion": "2.1.0"
+      }
     },
     {
       "name": "continuous-learning-v2",
@@ -1287,7 +6693,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/continuous-learning-v2",
       "relPath": "docs/tr/skills/continuous-learning-v2",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3519,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.451Z",
+        "evaluatedVersion": "2.1.0"
+      }
     },
     {
       "name": "continuous-learning-v2",
@@ -1299,7 +6756,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/continuous-learning-v2",
       "relPath": "skills/continuous-learning-v2",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3608,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.452Z",
+        "evaluatedVersion": "2.1.0"
+      }
     },
     {
       "name": "cost-aware-llm-pipeline",
@@ -1311,7 +6819,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/cost-aware-llm-pipeline",
       "relPath": "docs/zh-CN/skills/cost-aware-llm-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1232,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.452Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cost-aware-llm-pipeline",
@@ -1323,7 +6882,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/cost-aware-llm-pipeline",
       "relPath": "skills/cost-aware-llm-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1746,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.453Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "council",
@@ -1335,7 +6945,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/council",
       "relPath": "skills/council",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1858,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.453Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cpp-coding-standards",
@@ -1347,7 +7008,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/cpp-coding-standards",
       "relPath": "docs/zh-CN/skills/cpp-coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4967,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.455Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cpp-coding-standards",
@@ -1359,7 +7071,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/cpp-coding-standards",
       "relPath": "skills/cpp-coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6695,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.456Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cpp-testing",
@@ -1371,7 +7134,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/cpp-testing",
       "relPath": "docs/ja-JP/skills/cpp-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1247,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.457Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cpp-testing",
@@ -1383,7 +7197,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/cpp-testing",
       "relPath": "docs/zh-CN/skills/cpp-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1307,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.457Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cpp-testing",
@@ -1395,7 +7260,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/cpp-testing",
       "relPath": "skills/cpp-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1995,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.458Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "crosspost",
@@ -1407,7 +7323,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/crosspost",
       "relPath": ".agents/skills/crosspost",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1062,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.459Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "crosspost",
@@ -1419,7 +7386,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/crosspost",
       "relPath": "docs/zh-CN/skills/crosspost",
-      "verified": true
+      "verified": true,
+      "tokenCount": 718,
+      "evalSummary": {
+        "overallScore": 41,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.459Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "crosspost",
@@ -1431,7 +7449,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/crosspost",
       "relPath": "skills/crosspost",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1062,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.459Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-testing",
@@ -1443,7 +7512,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/csharp-testing",
       "relPath": "skills/csharp-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2354,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.460Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "customer-billing-ops",
@@ -1455,7 +7575,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/customer-billing-ops",
       "relPath": "skills/customer-billing-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1244,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.460Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "customs-trade-compliance",
@@ -1467,7 +7638,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/customs-trade-compliance",
       "relPath": "docs/zh-CN/skills/customs-trade-compliance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1429,
+      "evalSummary": {
+        "overallScore": 44,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.461Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "customs-trade-compliance",
@@ -1479,7 +7701,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/customs-trade-compliance",
       "relPath": "skills/customs-trade-compliance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8265,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.463Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "dart-flutter-patterns",
@@ -1491,7 +7764,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/dart-flutter-patterns",
       "relPath": "skills/dart-flutter-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3959,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.465Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dashboard-builder",
@@ -1503,7 +7827,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/dashboard-builder",
       "relPath": "skills/dashboard-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 705,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.465Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "data-scraper-agent",
@@ -1515,7 +7890,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/data-scraper-agent",
       "relPath": "docs/zh-CN/skills/data-scraper-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6246,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.467Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "data-scraper-agent",
@@ -1527,7 +7953,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/data-scraper-agent",
       "relPath": "skills/data-scraper-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7518,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.469Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "database-migrations",
@@ -1539,7 +8016,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/database-migrations",
       "relPath": "docs/zh-CN/skills/database-migrations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1939,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.470Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "database-migrations",
@@ -1551,7 +8079,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/database-migrations",
       "relPath": "docs/tr/skills/database-migrations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2399,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.470Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "database-migrations",
@@ -1563,7 +8142,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/database-migrations",
       "relPath": ".kiro/skills/database-migrations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2660,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.471Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "database-migrations",
@@ -1575,7 +8205,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/database-migrations",
       "relPath": "skills/database-migrations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3137,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.472Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "deep-research",
@@ -1587,7 +8268,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/deep-research",
       "relPath": ".agents/skills/deep-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1236,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.473Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "deep-research",
@@ -1599,7 +8331,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/deep-research",
       "relPath": "docs/zh-CN/skills/deep-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 452,
+      "evalSummary": {
+        "overallScore": 39,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.473Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "deep-research",
@@ -1611,7 +8394,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/deep-research",
       "relPath": "skills/deep-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1236,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.473Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "defi-amm-security",
@@ -1623,7 +8457,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/defi-amm-security",
       "relPath": "skills/defi-amm-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1102,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.474Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "deployment-patterns",
@@ -1635,7 +8520,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/deployment-patterns",
       "relPath": "docs/zh-CN/skills/deployment-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2303,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.475Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "deployment-patterns",
@@ -1647,7 +8583,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/deployment-patterns",
       "relPath": "docs/tr/skills/deployment-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3043,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.476Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "deployment-patterns",
@@ -1659,7 +8646,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/deployment-patterns",
       "relPath": ".kiro/skills/deployment-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3090,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.477Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "deployment-patterns",
@@ -1671,7 +8709,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/deployment-patterns",
       "relPath": "skills/deployment-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3009,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.478Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "design-system",
@@ -1683,7 +8772,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/design-system",
       "relPath": "skills/design-system",
-      "verified": true
+      "verified": true,
+      "tokenCount": 691,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.478Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-patterns",
@@ -1695,7 +8835,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/django-patterns",
       "relPath": "docs/ja-JP/skills/django-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4920,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.480Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-patterns",
@@ -1707,7 +8898,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/django-patterns",
       "relPath": "docs/zh-CN/skills/django-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5293,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.481Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-patterns",
@@ -1719,7 +8961,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/django-patterns",
       "relPath": "docs/tr/skills/django-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5499,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.483Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-patterns",
@@ -1731,7 +9024,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/django-patterns",
       "relPath": "skills/django-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5485,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.485Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-security",
@@ -1743,7 +9087,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/django-security",
       "relPath": "docs/ja-JP/skills/django-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3351,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.486Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-security",
@@ -1755,7 +9150,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/django-security",
       "relPath": "docs/zh-CN/skills/django-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3838,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.488Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-security",
@@ -1767,7 +9213,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/django-security",
       "relPath": "skills/django-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4092,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.489Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-tdd",
@@ -1779,7 +9276,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/django-tdd",
       "relPath": "docs/ja-JP/skills/django-tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4991,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.491Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-tdd",
@@ -1791,7 +9339,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/django-tdd",
       "relPath": "docs/zh-CN/skills/django-tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5410,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.493Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-tdd",
@@ -1803,7 +9402,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/django-tdd",
       "relPath": "skills/django-tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5730,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.494Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-verification",
@@ -1815,7 +9465,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/django-verification",
       "relPath": "docs/ja-JP/skills/django-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2296,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.495Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-verification",
@@ -1827,7 +9528,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/django-verification",
       "relPath": "docs/zh-CN/skills/django-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2687,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.496Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "django-verification",
@@ -1839,7 +9591,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/django-verification",
       "relPath": "skills/django-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3291,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.497Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dmux-workflows",
@@ -1851,7 +9654,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/dmux-workflows",
       "relPath": ".agents/skills/dmux-workflows",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1359,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.497Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dmux-workflows",
@@ -1863,7 +9717,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/dmux-workflows",
       "relPath": "docs/zh-CN/skills/dmux-workflows",
-      "verified": true
+      "verified": true,
+      "tokenCount": 988,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.498Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dmux-workflows",
@@ -1875,7 +9780,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/dmux-workflows",
       "relPath": "skills/dmux-workflows",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1758,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.498Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "docker-patterns",
@@ -1887,7 +9843,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/docker-patterns",
       "relPath": "docs/zh-CN/skills/docker-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2426,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.499Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "docker-patterns",
@@ -1899,7 +9906,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/docker-patterns",
       "relPath": "docs/tr/skills/docker-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2656,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.500Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "docker-patterns",
@@ -1911,7 +9969,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/docker-patterns",
       "relPath": ".kiro/skills/docker-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2752,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.501Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "docker-patterns",
@@ -1923,7 +10032,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/docker-patterns",
       "relPath": "skills/docker-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2664,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.501Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "documentation-lookup",
@@ -1935,7 +10095,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.cursor/skills/documentation-lookup",
       "relPath": ".cursor/skills/documentation-lookup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1377,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.502Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "documentation-lookup",
@@ -1947,7 +10158,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/documentation-lookup",
       "relPath": ".agents/skills/documentation-lookup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1377,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.502Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "documentation-lookup",
@@ -1959,7 +10221,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/documentation-lookup",
       "relPath": "docs/zh-CN/skills/documentation-lookup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 501,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.503Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "documentation-lookup",
@@ -1971,7 +10284,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/documentation-lookup",
       "relPath": "skills/documentation-lookup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1377,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.503Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dotnet-patterns",
@@ -1983,7 +10347,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/dotnet-patterns",
       "relPath": "skills/dotnet-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2400,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.504Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "e2e-testing",
@@ -1995,7 +10410,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/e2e-testing",
       "relPath": ".agents/skills/e2e-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1866,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.505Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "e2e-testing",
@@ -2007,7 +10473,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/e2e-testing",
       "relPath": "docs/zh-CN/skills/e2e-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1756,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.505Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "e2e-testing",
@@ -2019,7 +10536,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/e2e-testing",
       "relPath": "docs/tr/skills/e2e-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1862,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.506Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "e2e-testing",
@@ -2031,7 +10599,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/e2e-testing",
       "relPath": ".kiro/skills/e2e-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1872,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.507Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "e2e-testing",
@@ -2043,7 +10662,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/e2e-testing",
       "relPath": "skills/e2e-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1866,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.507Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ecc-tools-cost-audit",
@@ -2055,7 +10725,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/ecc-tools-cost-audit",
       "relPath": "skills/ecc-tools-cost-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1983,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.508Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "email-ops",
@@ -2067,7 +10788,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/email-ops",
       "relPath": "skills/email-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1058,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.508Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "energy-procurement",
@@ -2079,7 +10851,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/energy-procurement",
       "relPath": "docs/zh-CN/skills/energy-procurement",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1020,
+      "evalSummary": {
+        "overallScore": 39,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.509Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "energy-procurement",
@@ -2091,7 +10914,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/energy-procurement",
       "relPath": "skills/energy-procurement",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8644,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.511Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "enterprise-agent-ops",
@@ -2103,7 +10977,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/enterprise-agent-ops",
       "relPath": "docs/zh-CN/skills/enterprise-agent-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 118,
+      "evalSummary": {
+        "overallScore": 33,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.512Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "enterprise-agent-ops",
@@ -2115,7 +11040,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/enterprise-agent-ops",
       "relPath": "skills/enterprise-agent-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 304,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.512Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "eval-harness",
@@ -2127,7 +11103,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/eval-harness",
       "relPath": ".agents/skills/eval-harness",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1498,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.512Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "eval-harness",
@@ -2139,7 +11166,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/eval-harness",
       "relPath": "docs/ja-JP/skills/eval-harness",
-      "verified": true
+      "verified": true,
+      "tokenCount": 793,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.513Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "eval-harness",
@@ -2151,7 +11229,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/eval-harness",
       "relPath": "docs/zh-CN/skills/eval-harness",
-      "verified": true
+      "verified": true,
+      "tokenCount": 967,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.513Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "eval-harness",
@@ -2163,7 +11292,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/eval-harness",
       "relPath": "docs/zh-TW/skills/eval-harness",
-      "verified": true
+      "verified": true,
+      "tokenCount": 901,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.513Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "eval-harness",
@@ -2175,7 +11355,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/eval-harness",
       "relPath": "docs/ko-KR/skills/eval-harness",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1717,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.514Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "eval-harness",
@@ -2187,7 +11418,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/eval-harness",
       "relPath": "docs/tr/skills/eval-harness",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1719,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.515Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "eval-harness",
@@ -2199,7 +11481,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/eval-harness",
       "relPath": "skills/eval-harness",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1737,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.515Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "everything-claude-code-conventions",
@@ -2211,7 +11544,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/everything-claude-code",
       "relPath": ".agents/skills/everything-claude-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2603,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.516Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "everything-claude-code-conventions",
@@ -2223,7 +11607,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.claude/skills/everything-claude-code",
       "relPath": ".claude/skills/everything-claude-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2557,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.517Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "evm-token-decimals",
@@ -2235,7 +11670,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/evm-token-decimals",
       "relPath": "skills/evm-token-decimals",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1002,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.517Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "exa-search",
@@ -2247,7 +11733,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/exa-search",
       "relPath": ".agents/skills/exa-search",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1221,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.518Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "exa-search",
@@ -2259,7 +11796,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/exa-search",
       "relPath": "docs/zh-CN/skills/exa-search",
-      "verified": true
+      "verified": true,
+      "tokenCount": 467,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.518Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "exa-search",
@@ -2271,7 +11859,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/exa-search",
       "relPath": "skills/exa-search",
-      "verified": true
+      "verified": true,
+      "tokenCount": 899,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.518Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "fal-ai-media",
@@ -2283,7 +11922,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/fal-ai-media",
       "relPath": ".agents/skills/fal-ai-media",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1840,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.519Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "fal-ai-media",
@@ -2295,7 +11985,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/fal-ai-media",
       "relPath": "docs/zh-CN/skills/fal-ai-media",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1209,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.519Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "fal-ai-media",
@@ -2307,7 +12048,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/fal-ai-media",
       "relPath": "skills/fal-ai-media",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1869,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.520Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "finance-billing-ops",
@@ -2319,7 +12111,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/finance-billing-ops",
       "relPath": "skills/finance-billing-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1073,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.520Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flutter-dart-code-review",
@@ -2331,7 +12174,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/flutter-dart-code-review",
       "relPath": "docs/zh-CN/skills/flutter-dart-code-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3187,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.521Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flutter-dart-code-review",
@@ -2343,7 +12237,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/flutter-dart-code-review",
       "relPath": "skills/flutter-dart-code-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6629,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.523Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "foundation-models-on-device",
@@ -2355,7 +12300,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/foundation-models-on-device",
       "relPath": "docs/zh-CN/skills/foundation-models-on-device",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1617,
+      "evalSummary": {
+        "overallScore": 47,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.524Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "foundation-models-on-device",
@@ -2367,7 +12363,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/foundation-models-on-device",
       "relPath": "skills/foundation-models-on-device",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2365,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.525Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-design",
@@ -2379,7 +12426,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/frontend-design",
       "relPath": ".agents/skills/frontend-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1115,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.525Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-design",
@@ -2391,7 +12489,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/frontend-design",
       "relPath": "skills/frontend-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1115,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.525Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-patterns",
@@ -2403,7 +12552,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/frontend-patterns",
       "relPath": ".agents/skills/frontend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4394,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.527Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-patterns",
@@ -2415,7 +12615,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/frontend-patterns",
       "relPath": "docs/ja-JP/skills/frontend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4139,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.528Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-patterns",
@@ -2427,7 +12678,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/frontend-patterns",
       "relPath": "docs/zh-CN/skills/frontend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4194,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.529Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-patterns",
@@ -2439,7 +12741,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/frontend-patterns",
       "relPath": "docs/zh-TW/skills/frontend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4101,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.530Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-patterns",
@@ -2451,7 +12804,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/frontend-patterns",
       "relPath": "docs/ko-KR/skills/frontend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4482,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.532Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-patterns",
@@ -2463,7 +12867,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/frontend-patterns",
       "relPath": "docs/tr/skills/frontend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4390,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.534Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-patterns",
@@ -2475,7 +12930,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/frontend-patterns",
       "relPath": ".kiro/skills/frontend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4400,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.535Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-patterns",
@@ -2487,7 +12993,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/frontend-patterns",
       "relPath": "skills/frontend-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4394,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.536Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-slides",
@@ -2499,7 +13056,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.cursor/skills/frontend-slides",
       "relPath": ".cursor/skills/frontend-slides",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1840,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.537Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-slides",
@@ -2511,7 +13119,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/frontend-slides",
       "relPath": ".agents/skills/frontend-slides",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1840,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.537Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-slides",
@@ -2523,7 +13182,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/frontend-slides",
       "relPath": "docs/zh-CN/skills/frontend-slides",
-      "verified": true
+      "verified": true,
+      "tokenCount": 656,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.537Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-slides",
@@ -2535,7 +13245,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/frontend-slides",
       "relPath": "skills/frontend-slides",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1844,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.538Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gan-style-harness",
@@ -2547,7 +13308,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/gan-style-harness",
       "relPath": "skills/gan-style-harness",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3642,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.539Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gateguard",
@@ -2559,7 +13371,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/gateguard",
       "relPath": "skills/gateguard",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1308,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.539Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "git-workflow",
@@ -2571,7 +13434,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/git-workflow",
       "relPath": "skills/git-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4339,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.541Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "github-ops",
@@ -2583,7 +13497,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/github-ops",
       "relPath": "skills/github-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1291,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.541Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-patterns",
@@ -2595,7 +13560,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/golang-patterns",
       "relPath": "docs/ja-JP/skills/golang-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4227,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.542Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-patterns",
@@ -2607,7 +13623,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/golang-patterns",
       "relPath": "docs/zh-CN/skills/golang-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4294,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.544Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-patterns",
@@ -2619,7 +13686,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/golang-patterns",
       "relPath": "docs/zh-TW/skills/golang-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3973,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.545Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-patterns",
@@ -2631,7 +13749,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/golang-patterns",
       "relPath": "docs/ko-KR/skills/golang-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4705,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.546Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-patterns",
@@ -2643,7 +13812,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/golang-patterns",
       "relPath": "docs/tr/skills/golang-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4720,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.547Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-patterns",
@@ -2655,7 +13875,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/golang-patterns",
       "relPath": ".kiro/skills/golang-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1494,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.548Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-patterns",
@@ -2667,7 +13938,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/golang-patterns",
       "relPath": "skills/golang-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4728,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.549Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-testing",
@@ -2679,7 +14001,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/golang-testing",
       "relPath": "docs/ja-JP/skills/golang-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6294,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.551Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-testing",
@@ -2691,7 +14064,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/golang-testing",
       "relPath": "docs/zh-CN/skills/golang-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6204,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.553Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-testing",
@@ -2703,7 +14127,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/golang-testing",
       "relPath": "docs/zh-TW/skills/golang-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5933,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.555Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-testing",
@@ -2715,7 +14190,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/golang-testing",
       "relPath": "docs/ko-KR/skills/golang-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6568,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.556Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-testing",
@@ -2727,7 +14253,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/golang-testing",
       "relPath": "docs/tr/skills/golang-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6580,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.558Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-testing",
@@ -2739,7 +14316,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/golang-testing",
       "relPath": ".kiro/skills/golang-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2046,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.559Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "golang-testing",
@@ -2751,7 +14379,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/golang-testing",
       "relPath": "skills/golang-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6598,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.560Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "google-workspace-ops",
@@ -2763,7 +14442,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/google-workspace-ops",
       "relPath": "skills/google-workspace-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 832,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.561Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "healthcare-cdss-patterns",
@@ -2775,7 +14505,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/healthcare-cdss-patterns",
       "relPath": "skills/healthcare-cdss-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2480,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.561Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "healthcare-emr-patterns",
@@ -2787,7 +14568,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/healthcare-emr-patterns",
       "relPath": "skills/healthcare-emr-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1778,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.562Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "healthcare-eval-harness",
@@ -2799,7 +14631,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/healthcare-eval-harness",
       "relPath": "skills/healthcare-eval-harness",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2287,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.563Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "healthcare-phi-compliance",
@@ -2811,7 +14694,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/healthcare-phi-compliance",
       "relPath": "skills/healthcare-phi-compliance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1469,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.563Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "hexagonal-architecture",
@@ -2823,7 +14757,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/hexagonal-architecture",
       "relPath": "skills/hexagonal-architecture",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2918,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.564Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "hipaa-compliance",
@@ -2835,7 +14820,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/hipaa-compliance",
       "relPath": "skills/hipaa-compliance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 968,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.564Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "hookify-rules",
@@ -2847,7 +14883,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/hookify-rules",
       "relPath": "skills/hookify-rules",
-      "verified": true
+      "verified": true,
+      "tokenCount": 910,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.565Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "inventory-demand-planning",
@@ -2859,7 +14946,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/inventory-demand-planning",
       "relPath": "docs/zh-CN/skills/inventory-demand-planning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1757,
+      "evalSummary": {
+        "overallScore": 39,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.565Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "inventory-demand-planning",
@@ -2871,7 +15009,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/inventory-demand-planning",
       "relPath": "skills/inventory-demand-planning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7265,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.567Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "investor-materials",
@@ -2883,7 +15072,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.cursor/skills/investor-materials",
       "relPath": ".cursor/skills/investor-materials",
-      "verified": true
+      "verified": true,
+      "tokenCount": 782,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.567Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "investor-materials",
@@ -2895,7 +15135,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/investor-materials",
       "relPath": ".agents/skills/investor-materials",
-      "verified": true
+      "verified": true,
+      "tokenCount": 782,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.568Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "investor-materials",
@@ -2907,7 +15198,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/investor-materials",
       "relPath": "docs/zh-CN/skills/investor-materials",
-      "verified": true
+      "verified": true,
+      "tokenCount": 232,
+      "evalSummary": {
+        "overallScore": 37,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.568Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "investor-materials",
@@ -2919,7 +15261,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/investor-materials",
       "relPath": "skills/investor-materials",
-      "verified": true
+      "verified": true,
+      "tokenCount": 782,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.568Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "investor-outreach",
@@ -2931,7 +15324,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.cursor/skills/investor-outreach",
       "relPath": ".cursor/skills/investor-outreach",
-      "verified": true
+      "verified": true,
+      "tokenCount": 658,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.568Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "investor-outreach",
@@ -2943,7 +15387,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/investor-outreach",
       "relPath": ".agents/skills/investor-outreach",
-      "verified": true
+      "verified": true,
+      "tokenCount": 815,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.569Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "investor-outreach",
@@ -2955,7 +15450,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/investor-outreach",
       "relPath": "docs/zh-CN/skills/investor-outreach",
-      "verified": true
+      "verified": true,
+      "tokenCount": 164,
+      "evalSummary": {
+        "overallScore": 34,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.569Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "investor-outreach",
@@ -2967,7 +15513,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/investor-outreach",
       "relPath": "skills/investor-outreach",
-      "verified": true
+      "verified": true,
+      "tokenCount": 815,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.569Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "iterative-retrieval",
@@ -2979,7 +15576,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/iterative-retrieval",
       "relPath": "docs/ja-JP/skills/iterative-retrieval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1074,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.570Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "iterative-retrieval",
@@ -2991,7 +15639,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/iterative-retrieval",
       "relPath": "docs/zh-CN/skills/iterative-retrieval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1214,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.570Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "iterative-retrieval",
@@ -3003,7 +15702,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/iterative-retrieval",
       "relPath": "docs/zh-TW/skills/iterative-retrieval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1183,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.570Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "iterative-retrieval",
@@ -3015,7 +15765,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/iterative-retrieval",
       "relPath": "docs/ko-KR/skills/iterative-retrieval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1738,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.571Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "iterative-retrieval",
@@ -3027,7 +15828,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/iterative-retrieval",
       "relPath": "skills/iterative-retrieval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1788,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.572Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-coding-standards",
@@ -3039,7 +15891,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/java-coding-standards",
       "relPath": "docs/ja-JP/skills/java-coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 470,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.572Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-coding-standards",
@@ -3051,7 +15954,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/java-coding-standards",
       "relPath": "docs/zh-CN/skills/java-coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 587,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.572Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-coding-standards",
@@ -3063,7 +16017,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/java-coding-standards",
       "relPath": "skills/java-coding-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 939,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.572Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "jira-integration",
@@ -3075,7 +16080,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/jira-integration",
       "relPath": "skills/jira-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2479,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.573Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "jpa-patterns",
@@ -3087,7 +16143,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/jpa-patterns",
       "relPath": "docs/ja-JP/skills/jpa-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 564,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.574Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "jpa-patterns",
@@ -3099,7 +16206,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/jpa-patterns",
       "relPath": "docs/zh-CN/skills/jpa-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 620,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.574Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "jpa-patterns",
@@ -3111,7 +16269,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/jpa-patterns",
       "relPath": "docs/tr/skills/jpa-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 952,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.574Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "jpa-patterns",
@@ -3123,7 +16332,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/jpa-patterns",
       "relPath": "skills/jpa-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 954,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.575Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "knowledge-ops",
@@ -3135,7 +16395,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/knowledge-ops",
       "relPath": "skills/knowledge-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1862,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.575Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-coroutines-flows",
@@ -3147,7 +16458,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/kotlin-coroutines-flows",
       "relPath": "docs/zh-CN/skills/kotlin-coroutines-flows",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1838,
+      "evalSummary": {
+        "overallScore": 44,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.576Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-coroutines-flows",
@@ -3159,7 +16521,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/kotlin-coroutines-flows",
       "relPath": "skills/kotlin-coroutines-flows",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2160,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.577Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-exposed-patterns",
@@ -3171,7 +16584,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/kotlin-exposed-patterns",
       "relPath": "docs/zh-CN/skills/kotlin-exposed-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6553,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.579Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-exposed-patterns",
@@ -3183,7 +16647,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/kotlin-exposed-patterns",
       "relPath": "skills/kotlin-exposed-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6877,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.581Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-ktor-patterns",
@@ -3195,7 +16710,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/kotlin-ktor-patterns",
       "relPath": "docs/zh-CN/skills/kotlin-ktor-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6363,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.582Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-ktor-patterns",
@@ -3207,7 +16773,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/kotlin-ktor-patterns",
       "relPath": "skills/kotlin-ktor-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6577,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.584Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-patterns",
@@ -3219,7 +16836,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/kotlin-patterns",
       "relPath": "docs/zh-CN/skills/kotlin-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4919,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.586Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-patterns",
@@ -3231,7 +16899,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/kotlin-patterns",
       "relPath": "docs/tr/skills/kotlin-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4097,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.587Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-patterns",
@@ -3243,7 +16962,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/kotlin-patterns",
       "relPath": "skills/kotlin-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5393,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.589Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-testing",
@@ -3255,7 +17025,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/kotlin-testing",
       "relPath": "docs/zh-CN/skills/kotlin-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6052,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.590Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-testing",
@@ -3267,7 +17088,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/kotlin-testing",
       "relPath": "docs/tr/skills/kotlin-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4506,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.592Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-testing",
@@ -3279,7 +17151,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/kotlin-testing",
       "relPath": "skills/kotlin-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6528,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.594Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-patterns",
@@ -3291,7 +17214,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/laravel-patterns",
       "relPath": "docs/zh-CN/skills/laravel-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1956,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.595Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-patterns",
@@ -3303,7 +17277,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/laravel-patterns",
       "relPath": "docs/tr/skills/laravel-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2658,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.596Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-patterns",
@@ -3315,7 +17340,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/laravel-patterns",
       "relPath": "skills/laravel-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2650,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.597Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-plugin-discovery",
@@ -3327,7 +17403,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/laravel-plugin-discovery",
       "relPath": "skills/laravel-plugin-discovery",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1615,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.598Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-security",
@@ -3339,7 +17466,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/laravel-security",
       "relPath": "docs/zh-CN/skills/laravel-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1138,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.598Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-security",
@@ -3351,7 +17529,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/laravel-security",
       "relPath": "docs/tr/skills/laravel-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1818,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.599Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-security",
@@ -3363,7 +17592,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/laravel-security",
       "relPath": "skills/laravel-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1792,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.599Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-tdd",
@@ -3375,7 +17655,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/laravel-tdd",
       "relPath": "docs/zh-CN/skills/laravel-tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1088,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.600Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-tdd",
@@ -3387,7 +17718,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/laravel-tdd",
       "relPath": "docs/tr/skills/laravel-tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1622,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.601Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-tdd",
@@ -3399,7 +17781,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/laravel-tdd",
       "relPath": "skills/laravel-tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1670,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.601Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-verification",
@@ -3411,7 +17844,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/laravel-verification",
       "relPath": "docs/zh-CN/skills/laravel-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 521,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.602Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-verification",
@@ -3423,7 +17907,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/laravel-verification",
       "relPath": "docs/tr/skills/laravel-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 983,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.602Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "laravel-verification",
@@ -3435,7 +17970,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/laravel-verification",
       "relPath": "skills/laravel-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1011,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.602Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "lead-intelligence",
@@ -3447,7 +18033,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/lead-intelligence",
       "relPath": "skills/lead-intelligence",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3310,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.603Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "liquid-glass-design",
@@ -3459,7 +18096,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/liquid-glass-design",
       "relPath": "docs/zh-CN/skills/liquid-glass-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1489,
+      "evalSummary": {
+        "overallScore": 44,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.604Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "liquid-glass-design",
@@ -3471,7 +18159,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/liquid-glass-design",
       "relPath": "skills/liquid-glass-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2309,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.605Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "llm-trading-agent-security",
@@ -3483,7 +18222,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/llm-trading-agent-security",
       "relPath": "skills/llm-trading-agent-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1178,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.605Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "logistics-exception-management",
@@ -3495,7 +18285,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/logistics-exception-management",
       "relPath": "docs/zh-CN/skills/logistics-exception-management",
-      "verified": true
+      "verified": true,
+      "tokenCount": 810,
+      "evalSummary": {
+        "overallScore": 39,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.606Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "logistics-exception-management",
@@ -3507,7 +18348,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/logistics-exception-management",
       "relPath": "skills/logistics-exception-management",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4703,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.607Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "manim-video",
@@ -3519,7 +18411,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/manim-video",
       "relPath": "skills/manim-video",
-      "verified": true
+      "verified": true,
+      "tokenCount": 821,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.607Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "market-research",
@@ -3531,7 +18474,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.cursor/skills/market-research",
       "relPath": ".cursor/skills/market-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 600,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.608Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "market-research",
@@ -3543,7 +18537,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/market-research",
       "relPath": ".agents/skills/market-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 600,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.608Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "market-research",
@@ -3555,7 +18600,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/market-research",
       "relPath": "docs/zh-CN/skills/market-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 174,
+      "evalSummary": {
+        "overallScore": 34,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.608Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "market-research",
@@ -3567,7 +18663,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/market-research",
       "relPath": "skills/market-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 600,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.608Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-server-patterns",
@@ -3579,7 +18726,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.cursor/skills/mcp-server-patterns",
       "relPath": ".cursor/skills/mcp-server-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1057,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.609Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-server-patterns",
@@ -3591,7 +18789,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/mcp-server-patterns",
       "relPath": ".agents/skills/mcp-server-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1057,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.609Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-server-patterns",
@@ -3603,7 +18852,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/mcp-server-patterns",
       "relPath": "docs/zh-CN/skills/mcp-server-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 417,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.609Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-server-patterns",
@@ -3615,7 +18915,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/mcp-server-patterns",
       "relPath": "skills/mcp-server-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1102,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.609Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "messages-ops",
@@ -3627,7 +18978,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/messages-ops",
       "relPath": "skills/messages-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 937,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.610Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nanoclaw-repl",
@@ -3639,7 +19041,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/nanoclaw-repl",
       "relPath": "docs/zh-CN/skills/nanoclaw-repl",
-      "verified": true
+      "verified": true,
+      "tokenCount": 119,
+      "evalSummary": {
+        "overallScore": 37,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.610Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nanoclaw-repl",
@@ -3651,7 +19104,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/nanoclaw-repl",
       "relPath": "skills/nanoclaw-repl",
-      "verified": true
+      "verified": true,
+      "tokenCount": 209,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.610Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nestjs-patterns",
@@ -3663,7 +19167,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/nestjs-patterns",
       "relPath": "skills/nestjs-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1592,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.611Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nextjs-turbopack",
@@ -3675,7 +19230,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.cursor/skills/nextjs-turbopack",
       "relPath": ".cursor/skills/nextjs-turbopack",
-      "verified": true
+      "verified": true,
+      "tokenCount": 630,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.611Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nextjs-turbopack",
@@ -3687,7 +19293,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/nextjs-turbopack",
       "relPath": ".agents/skills/nextjs-turbopack",
-      "verified": true
+      "verified": true,
+      "tokenCount": 630,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.611Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nextjs-turbopack",
@@ -3699,7 +19356,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/nextjs-turbopack",
       "relPath": "docs/zh-CN/skills/nextjs-turbopack",
-      "verified": true
+      "verified": true,
+      "tokenCount": 220,
+      "evalSummary": {
+        "overallScore": 41,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.612Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nextjs-turbopack",
@@ -3711,7 +19419,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/nextjs-turbopack",
       "relPath": "docs/tr/skills/nextjs-turbopack",
-      "verified": true
+      "verified": true,
+      "tokenCount": 616,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.612Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nextjs-turbopack",
@@ -3723,7 +19482,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/nextjs-turbopack",
       "relPath": "skills/nextjs-turbopack",
-      "verified": true
+      "verified": true,
+      "tokenCount": 630,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.612Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nodejs-keccak256",
@@ -3735,7 +19545,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/nodejs-keccak256",
       "relPath": "skills/nodejs-keccak256",
-      "verified": true
+      "verified": true,
+      "tokenCount": 597,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.612Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "nutrient-document-processing",
@@ -3747,7 +19608,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/nutrient-document-processing",
       "relPath": "docs/ja-JP/skills/nutrient-document-processing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 775,
+      "evalSummary": {
+        "overallScore": 41,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.613Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nutrient-document-processing",
@@ -3759,7 +19671,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/nutrient-document-processing",
       "relPath": "docs/zh-CN/skills/nutrient-document-processing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 888,
+      "evalSummary": {
+        "overallScore": 41,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.613Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nutrient-document-processing",
@@ -3771,7 +19734,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/nutrient-document-processing",
       "relPath": "skills/nutrient-document-processing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1137,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.614Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nuxt4-patterns",
@@ -3783,7 +19797,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/nuxt4-patterns",
       "relPath": "docs/zh-CN/skills/nuxt4-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 564,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.614Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nuxt4-patterns",
@@ -3795,7 +19860,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/nuxt4-patterns",
       "relPath": "skills/nuxt4-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1292,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.615Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "openclaw-persona-forge",
@@ -3807,7 +19923,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/openclaw-persona-forge",
       "relPath": "skills/openclaw-persona-forge",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1268,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.615Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "opensource-pipeline",
@@ -3819,7 +19986,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/opensource-pipeline",
       "relPath": "skills/opensource-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1738,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.616Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "perl-patterns",
@@ -3831,7 +20049,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/perl-patterns",
       "relPath": "docs/zh-CN/skills/perl-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3379,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.617Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "perl-patterns",
@@ -3843,7 +20112,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/perl-patterns",
       "relPath": "skills/perl-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3753,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.618Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "perl-security",
@@ -3855,7 +20175,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/perl-security",
       "relPath": "docs/zh-CN/skills/perl-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3337,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.619Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "perl-security",
@@ -3867,7 +20238,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/perl-security",
       "relPath": "skills/perl-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3915,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.620Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "perl-testing",
@@ -3879,7 +20301,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/perl-testing",
       "relPath": "docs/zh-CN/skills/perl-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2691,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.621Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "perl-testing",
@@ -3891,7 +20364,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/perl-testing",
       "relPath": "skills/perl-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3283,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.622Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "plankton-code-quality",
@@ -3903,7 +20427,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/plankton-code-quality",
       "relPath": "docs/zh-CN/skills/plankton-code-quality",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1360,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.623Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "plankton-code-quality",
@@ -3915,7 +20490,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/plankton-code-quality",
       "relPath": "skills/plankton-code-quality",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2233,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.623Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgres-patterns",
@@ -3927,7 +20553,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/postgres-patterns",
       "relPath": "docs/ja-JP/skills/postgres-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 904,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.624Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgres-patterns",
@@ -3939,7 +20616,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/postgres-patterns",
       "relPath": "docs/zh-CN/skills/postgres-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 935,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.624Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgres-patterns",
@@ -3951,7 +20679,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/postgres-patterns",
       "relPath": "docs/zh-TW/skills/postgres-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 932,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.624Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgres-patterns",
@@ -3963,7 +20742,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/postgres-patterns",
       "relPath": "docs/ko-KR/skills/postgres-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1085,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.625Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgres-patterns",
@@ -3975,7 +20805,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/postgres-patterns",
       "relPath": "docs/tr/skills/postgres-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1093,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.625Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgres-patterns",
@@ -3987,7 +20868,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/postgres-patterns",
       "relPath": ".kiro/skills/postgres-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1187,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.626Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgres-patterns",
@@ -3999,7 +20931,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/postgres-patterns",
       "relPath": "skills/postgres-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1087,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.626Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-capability",
@@ -4011,7 +20994,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/product-capability",
       "relPath": ".agents/skills/product-capability",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1195,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.626Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-capability",
@@ -4023,7 +21057,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/product-capability",
       "relPath": "skills/product-capability",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1195,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.627Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-lens",
@@ -4035,7 +21120,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/product-lens",
       "relPath": "skills/product-lens",
-      "verified": true
+      "verified": true,
+      "tokenCount": 898,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.627Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "production-scheduling",
@@ -4047,7 +21183,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/production-scheduling",
       "relPath": "docs/zh-CN/skills/production-scheduling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 902,
+      "evalSummary": {
+        "overallScore": 39,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.628Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "production-scheduling",
@@ -4059,7 +21246,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/production-scheduling",
       "relPath": "skills/production-scheduling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8214,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.630Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "project-flow-ops",
@@ -4071,7 +21309,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/project-flow-ops",
       "relPath": "skills/project-flow-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 990,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.630Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "project-guidelines-example",
@@ -4083,7 +21372,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/project-guidelines-example",
       "relPath": "docs/ja-JP/skills/project-guidelines-example",
-      "verified": false
+      "verified": false,
+      "tokenCount": 2537,
+      "evalSummary": {
+        "overallScore": 44,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.631Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "project-guidelines-example",
@@ -4095,7 +21435,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/project-guidelines-example",
       "relPath": "docs/zh-TW/skills/project-guidelines-example",
-      "verified": false
+      "verified": false,
+      "tokenCount": 2564,
+      "evalSummary": {
+        "overallScore": 44,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.632Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "prompt-optimizer",
@@ -4107,7 +21498,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/prompt-optimizer",
       "relPath": "docs/zh-CN/skills/prompt-optimizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2395,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.633Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "prompt-optimizer",
@@ -4119,7 +21561,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/prompt-optimizer",
       "relPath": "skills/prompt-optimizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4445,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.634Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "python-patterns",
@@ -4131,7 +21624,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/python-patterns",
       "relPath": "docs/ja-JP/skills/python-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4509,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.635Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-patterns",
@@ -4143,7 +21687,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/python-patterns",
       "relPath": "docs/zh-CN/skills/python-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4574,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.637Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-patterns",
@@ -4155,7 +21750,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/python-patterns",
       "relPath": "docs/tr/skills/python-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4922,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.639Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-patterns",
@@ -4167,7 +21813,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/python-patterns",
       "relPath": ".kiro/skills/python-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2872,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.639Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-patterns",
@@ -4179,7 +21876,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/python-patterns",
       "relPath": "skills/python-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4938,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.641Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-testing",
@@ -4191,7 +21939,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/python-testing",
       "relPath": "docs/ja-JP/skills/python-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4107,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.642Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-testing",
@@ -4203,7 +22002,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/python-testing",
       "relPath": "docs/zh-CN/skills/python-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4168,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.644Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-testing",
@@ -4215,7 +22065,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/python-testing",
       "relPath": "docs/tr/skills/python-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4732,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.646Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-testing",
@@ -4227,7 +22128,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/python-testing",
       "relPath": ".kiro/skills/python-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2565,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.647Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-testing",
@@ -4239,7 +22191,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/python-testing",
       "relPath": "skills/python-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4722,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.648Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pytorch-patterns",
@@ -4251,7 +22254,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/pytorch-patterns",
       "relPath": "docs/zh-CN/skills/pytorch-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2948,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.649Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pytorch-patterns",
@@ -4263,7 +22317,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/pytorch-patterns",
       "relPath": "skills/pytorch-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3240,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.650Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "quality-nonconformance",
@@ -4275,7 +22380,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/quality-nonconformance",
       "relPath": "docs/zh-CN/skills/quality-nonconformance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1157,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.651Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "quality-nonconformance",
@@ -4287,7 +22443,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/quality-nonconformance",
       "relPath": "skills/quality-nonconformance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 8399,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.653Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ralphinho-rfc-pipeline",
@@ -4299,7 +22506,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/ralphinho-rfc-pipeline",
       "relPath": "docs/zh-CN/skills/ralphinho-rfc-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 162,
+      "evalSummary": {
+        "overallScore": 44,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.653Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ralphinho-rfc-pipeline",
@@ -4311,7 +22569,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/ralphinho-rfc-pipeline",
       "relPath": "skills/ralphinho-rfc-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 394,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.654Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "regex-vs-llm-structured-text",
@@ -4323,7 +22632,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/regex-vs-llm-structured-text",
       "relPath": "docs/zh-CN/skills/regex-vs-llm-structured-text",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1483,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.654Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "regex-vs-llm-structured-text",
@@ -4335,7 +22695,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/regex-vs-llm-structured-text",
       "relPath": "skills/regex-vs-llm-structured-text",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2016,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.655Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "remotion-video-creation",
@@ -4347,7 +22758,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/remotion-video-creation",
       "relPath": "skills/remotion-video-creation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 744,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.655Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "repo-scan",
@@ -4359,7 +22821,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/repo-scan",
       "relPath": "skills/repo-scan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 991,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.656Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "research-ops",
@@ -4371,7 +22884,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/research-ops",
       "relPath": "skills/research-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1051,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.656Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "returns-reverse-logistics",
@@ -4383,7 +22947,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/returns-reverse-logistics",
       "relPath": "docs/zh-CN/skills/returns-reverse-logistics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1120,
+      "evalSummary": {
+        "overallScore": 39,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.657Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "returns-reverse-logistics",
@@ -4395,7 +23010,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/returns-reverse-logistics",
       "relPath": "skills/returns-reverse-logistics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7110,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.658Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "rules-distill",
@@ -4407,7 +23073,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/rules-distill",
       "relPath": "docs/zh-CN/skills/rules-distill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1096,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.659Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rules-distill",
@@ -4419,7 +23136,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/rules-distill",
       "relPath": "skills/rules-distill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2560,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.660Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rust-patterns",
@@ -4431,7 +23199,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/rust-patterns",
       "relPath": "docs/zh-CN/skills/rust-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3375,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.661Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rust-patterns",
@@ -4443,7 +23262,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/rust-patterns",
       "relPath": "docs/tr/skills/rust-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3871,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.662Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rust-patterns",
@@ -4455,7 +23325,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/rust-patterns",
       "relPath": "skills/rust-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3885,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.663Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rust-testing",
@@ -4467,7 +23388,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/rust-testing",
       "relPath": "docs/zh-CN/skills/rust-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2968,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.664Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rust-testing",
@@ -4479,7 +23451,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/rust-testing",
       "relPath": "docs/tr/skills/rust-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3374,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.665Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rust-testing",
@@ -4491,7 +23514,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/rust-testing",
       "relPath": "skills/rust-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3412,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.666Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "safety-guard",
@@ -4503,7 +23577,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/safety-guard",
       "relPath": "skills/safety-guard",
-      "verified": true
+      "verified": true,
+      "tokenCount": 536,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.666Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "santa-method",
@@ -4515,7 +23640,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/santa-method",
       "relPath": "skills/santa-method",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3718,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.667Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "search-first",
@@ -4527,7 +23703,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/search-first",
       "relPath": "docs/zh-CN/skills/search-first",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1131,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.668Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "search-first",
@@ -4539,7 +23766,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/search-first",
       "relPath": ".kiro/skills/search-first",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1829,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.668Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "search-first",
@@ -4551,7 +23829,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/search-first",
       "relPath": "skills/search-first",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1731,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.669Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-bounty-hunter",
@@ -4563,7 +23892,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/security-bounty-hunter",
       "relPath": "skills/security-bounty-hunter",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1028,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.669Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "security-review",
@@ -4575,7 +23955,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/security-review",
       "relPath": ".agents/skills/security-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3352,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.670Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-review",
@@ -4587,7 +24018,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/security-review",
       "relPath": "docs/ja-JP/skills/security-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2389,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.671Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-review",
@@ -4599,7 +24081,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/security-review",
       "relPath": "docs/zh-CN/skills/security-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2694,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.672Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-review",
@@ -4611,7 +24144,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/security-review",
       "relPath": "docs/zh-TW/skills/security-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2601,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.673Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-review",
@@ -4623,7 +24207,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/security-review",
       "relPath": "docs/ko-KR/skills/security-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3432,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.674Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-review",
@@ -4635,7 +24270,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/security-review",
       "relPath": "docs/tr/skills/security-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3344,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.675Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-review",
@@ -4647,7 +24333,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/security-review",
       "relPath": ".kiro/skills/security-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3358,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.676Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-review",
@@ -4659,7 +24396,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/security-review",
       "relPath": "skills/security-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3352,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.677Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-scan",
@@ -4671,7 +24459,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/security-scan",
       "relPath": "docs/ja-JP/skills/security-scan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 608,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.678Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-scan",
@@ -4683,7 +24522,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/security-scan",
       "relPath": "docs/zh-CN/skills/security-scan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 675,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.678Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-scan",
@@ -4695,7 +24585,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/security-scan",
       "relPath": "skills/security-scan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1111,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.678Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "seo",
@@ -4707,7 +24648,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/seo",
       "relPath": "skills/seo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1222,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.679Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "skill-comply",
@@ -4719,7 +24711,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/skill-comply",
       "relPath": "skills/skill-comply",
-      "verified": true
+      "verified": true,
+      "tokenCount": 594,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.679Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "skill-stocktake",
@@ -4731,7 +24774,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/skill-stocktake",
       "relPath": "docs/zh-CN/skills/skill-stocktake",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1013,
+      "evalSummary": {
+        "overallScore": 34,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.679Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "skill-stocktake",
@@ -4743,7 +24837,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/skill-stocktake",
       "relPath": "skills/skill-stocktake",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2081,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.680Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "social-graph-ranker",
@@ -4755,7 +24900,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/social-graph-ranker",
       "relPath": "skills/social-graph-ranker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1229,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.681Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-patterns",
@@ -4767,7 +24963,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/springboot-patterns",
       "relPath": "docs/ja-JP/skills/springboot-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1724,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.681Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-patterns",
@@ -4779,7 +25026,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/springboot-patterns",
       "relPath": "docs/zh-CN/skills/springboot-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2046,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.682Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-patterns",
@@ -4791,7 +25089,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/springboot-patterns",
       "relPath": "docs/tr/skills/springboot-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2338,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.683Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-patterns",
@@ -4803,7 +25152,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/springboot-patterns",
       "relPath": "skills/springboot-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2400,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.684Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-security",
@@ -4815,7 +25215,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/springboot-security",
       "relPath": "docs/ja-JP/skills/springboot-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 498,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.684Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-security",
@@ -4827,7 +25278,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/springboot-security",
       "relPath": "docs/zh-CN/skills/springboot-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1334,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.685Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-security",
@@ -4839,7 +25341,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/springboot-security",
       "relPath": "docs/tr/skills/springboot-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1844,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.685Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-security",
@@ -4851,7 +25404,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/springboot-security",
       "relPath": "skills/springboot-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1820,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.686Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-tdd",
@@ -4863,7 +25467,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/springboot-tdd",
       "relPath": "docs/ja-JP/skills/springboot-tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 617,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.686Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-tdd",
@@ -4875,7 +25530,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/springboot-tdd",
       "relPath": "docs/zh-CN/skills/springboot-tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 640,
+      "evalSummary": {
+        "overallScore": 47,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.687Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-tdd",
@@ -4887,7 +25593,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/springboot-tdd",
       "relPath": "docs/tr/skills/springboot-tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 820,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.687Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-tdd",
@@ -4899,7 +25656,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/springboot-tdd",
       "relPath": "skills/springboot-tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 808,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.687Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-verification",
@@ -4911,7 +25719,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/springboot-verification",
       "relPath": "docs/ja-JP/skills/springboot-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 339,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.688Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-verification",
@@ -4923,7 +25782,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/springboot-verification",
       "relPath": "docs/zh-CN/skills/springboot-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 997,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.688Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-verification",
@@ -4935,7 +25845,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/springboot-verification",
       "relPath": "docs/tr/skills/springboot-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1301,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.689Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "springboot-verification",
@@ -4947,7 +25908,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/springboot-verification",
       "relPath": "skills/springboot-verification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1313,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.689Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "strategic-compact",
@@ -4959,7 +25971,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/strategic-compact",
       "relPath": ".agents/skills/strategic-compact",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1136,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.690Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "strategic-compact",
@@ -4971,7 +26034,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/strategic-compact",
       "relPath": "docs/ja-JP/skills/strategic-compact",
-      "verified": true
+      "verified": true,
+      "tokenCount": 224,
+      "evalSummary": {
+        "overallScore": 36,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.690Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "strategic-compact",
@@ -4983,7 +26097,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/strategic-compact",
       "relPath": "docs/zh-CN/skills/strategic-compact",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1316,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.690Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "strategic-compact",
@@ -4995,7 +26160,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/strategic-compact",
       "relPath": "docs/zh-TW/skills/strategic-compact",
-      "verified": true
+      "verified": true,
+      "tokenCount": 274,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.690Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "strategic-compact",
@@ -5007,7 +26223,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/strategic-compact",
       "relPath": "docs/ko-KR/skills/strategic-compact",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1102,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.690Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "strategic-compact",
@@ -5019,7 +26286,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/strategic-compact",
       "relPath": "skills/strategic-compact",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1464,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.691Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "swift-actor-persistence",
@@ -5031,7 +26349,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/swift-actor-persistence",
       "relPath": "docs/zh-CN/skills/swift-actor-persistence",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1040,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.691Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "swift-actor-persistence",
@@ -5043,7 +26412,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/swift-actor-persistence",
       "relPath": "skills/swift-actor-persistence",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1448,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.692Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "swift-concurrency-6-2",
@@ -5055,7 +26475,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/swift-concurrency-6-2",
       "relPath": "docs/zh-CN/skills/swift-concurrency-6-2",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1465,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.692Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "swift-concurrency-6-2",
@@ -5067,7 +26538,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/swift-concurrency-6-2",
       "relPath": "skills/swift-concurrency-6-2",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2225,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.693Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "swift-protocol-di-testing",
@@ -5079,7 +26601,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/swift-protocol-di-testing",
       "relPath": "docs/zh-CN/skills/swift-protocol-di-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1274,
+      "evalSummary": {
+        "overallScore": 47,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.693Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "swift-protocol-di-testing",
@@ -5091,7 +26664,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/swift-protocol-di-testing",
       "relPath": "skills/swift-protocol-di-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1738,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.694Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "swiftui-patterns",
@@ -5103,7 +26727,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/swiftui-patterns",
       "relPath": "docs/zh-CN/skills/swiftui-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1643,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.695Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "swiftui-patterns",
@@ -5115,7 +26790,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/swiftui-patterns",
       "relPath": "skills/swiftui-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2085,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.696Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd-workflow",
@@ -5127,7 +26853,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/tdd-workflow",
       "relPath": ".agents/skills/tdd-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2642,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.696Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd-workflow",
@@ -5139,7 +26916,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/tdd-workflow",
       "relPath": "docs/ja-JP/skills/tdd-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1827,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.697Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd-workflow",
@@ -5151,7 +26979,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/tdd-workflow",
       "relPath": "docs/zh-CN/skills/tdd-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2068,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.698Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd-workflow",
@@ -5163,7 +27042,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/tdd-workflow",
       "relPath": "docs/zh-TW/skills/tdd-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1975,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.699Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd-workflow",
@@ -5175,7 +27105,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/tdd-workflow",
       "relPath": "docs/ko-KR/skills/tdd-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2631,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.699Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd-workflow",
@@ -5187,7 +27168,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/tdd-workflow",
       "relPath": "docs/tr/skills/tdd-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2634,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.700Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd-workflow",
@@ -5199,7 +27231,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/tdd-workflow",
       "relPath": ".kiro/skills/tdd-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2654,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.701Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "tdd-workflow",
@@ -5211,7 +27294,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/tdd-workflow",
       "relPath": "skills/tdd-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3694,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.702Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "team-builder",
@@ -5223,7 +27357,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/team-builder",
       "relPath": "docs/zh-CN/skills/team-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 591,
+      "evalSummary": {
+        "overallScore": 41,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.702Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "team-builder",
@@ -5235,7 +27420,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/team-builder",
       "relPath": "skills/team-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1983,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.703Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "terminal-ops",
@@ -5247,7 +27483,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/terminal-ops",
       "relPath": "skills/terminal-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 943,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.703Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "token-budget-advisor",
@@ -5259,7 +27546,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/token-budget-advisor",
       "relPath": "skills/token-budget-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2178,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.704Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ui-demo",
@@ -5271,7 +27609,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/ui-demo",
       "relPath": "skills/ui-demo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4389,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.705Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "unified-notifications-ops",
@@ -5283,7 +27672,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/unified-notifications-ops",
       "relPath": "skills/unified-notifications-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1655,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.705Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "verification-loop",
@@ -5295,7 +27735,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/verification-loop",
       "relPath": ".agents/skills/verification-loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 716,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.706Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "verification-loop",
@@ -5307,7 +27798,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ja-JP/skills/verification-loop",
       "relPath": "docs/ja-JP/skills/verification-loop",
-      "verified": false
+      "verified": false,
+      "tokenCount": 402,
+      "evalSummary": {
+        "overallScore": 31,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.706Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "verification-loop",
@@ -5319,7 +27861,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/verification-loop",
       "relPath": "docs/zh-CN/skills/verification-loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 465,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.706Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "verification-loop",
@@ -5331,7 +27924,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-TW/skills/verification-loop",
       "relPath": "docs/zh-TW/skills/verification-loop",
-      "verified": false
+      "verified": false,
+      "tokenCount": 422,
+      "evalSummary": {
+        "overallScore": 33,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.706Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "verification-loop",
@@ -5343,7 +27987,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/ko-KR/skills/verification-loop",
       "relPath": "docs/ko-KR/skills/verification-loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 701,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.706Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "verification-loop",
@@ -5355,7 +28050,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/tr/skills/verification-loop",
       "relPath": "docs/tr/skills/verification-loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 721,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.707Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "verification-loop",
@@ -5367,7 +28113,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.kiro/skills/verification-loop",
       "relPath": ".kiro/skills/verification-loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 718,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.707Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "verification-loop",
@@ -5379,7 +28176,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/verification-loop",
       "relPath": "skills/verification-loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 716,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.707Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "video-editing",
@@ -5391,7 +28239,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/video-editing",
       "relPath": ".agents/skills/video-editing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2724,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.708Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "video-editing",
@@ -5403,7 +28302,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/video-editing",
       "relPath": "docs/zh-CN/skills/video-editing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1420,
+      "evalSummary": {
+        "overallScore": 41,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.709Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "video-editing",
@@ -5415,7 +28365,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/video-editing",
       "relPath": "skills/video-editing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2731,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.710Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "videodb",
@@ -5427,7 +28428,58 @@
       "allowedTools": ["Read", "Grep", "Glob", "Bash(python:*)"],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/videodb",
       "relPath": "docs/zh-CN/skills/videodb",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1989,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.710Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "videodb",
@@ -5439,7 +28491,58 @@
       "allowedTools": ["Read", "Grep", "Glob", "Bash(python:*)"],
       "installUrl": "github:affaan-m/everything-claude-code:skills/videodb",
       "relPath": "skills/videodb",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3461,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.712Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "visa-doc-translate",
@@ -5451,7 +28554,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/visa-doc-translate",
       "relPath": "docs/zh-CN/skills/visa-doc-translate",
-      "verified": true
+      "verified": true,
+      "tokenCount": 548,
+      "evalSummary": {
+        "overallScore": 39,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.712Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "visa-doc-translate",
@@ -5463,7 +28617,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/visa-doc-translate",
       "relPath": "skills/visa-doc-translate",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1076,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.712Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "workspace-surface-audit",
@@ -5475,7 +28680,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/workspace-surface-audit",
       "relPath": "skills/workspace-surface-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1519,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.713Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "x-api",
@@ -5487,7 +28743,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:.agents/skills/x-api",
       "relPath": ".agents/skills/x-api",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1554,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.714Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "x-api",
@@ -5499,7 +28806,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:docs/zh-CN/skills/x-api",
       "relPath": "docs/zh-CN/skills/x-api",
-      "verified": true
+      "verified": true,
+      "tokenCount": 935,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.714Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "x-api",
@@ -5511,7 +28869,58 @@
       "allowedTools": [],
       "installUrl": "github:affaan-m/everything-claude-code:skills/x-api",
       "relPath": "skills/x-api",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1554,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:59.715Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/alirezarezvani_claude-skills.json
+++ b/data/skill-index/alirezarezvani_claude-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/alirezarezvani/claude-skills.git",
   "owner": "alirezarezvani",
   "repo": "claude-skills",
-  "updatedAt": "2026-04-20T06:33:46.912Z",
+  "updatedAt": "2026-04-20T07:46:04.980Z",
   "skillCount": 508,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/a11y-audit",
       "relPath": ".gemini/skills/a11y-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2605,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.374Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "a11y-audit",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cmd-a11y-audit",
       "relPath": ".gemini/skills/cmd-a11y-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 607,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.375Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "a11y-audit",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/a11y-audit",
       "relPath": ".codex/skills/a11y-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2605,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.375Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ab-test-setup",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ab-test-setup",
       "relPath": ".gemini/skills/ab-test-setup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2624,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.376Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ab-test-setup",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ab-test-setup",
       "relPath": ".codex/skills/ab-test-setup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2624,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.377Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ad-creative",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ad-creative",
       "relPath": ".gemini/skills/ad-creative",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3422,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.378Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ad-creative",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ad-creative",
       "relPath": ".codex/skills/ad-creative",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3422,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.379Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "adversarial-reviewer",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/adversarial-reviewer",
       "relPath": ".gemini/skills/adversarial-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3464,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.380Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "adversarial-reviewer",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/adversarial-reviewer",
       "relPath": ".codex/skills/adversarial-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3464,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.381Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "Agent Name",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/TEMPLATE",
       "relPath": ".gemini/skills/TEMPLATE",
-      "verified": true
+      "verified": true,
+      "tokenCount": 599,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.381Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "Agent Name",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/README",
       "relPath": ".gemini/skills/README",
-      "verified": true
+      "verified": true,
+      "tokenCount": 741,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.382Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-designer",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/agent-designer",
       "relPath": ".gemini/skills/agent-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2707,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.383Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-designer",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-designer",
       "relPath": ".codex/skills/agent-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2707,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.383Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-protocol",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/agent-protocol",
       "relPath": ".gemini/skills/agent-protocol",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3901,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.385Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "agent-protocol",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-protocol",
       "relPath": ".codex/skills/agent-protocol",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3901,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.386Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "agent-workflow-designer",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/agent-workflow-designer",
       "relPath": ".gemini/skills/agent-workflow-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 555,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.386Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-workflow-designer",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agent-workflow-designer",
       "relPath": ".codex/skills/agent-workflow-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 555,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.386Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agenthub",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/agenthub",
       "relPath": ".gemini/skills/agenthub",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2162,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.387Z",
+        "evaluatedVersion": "2.1.2"
+      }
     },
     {
       "name": "agenthub",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub",
       "relPath": ".codex/skills/agenthub",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2162,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.388Z",
+        "evaluatedVersion": "2.1.2"
+      }
     },
     {
       "name": "agile-product-owner",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/agile-product-owner",
       "relPath": ".gemini/skills/agile-product-owner",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3322,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.389Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agile-product-owner",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agile-product-owner",
       "relPath": ".codex/skills/agile-product-owner",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3322,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.390Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ai-security",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ai-security",
       "relPath": ".gemini/skills/ai-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4674,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.391Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ai-security",
@@ -279,7 +1401,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-security",
       "relPath": ".codex/skills/ai-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4674,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.393Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ai-seo",
@@ -291,7 +1464,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ai-seo",
       "relPath": ".gemini/skills/ai-seo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4792,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.394Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ai-seo",
@@ -303,7 +1527,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ai-seo",
       "relPath": ".codex/skills/ai-seo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4792,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.395Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "analytics-tracking",
@@ -315,7 +1590,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/analytics-tracking",
       "relPath": ".gemini/skills/analytics-tracking",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4077,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.397Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "analytics-tracking",
@@ -327,7 +1653,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/analytics-tracking",
       "relPath": ".codex/skills/analytics-tracking",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4077,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.398Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "api-design-reviewer",
@@ -339,7 +1716,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/api-design-reviewer",
       "relPath": ".gemini/skills/api-design-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2861,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.399Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "api-design-reviewer",
@@ -351,7 +1779,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/api-design-reviewer",
       "relPath": ".codex/skills/api-design-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2861,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.400Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "api-test-suite-builder",
@@ -363,7 +1842,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/api-test-suite-builder",
       "relPath": ".gemini/skills/api-test-suite-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1759,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.401Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "api-test-suite-builder",
@@ -375,7 +1905,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/api-test-suite-builder",
       "relPath": ".codex/skills/api-test-suite-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1759,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.401Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "app-store-optimization",
@@ -387,7 +1968,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/app-store-optimization",
       "relPath": ".gemini/skills/app-store-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4649,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.402Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "app-store-optimization",
@@ -399,7 +2031,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/app-store-optimization",
       "relPath": ".codex/skills/app-store-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4649,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.404Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "apple-hig-expert",
@@ -411,7 +2094,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/apple-hig-expert",
       "relPath": ".gemini/skills/apple-hig-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 964,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.404Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "apple-hig-expert",
@@ -423,7 +2157,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/apple-hig-expert",
       "relPath": ".codex/skills/apple-hig-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 964,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.404Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "atlassian-admin",
@@ -435,7 +2220,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/atlassian-admin",
       "relPath": ".gemini/skills/atlassian-admin",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3111,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.405Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "atlassian-admin",
@@ -447,7 +2283,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-admin",
       "relPath": ".codex/skills/atlassian-admin",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3111,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.406Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "atlassian-templates",
@@ -459,7 +2346,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/atlassian-templates",
       "relPath": ".gemini/skills/atlassian-templates",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2511,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.407Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "atlassian-templates",
@@ -471,7 +2409,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/atlassian-templates",
       "relPath": ".codex/skills/atlassian-templates",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2511,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.408Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "autoresearch-agent",
@@ -483,7 +2472,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/autoresearch-agent",
       "relPath": ".gemini/skills/autoresearch-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3493,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.409Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "autoresearch-agent",
@@ -495,7 +2535,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent",
       "relPath": ".codex/skills/autoresearch-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3493,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.410Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "aws-solution-architect",
@@ -507,7 +2598,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/aws-solution-architect",
       "relPath": ".gemini/skills/aws-solution-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2498,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.411Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "aws-solution-architect",
@@ -519,7 +2661,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/aws-solution-architect",
       "relPath": ".codex/skills/aws-solution-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2498,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.412Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-cloud-architect",
@@ -531,7 +2724,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/azure-cloud-architect",
       "relPath": ".gemini/skills/azure-cloud-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3602,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.413Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-cloud-architect",
@@ -543,7 +2787,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/azure-cloud-architect",
       "relPath": ".codex/skills/azure-cloud-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3602,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.414Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "behuman",
@@ -555,7 +2850,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/behuman",
       "relPath": ".gemini/skills/behuman",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2434,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.415Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "behuman",
@@ -567,7 +2913,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/behuman",
       "relPath": ".codex/skills/behuman",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2434,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.415Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "board",
@@ -579,7 +2976,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/board",
       "relPath": ".gemini/skills/board",
-      "verified": true
+      "verified": true,
+      "tokenCount": 637,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.416Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "board-deck-builder",
@@ -591,7 +3039,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/board-deck-builder",
       "relPath": ".gemini/skills/board-deck-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2264,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.416Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "board-deck-builder",
@@ -603,7 +3102,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-deck-builder",
       "relPath": ".codex/skills/board-deck-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2264,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.417Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "board-meeting",
@@ -615,7 +3165,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/board-meeting",
       "relPath": ".gemini/skills/board-meeting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1456,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.418Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "board-meeting",
@@ -627,7 +3228,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/board-meeting",
       "relPath": ".codex/skills/board-meeting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1456,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.418Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "board-prep",
@@ -639,7 +3291,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/board-prep",
       "relPath": ".gemini/skills/board-prep",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2027,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.419Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "brand-guidelines",
@@ -651,7 +3354,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/brand-guidelines",
       "relPath": ".gemini/skills/brand-guidelines",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1547,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.419Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "brand-guidelines",
@@ -663,7 +3417,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/brand-guidelines",
       "relPath": ".codex/skills/brand-guidelines",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1547,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.420Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "browser-automation",
@@ -675,7 +3480,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/browser-automation",
       "relPath": ".gemini/skills/browser-automation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3487,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.421Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "browser-automation",
@@ -687,7 +3543,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/browser-automation",
       "relPath": ".codex/skills/browser-automation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3487,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.422Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "browserstack",
@@ -699,7 +3606,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/browserstack",
       "relPath": ".gemini/skills/browserstack",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1211,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.422Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "business-growth-skills",
@@ -711,7 +3669,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/business-growth-bundle",
       "relPath": ".gemini/skills/business-growth-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 368,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.422Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "business-growth-skills",
@@ -723,7 +3732,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:business-growth",
       "relPath": "business-growth",
-      "verified": true
+      "verified": true,
+      "tokenCount": 368,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.423Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "business-investment-advisor",
@@ -735,7 +3795,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/business-investment-advisor",
       "relPath": ".gemini/skills/business-investment-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3031,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.423Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "business-investment-advisor",
@@ -747,7 +3858,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-investment-advisor",
       "relPath": ".codex/skills/business-investment-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3031,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.424Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "c-level-advisor",
@@ -759,7 +3921,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/c-level-advisor-main",
       "relPath": ".gemini/skills/c-level-advisor-main",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1775,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.425Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "c-level-advisor",
@@ -771,7 +3984,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/c-level-advisor-bundle",
       "relPath": ".gemini/skills/c-level-advisor-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1775,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.425Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "c-level-advisor",
@@ -783,7 +4047,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor",
       "relPath": "c-level-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1775,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.426Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "campaign-analytics",
@@ -795,7 +4110,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/campaign-analytics",
       "relPath": ".gemini/skills/campaign-analytics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2077,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.427Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "campaign-analytics",
@@ -807,7 +4173,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/campaign-analytics",
       "relPath": ".codex/skills/campaign-analytics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2077,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.428Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "capa-officer",
@@ -819,7 +4236,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/capa-officer",
       "relPath": ".gemini/skills/capa-officer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3942,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.429Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "capa-officer",
@@ -831,7 +4299,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/capa-officer",
       "relPath": ".codex/skills/capa-officer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3942,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.430Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ceo-advisor",
@@ -843,7 +4362,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ceo-advisor",
       "relPath": ".gemini/skills/ceo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2272,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.431Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "ceo-advisor",
@@ -855,7 +4425,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ceo-advisor",
       "relPath": ".codex/skills/ceo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2272,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.432Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "cfo-advisor",
@@ -867,7 +4488,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cfo-advisor",
       "relPath": ".gemini/skills/cfo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2049,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.432Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "cfo-advisor",
@@ -879,7 +4551,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cfo-advisor",
       "relPath": ".codex/skills/cfo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2049,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.433Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "challenge",
@@ -891,7 +4614,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/challenge",
       "relPath": ".gemini/skills/challenge",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1997,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.434Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "change-management",
@@ -903,7 +4677,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/change-management",
       "relPath": ".gemini/skills/change-management",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3381,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.435Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "change-management",
@@ -915,7 +4740,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/change-management",
       "relPath": ".codex/skills/change-management",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3381,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.436Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "changelog",
@@ -927,7 +4803,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/changelog",
       "relPath": ".gemini/skills/changelog",
-      "verified": true
+      "verified": true,
+      "tokenCount": 205,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.436Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "changelog-generator",
@@ -939,7 +4866,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/changelog-generator",
       "relPath": ".gemini/skills/changelog-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1215,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.436Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "changelog-generator",
@@ -951,7 +4929,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/changelog-generator",
       "relPath": ".codex/skills/changelog-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1215,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.437Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "chief-of-staff",
@@ -963,7 +4992,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/chief-of-staff",
       "relPath": ".gemini/skills/chief-of-staff",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1508,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.437Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "chief-of-staff",
@@ -975,7 +5055,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/chief-of-staff",
       "relPath": ".codex/skills/chief-of-staff",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1508,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.438Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "chro-advisor",
@@ -987,7 +5118,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/chro-advisor",
       "relPath": ".gemini/skills/chro-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2117,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.438Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "chro-advisor",
@@ -999,7 +5181,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/chro-advisor",
       "relPath": ".codex/skills/chro-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2117,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.439Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "churn-prevention",
@@ -1011,7 +5244,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/churn-prevention",
       "relPath": ".gemini/skills/churn-prevention",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3379,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.440Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "churn-prevention",
@@ -1023,7 +5307,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/churn-prevention",
       "relPath": ".codex/skills/churn-prevention",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3379,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.441Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ci-cd-pipeline-builder",
@@ -1035,7 +5370,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ci-cd-pipeline-builder",
       "relPath": ".gemini/skills/ci-cd-pipeline-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1170,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.441Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ci-cd-pipeline-builder",
@@ -1047,7 +5433,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ci-cd-pipeline-builder",
       "relPath": ".codex/skills/ci-cd-pipeline-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1170,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.442Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ciso-advisor",
@@ -1059,7 +5496,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ciso-advisor",
       "relPath": ".gemini/skills/ciso-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2029,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.442Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ciso-advisor",
@@ -1071,7 +5559,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ciso-advisor",
       "relPath": ".codex/skills/ciso-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2029,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.443Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "cloud-security",
@@ -1083,7 +5622,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cloud-security",
       "relPath": ".gemini/skills/cloud-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4335,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.444Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cloud-security",
@@ -1095,7 +5685,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cloud-security",
       "relPath": ".codex/skills/cloud-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4335,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.445Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cmo-advisor",
@@ -1107,7 +5748,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cmo-advisor",
       "relPath": ".gemini/skills/cmo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2327,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.446Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "cmo-advisor",
@@ -1119,7 +5811,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cmo-advisor",
       "relPath": ".codex/skills/cmo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2327,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.447Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "code-reviewer",
@@ -1131,7 +5874,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/code-reviewer",
       "relPath": ".gemini/skills/code-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1136,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.448Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "code-reviewer",
@@ -1143,7 +5937,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-reviewer",
       "relPath": ".codex/skills/code-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1136,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.448Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "code-to-prd",
@@ -1155,7 +6000,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/code-to-prd",
       "relPath": ".gemini/skills/code-to-prd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5178,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.450Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "code-to-prd",
@@ -1167,7 +6063,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cmd-code-to-prd",
       "relPath": ".gemini/skills/cmd-code-to-prd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 606,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.450Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "code-to-prd",
@@ -1179,7 +6126,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-to-prd",
       "relPath": ".codex/skills/code-to-prd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5178,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.452Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "code-tour",
@@ -1191,7 +6189,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/code-tour",
       "relPath": ".gemini/skills/code-tour",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1950,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.452Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "code-tour",
@@ -1203,7 +6252,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-tour",
       "relPath": ".codex/skills/code-tour",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1950,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.453Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "codebase-onboarding",
@@ -1215,7 +6315,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/codebase-onboarding",
       "relPath": ".gemini/skills/codebase-onboarding",
-      "verified": true
+      "verified": true,
+      "tokenCount": 551,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.453Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "codebase-onboarding",
@@ -1227,7 +6378,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/codebase-onboarding",
       "relPath": ".codex/skills/codebase-onboarding",
-      "verified": true
+      "verified": true,
+      "tokenCount": 551,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.453Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cold-email",
@@ -1239,7 +6441,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cold-email",
       "relPath": ".gemini/skills/cold-email",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4563,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.454Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "cold-email",
@@ -1251,7 +6504,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cold-email",
       "relPath": ".codex/skills/cold-email",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4563,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.456Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "company-os",
@@ -1263,7 +6567,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/company-os",
       "relPath": ".gemini/skills/company-os",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3304,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.457Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "company-os",
@@ -1275,7 +6630,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/company-os",
       "relPath": ".codex/skills/company-os",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3304,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.458Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "competitive-intel",
@@ -1287,7 +6693,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitive-intel",
       "relPath": ".gemini/skills/competitive-intel",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2338,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.458Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "competitive-intel",
@@ -1299,7 +6756,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-intel",
       "relPath": ".codex/skills/competitive-intel",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2338,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.459Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "competitive-matrix",
@@ -1311,7 +6819,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitive-matrix",
       "relPath": ".gemini/skills/competitive-matrix",
-      "verified": true
+      "verified": true,
+      "tokenCount": 228,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.459Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "competitive-teardown",
@@ -1323,7 +6882,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitive-teardown",
       "relPath": ".gemini/skills/competitive-teardown",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2311,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.460Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "competitive-teardown",
@@ -1335,7 +6945,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitive-teardown",
       "relPath": ".codex/skills/competitive-teardown",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2311,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.461Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "competitor-alternatives",
@@ -1347,7 +7008,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitor-alternatives",
       "relPath": ".gemini/skills/competitor-alternatives",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2820,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.461Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "competitor-alternatives",
@@ -1359,7 +7071,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/competitor-alternatives",
       "relPath": ".codex/skills/competitor-alternatives",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2820,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.462Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "confluence-expert",
@@ -1371,7 +7134,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/confluence-expert",
       "relPath": ".gemini/skills/confluence-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2291,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.463Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "confluence-expert",
@@ -1383,7 +7197,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/confluence-expert",
       "relPath": ".codex/skills/confluence-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2291,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.464Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "Content Strategist",
@@ -1395,7 +7260,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-strategist",
       "relPath": ".gemini/skills/content-strategist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1342,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.465Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "content-creator",
@@ -1407,7 +7323,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-creator",
       "relPath": ".gemini/skills/content-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 711,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.465Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "content-creator",
@@ -1419,7 +7386,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-creator",
       "relPath": ".codex/skills/content-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 711,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.465Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "content-humanizer",
@@ -1431,7 +7449,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-humanizer",
       "relPath": ".gemini/skills/content-humanizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4227,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.466Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "content-humanizer",
@@ -1443,7 +7512,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-humanizer",
       "relPath": ".codex/skills/content-humanizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4227,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.467Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "content-production",
@@ -1455,7 +7575,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-production",
       "relPath": ".gemini/skills/content-production",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3152,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.468Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "content-production",
@@ -1467,7 +7638,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-production",
       "relPath": ".codex/skills/content-production",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3152,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.469Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "content-strategy",
@@ -1479,7 +7701,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-strategy",
       "relPath": ".gemini/skills/content-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1627,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.470Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "content-strategy",
@@ -1491,7 +7764,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/content-strategy",
       "relPath": ".codex/skills/content-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1627,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.470Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "context-engine",
@@ -1503,7 +7827,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/context-engine",
       "relPath": ".gemini/skills/context-engine",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1242,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.471Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "context-engine",
@@ -1515,7 +7890,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/context-engine",
       "relPath": ".codex/skills/context-engine",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1242,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.471Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "contract-and-proposal-writer",
@@ -1527,7 +7953,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/contract-and-proposal-writer",
       "relPath": ".gemini/skills/contract-and-proposal-writer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3659,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.472Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "contract-and-proposal-writer",
@@ -1539,7 +8016,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/contract-and-proposal-writer",
       "relPath": ".codex/skills/contract-and-proposal-writer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3659,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.473Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "coo-advisor",
@@ -1551,7 +8079,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/coo-advisor",
       "relPath": ".gemini/skills/coo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1829,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.474Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "coo-advisor",
@@ -1563,7 +8142,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/coo-advisor",
       "relPath": ".codex/skills/coo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1829,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.475Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "copy-editing",
@@ -1575,7 +8205,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/copy-editing",
       "relPath": ".gemini/skills/copy-editing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4743,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.476Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "copy-editing",
@@ -1587,7 +8268,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copy-editing",
       "relPath": ".codex/skills/copy-editing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4743,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.477Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "copywriting",
@@ -1599,7 +8331,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/copywriting",
       "relPath": ".gemini/skills/copywriting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2776,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.478Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "copywriting",
@@ -1611,7 +8394,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/copywriting",
       "relPath": ".codex/skills/copywriting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2776,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.479Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "coverage",
@@ -1623,7 +8457,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/coverage",
       "relPath": ".gemini/skills/coverage",
-      "verified": true
+      "verified": true,
+      "tokenCount": 792,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.479Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cpo-advisor",
@@ -1635,7 +8520,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cpo-advisor",
       "relPath": ".gemini/skills/cpo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2647,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.480Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "cpo-advisor",
@@ -1647,7 +8583,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cpo-advisor",
       "relPath": ".codex/skills/cpo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2647,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.481Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "cro-advisor",
@@ -1659,7 +8646,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cro-advisor",
       "relPath": ".gemini/skills/cro-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2547,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.482Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "cro-advisor",
@@ -1671,7 +8709,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cro-advisor",
       "relPath": ".codex/skills/cro-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2547,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.483Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "cs-agile-product-owner",
@@ -1683,7 +8772,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-agile-product-owner",
       "relPath": ".gemini/skills/cs-agile-product-owner",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3658,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.484Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-ceo-advisor",
@@ -1695,7 +8835,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-ceo-advisor",
       "relPath": ".gemini/skills/cs-ceo-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3390,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.485Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-content-creator",
@@ -1707,7 +8898,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-content-creator",
       "relPath": ".gemini/skills/cs-content-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2299,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.486Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-cto-advisor",
@@ -1719,7 +8961,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-cto-advisor",
       "relPath": ".gemini/skills/cs-cto-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4015,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.487Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-demand-gen-specialist",
@@ -1731,7 +9024,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-demand-gen-specialist",
       "relPath": ".gemini/skills/cs-demand-gen-specialist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2758,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.488Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-engineering-lead",
@@ -1743,7 +9087,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-engineering-lead",
       "relPath": ".gemini/skills/cs-engineering-lead",
-      "verified": true
+      "verified": true,
+      "tokenCount": 782,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.488Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-financial-analyst",
@@ -1755,7 +9150,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-financial-analyst",
       "relPath": ".gemini/skills/cs-financial-analyst",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1026,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.489Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-growth-strategist",
@@ -1767,7 +9213,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-growth-strategist",
       "relPath": ".gemini/skills/cs-growth-strategist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 603,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.489Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-karpathy-reviewer",
@@ -1779,7 +9276,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-karpathy-reviewer",
       "relPath": ".gemini/skills/cs-karpathy-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 762,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.489Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-onboard",
@@ -1791,7 +9339,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-onboard",
       "relPath": ".gemini/skills/cs-onboard",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1269,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.490Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "cs-onboard",
@@ -1803,7 +9402,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cs-onboard",
       "relPath": ".codex/skills/cs-onboard",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1269,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.490Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "cs-product-analyst",
@@ -1815,7 +9465,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-product-analyst",
       "relPath": ".gemini/skills/cs-product-analyst",
-      "verified": true
+      "verified": true,
+      "tokenCount": 198,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.490Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-product-manager",
@@ -1827,7 +9528,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-product-manager",
       "relPath": ".gemini/skills/cs-product-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6646,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.492Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-product-strategist",
@@ -1839,7 +9591,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-product-strategist",
       "relPath": ".gemini/skills/cs-product-strategist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4461,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.494Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-project-manager",
@@ -1851,7 +9654,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-project-manager",
       "relPath": ".gemini/skills/cs-project-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5156,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.496Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-quality-regulatory",
@@ -1863,7 +9717,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-quality-regulatory",
       "relPath": ".gemini/skills/cs-quality-regulatory",
-      "verified": true
+      "verified": true,
+      "tokenCount": 881,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.496Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-senior-engineer",
@@ -1875,7 +9780,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-senior-engineer",
       "relPath": ".gemini/skills/cs-senior-engineer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1036,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.496Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-ux-researcher",
@@ -1887,7 +9843,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-ux-researcher",
       "relPath": ".gemini/skills/cs-ux-researcher",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4881,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.498Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-wiki-ingestor",
@@ -1899,7 +9906,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-ingestor",
       "relPath": ".gemini/skills/cs-wiki-ingestor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1312,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.498Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-wiki-librarian",
@@ -1911,7 +9969,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-librarian",
       "relPath": ".gemini/skills/cs-wiki-librarian",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1098,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.499Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-wiki-linter",
@@ -1923,7 +10032,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-wiki-linter",
       "relPath": ".gemini/skills/cs-wiki-linter",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1156,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.499Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cs-workspace-admin",
@@ -1935,7 +10095,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-workspace-admin",
       "relPath": ".gemini/skills/cs-workspace-admin",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1288,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.499Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cto-advisor",
@@ -1947,7 +10158,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cto-advisor",
       "relPath": ".gemini/skills/cto-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3622,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.500Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "cto-advisor",
@@ -1959,7 +10221,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/cto-advisor",
       "relPath": ".codex/skills/cto-advisor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3622,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.502Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "culture-architect",
@@ -1971,7 +10284,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/culture-architect",
       "relPath": ".gemini/skills/culture-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2564,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.503Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "culture-architect",
@@ -1983,7 +10347,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/culture-architect",
       "relPath": ".codex/skills/culture-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2564,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.504Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "customer-success-manager",
@@ -1995,7 +10410,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/customer-success-manager",
       "relPath": ".gemini/skills/customer-success-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1977,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.505Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "customer-success-manager",
@@ -2007,7 +10473,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/customer-success-manager",
       "relPath": ".codex/skills/customer-success-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1977,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.505Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "data-quality-auditor",
@@ -2019,7 +10536,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/data-quality-auditor",
       "relPath": ".gemini/skills/data-quality-auditor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2384,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.506Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "data-quality-auditor",
@@ -2031,7 +10599,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/data-quality-auditor",
       "relPath": ".codex/skills/data-quality-auditor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2384,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.507Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "database-designer",
@@ -2043,7 +10662,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/database-designer",
       "relPath": ".gemini/skills/database-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3162,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.508Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "database-designer",
@@ -2055,7 +10725,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/database-designer",
       "relPath": ".codex/skills/database-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3162,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.509Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "database-schema-designer",
@@ -2067,7 +10788,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/database-schema-designer",
       "relPath": ".gemini/skills/database-schema-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2134,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.509Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "database-schema-designer",
@@ -2079,7 +10851,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/database-schema-designer",
       "relPath": ".codex/skills/database-schema-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2134,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.510Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "decision-logger",
@@ -2091,7 +10914,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/decision-logger",
       "relPath": ".gemini/skills/decision-logger",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1247,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.511Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "decision-logger",
@@ -2103,7 +10977,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/decision-logger",
       "relPath": ".codex/skills/decision-logger",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1247,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.511Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "demo-video",
@@ -2115,7 +11040,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/demo-video",
       "relPath": ".gemini/skills/demo-video",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1555,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.512Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "demo-video",
@@ -2127,7 +11103,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/demo-video",
       "relPath": ".codex/skills/demo-video",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1555,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.512Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dependency-auditor",
@@ -2139,7 +11166,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/dependency-auditor",
       "relPath": ".gemini/skills/dependency-auditor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2833,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.513Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dependency-auditor",
@@ -2151,7 +11229,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/dependency-auditor",
       "relPath": ".codex/skills/dependency-auditor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2833,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.514Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "DevOps Engineer",
@@ -2163,7 +11292,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/devops-engineer",
       "relPath": ".gemini/skills/devops-engineer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1543,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.515Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "docker-development",
@@ -2175,7 +11355,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/docker-development",
       "relPath": ".gemini/skills/docker-development",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3204,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.516Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "docker-development",
@@ -2187,7 +11418,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/docker-development",
       "relPath": ".codex/skills/docker-development",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3204,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.517Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "email-sequence",
@@ -2199,7 +11481,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/email-sequence",
       "relPath": ".gemini/skills/email-sequence",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1559,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.517Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "email-sequence",
@@ -2211,7 +11544,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/email-sequence",
       "relPath": ".codex/skills/email-sequence",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1559,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.518Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "email-template-builder",
@@ -2223,7 +11607,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/email-template-builder",
       "relPath": ".gemini/skills/email-template-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4293,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.520Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "email-template-builder",
@@ -2235,7 +11670,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/email-template-builder",
       "relPath": ".codex/skills/email-template-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4293,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.521Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "engineering-advanced-skills",
@@ -2247,7 +11733,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/engineering-main",
       "relPath": ".gemini/skills/engineering-main",
-      "verified": true
+      "verified": true,
+      "tokenCount": 747,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.521Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "engineering-advanced-skills",
@@ -2259,7 +11796,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/engineering-bundle",
       "relPath": ".gemini/skills/engineering-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 747,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.521Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "engineering-advanced-skills",
@@ -2271,7 +11859,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:engineering",
       "relPath": "engineering",
-      "verified": true
+      "verified": true,
+      "tokenCount": 747,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.522Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "engineering-skills",
@@ -2283,7 +11922,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/engineering-team-bundle",
       "relPath": ".gemini/skills/engineering-team-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 873,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.522Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "engineering-skills",
@@ -2295,7 +11985,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:engineering-team",
       "relPath": "engineering-team",
-      "verified": true
+      "verified": true,
+      "tokenCount": 873,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.522Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "env-secrets-manager",
@@ -2307,7 +12048,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/env-secrets-manager",
       "relPath": ".gemini/skills/env-secrets-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2690,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.523Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "env-secrets-manager",
@@ -2319,7 +12111,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/env-secrets-manager",
       "relPath": ".codex/skills/env-secrets-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2690,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.524Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "epic-design",
@@ -2331,7 +12174,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/epic-design",
       "relPath": ".gemini/skills/epic-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4777,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.525Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "epic-design",
@@ -2343,7 +12237,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/epic-design",
       "relPath": ".codex/skills/epic-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4777,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.527Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "eval",
@@ -2355,7 +12300,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/eval",
       "relPath": ".gemini/skills/eval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 802,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.527Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "executive-mentor",
@@ -2367,7 +12363,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/executive-mentor",
       "relPath": ".gemini/skills/executive-mentor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1980,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.528Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "executive-mentor",
@@ -2379,7 +12426,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor",
       "relPath": ".codex/skills/executive-mentor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1980,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.528Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "experiment-designer",
@@ -2391,7 +12489,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/experiment-designer",
       "relPath": ".gemini/skills/experiment-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 776,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.529Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "experiment-designer",
@@ -2403,7 +12552,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/experiment-designer",
       "relPath": ".codex/skills/experiment-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 776,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.529Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "extract",
@@ -2415,7 +12615,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/extract",
       "relPath": ".gemini/skills/extract",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1401,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.530Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "fda-consultant-specialist",
@@ -2427,7 +12678,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/fda-consultant-specialist",
       "relPath": ".gemini/skills/fda-consultant-specialist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2514,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.530Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "fda-consultant-specialist",
@@ -2439,7 +12741,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/fda-consultant-specialist",
       "relPath": ".codex/skills/fda-consultant-specialist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2514,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.531Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "Finance Lead",
@@ -2451,7 +12804,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/finance-lead",
       "relPath": ".gemini/skills/finance-lead",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1588,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.532Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "finance-skills",
@@ -2463,7 +12867,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/finance-bundle",
       "relPath": ".gemini/skills/finance-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 271,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.532Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "finance-skills",
@@ -2475,7 +12930,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:finance",
       "relPath": "finance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 271,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.532Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "financial-analyst",
@@ -2487,7 +12993,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/financial-analyst",
       "relPath": ".gemini/skills/financial-analyst",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1410,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.533Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "financial-analyst",
@@ -2499,7 +13056,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/financial-analyst",
       "relPath": ".codex/skills/financial-analyst",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1410,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.533Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "financial-health",
@@ -2511,7 +13119,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/financial-health",
       "relPath": ".gemini/skills/financial-health",
-      "verified": true
+      "verified": true,
+      "tokenCount": 253,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.534Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "fix",
@@ -2523,7 +13182,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/fix",
       "relPath": ".gemini/skills/fix",
-      "verified": true
+      "verified": true,
+      "tokenCount": 850,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.534Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "focused-fix",
@@ -2535,7 +13245,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/focused-fix",
       "relPath": ".gemini/skills/focused-fix",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4315,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.535Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "focused-fix",
@@ -2547,7 +13308,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cmd-focused-fix",
       "relPath": ".gemini/skills/cmd-focused-fix",
-      "verified": true
+      "verified": true,
+      "tokenCount": 958,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.536Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "focused-fix",
@@ -2559,7 +13371,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/focused-fix",
       "relPath": ".codex/skills/focused-fix",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4315,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.537Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "form-cro",
@@ -2571,7 +13434,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/form-cro",
       "relPath": ".gemini/skills/form-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2315,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.538Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "form-cro",
@@ -2583,7 +13497,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/form-cro",
       "relPath": ".codex/skills/form-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2315,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.538Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "founder-coach",
@@ -2595,7 +13560,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/founder-coach",
       "relPath": ".gemini/skills/founder-coach",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4254,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.540Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "founder-coach",
@@ -2607,7 +13623,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/founder-coach",
       "relPath": ".codex/skills/founder-coach",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4254,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.541Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "free-tool-strategy",
@@ -2619,7 +13686,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/free-tool-strategy",
       "relPath": ".gemini/skills/free-tool-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3758,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.542Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "free-tool-strategy",
@@ -2631,7 +13749,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/free-tool-strategy",
       "relPath": ".codex/skills/free-tool-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3758,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.543Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "gcp-cloud-architect",
@@ -2643,7 +13812,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/gcp-cloud-architect",
       "relPath": ".gemini/skills/gcp-cloud-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3311,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.544Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gcp-cloud-architect",
@@ -2655,7 +13875,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/gcp-cloud-architect",
       "relPath": ".codex/skills/gcp-cloud-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3311,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.545Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gdpr-dsgvo-expert",
@@ -2667,7 +13938,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/gdpr-dsgvo-expert",
       "relPath": ".gemini/skills/gdpr-dsgvo-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2017,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.546Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gdpr-dsgvo-expert",
@@ -2679,7 +14001,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/gdpr-dsgvo-expert",
       "relPath": ".codex/skills/gdpr-dsgvo-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2017,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.546Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "generate",
@@ -2691,7 +14064,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/generate",
       "relPath": ".gemini/skills/generate",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1232,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.547Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "git-worktree-manager",
@@ -2703,7 +14127,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/git-worktree-manager",
       "relPath": ".gemini/skills/git-worktree-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1794,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.547Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "git-worktree-manager",
@@ -2715,7 +14190,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/git-worktree-manager",
       "relPath": ".codex/skills/git-worktree-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1794,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.548Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "google-workspace",
@@ -2727,7 +14253,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/google-workspace",
       "relPath": ".gemini/skills/google-workspace",
-      "verified": true
+      "verified": true,
+      "tokenCount": 462,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.548Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "google-workspace-cli",
@@ -2739,7 +14316,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/google-workspace-cli",
       "relPath": ".gemini/skills/google-workspace-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2559,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.549Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "google-workspace-cli",
@@ -2751,7 +14379,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/google-workspace-cli",
       "relPath": ".codex/skills/google-workspace-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2559,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.550Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "Growth Marketer",
@@ -2763,7 +14442,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/growth-marketer",
       "relPath": ".gemini/skills/growth-marketer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2747,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.551Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "hard-call",
@@ -2775,7 +14505,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/hard-call",
       "relPath": ".gemini/skills/hard-call",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2312,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.551Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "helm-chart-builder",
@@ -2787,7 +14568,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/helm-chart-builder",
       "relPath": ".gemini/skills/helm-chart-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4452,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.553Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "helm-chart-builder",
@@ -2799,7 +14631,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/helm-chart-builder",
       "relPath": ".codex/skills/helm-chart-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4452,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.554Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "incident-commander",
@@ -2811,7 +14694,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/incident-commander",
       "relPath": ".gemini/skills/incident-commander",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3958,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.555Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "incident-commander",
@@ -2823,7 +14757,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/incident-commander",
       "relPath": ".codex/skills/incident-commander",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3958,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.557Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "incident-response",
@@ -2835,7 +14820,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/incident-response",
       "relPath": ".gemini/skills/incident-response",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4077,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.558Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "incident-response",
@@ -2847,7 +14883,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/incident-response",
       "relPath": ".codex/skills/incident-response",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4077,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.559Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "information-security-manager-iso27001",
@@ -2859,7 +14946,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/information-security-manager-iso27001",
       "relPath": ".gemini/skills/information-security-manager-iso27001",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2874,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.560Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "information-security-manager-iso27001",
@@ -2871,7 +15009,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/information-security-manager-iso27001",
       "relPath": ".codex/skills/information-security-manager-iso27001",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2874,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.561Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "init",
@@ -2883,7 +15072,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/init",
       "relPath": ".gemini/skills/init",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1293,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.562Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "init",
@@ -2895,7 +15135,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/skills-init",
       "relPath": ".gemini/skills/skills-init",
-      "verified": true
+      "verified": true,
+      "tokenCount": 808,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.562Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "internal-narrative",
@@ -2907,7 +15198,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/internal-narrative",
       "relPath": ".gemini/skills/internal-narrative",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3141,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.563Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "internal-narrative",
@@ -2919,7 +15261,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/internal-narrative",
       "relPath": ".codex/skills/internal-narrative",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3141,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.564Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "interview-system-designer",
@@ -2931,7 +15324,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/interview-system-designer",
       "relPath": ".gemini/skills/interview-system-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 522,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.564Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "interview-system-designer",
@@ -2943,7 +15387,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/interview-system-designer",
       "relPath": ".codex/skills/interview-system-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 522,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.564Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "intl-expansion",
@@ -2955,7 +15450,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/intl-expansion",
       "relPath": ".gemini/skills/intl-expansion",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1341,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.565Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "intl-expansion",
@@ -2967,7 +15513,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/intl-expansion",
       "relPath": ".codex/skills/intl-expansion",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1341,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.565Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "isms-audit-expert",
@@ -2979,7 +15576,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/isms-audit-expert",
       "relPath": ".gemini/skills/isms-audit-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1950,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.566Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "isms-audit-expert",
@@ -2991,7 +15639,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/isms-audit-expert",
       "relPath": ".codex/skills/isms-audit-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1950,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.566Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "jira-expert",
@@ -3003,7 +15702,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/jira-expert",
       "relPath": ".gemini/skills/jira-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2350,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.567Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "jira-expert",
@@ -3015,7 +15765,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/jira-expert",
       "relPath": ".codex/skills/jira-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2350,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.568Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "karpathy-check",
@@ -3027,7 +15828,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/karpathy-check",
       "relPath": ".gemini/skills/karpathy-check",
-      "verified": true
+      "verified": true,
+      "tokenCount": 362,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.568Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "karpathy-coder",
@@ -3039,7 +15891,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/karpathy-coder",
       "relPath": ".gemini/skills/karpathy-coder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1580,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.568Z",
+        "evaluatedVersion": "2.3.0"
+      }
     },
     {
       "name": "karpathy-coder",
@@ -3051,7 +15954,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/karpathy-coder",
       "relPath": ".codex/skills/karpathy-coder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1580,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.569Z",
+        "evaluatedVersion": "2.3.0"
+      }
     },
     {
       "name": "landing-page-generator",
@@ -3063,7 +16017,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/landing-page-generator",
       "relPath": ".gemini/skills/landing-page-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3025,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.570Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "landing-page-generator",
@@ -3075,7 +16080,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/landing-page-generator",
       "relPath": ".codex/skills/landing-page-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3025,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.570Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "launch-strategy",
@@ -3087,7 +16143,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/launch-strategy",
       "relPath": ".gemini/skills/launch-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1205,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.571Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "launch-strategy",
@@ -3099,7 +16206,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/launch-strategy",
       "relPath": ".codex/skills/launch-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1205,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.571Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "llm-cost-optimizer",
@@ -3111,7 +16269,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/llm-cost-optimizer",
       "relPath": ".gemini/skills/llm-cost-optimizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2885,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.572Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "llm-cost-optimizer",
@@ -3123,7 +16332,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/llm-cost-optimizer",
       "relPath": ".codex/skills/llm-cost-optimizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2885,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.573Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "llm-wiki",
@@ -3135,7 +16395,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/llm-wiki",
       "relPath": ".gemini/skills/llm-wiki",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2893,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.574Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "llm-wiki",
@@ -3147,7 +16458,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/llm-wiki",
       "relPath": ".codex/skills/llm-wiki",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2893,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.575Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "loop",
@@ -3159,7 +16521,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/loop",
       "relPath": ".gemini/skills/loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1169,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.575Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ma-playbook",
@@ -3171,7 +16584,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ma-playbook",
       "relPath": ".gemini/skills/ma-playbook",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1122,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.576Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ma-playbook",
@@ -3183,7 +16647,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ma-playbook",
       "relPath": ".codex/skills/ma-playbook",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1122,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.576Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "marketing-context",
@@ -3195,7 +16710,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-context",
       "relPath": ".gemini/skills/marketing-context",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1975,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.577Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "marketing-context",
@@ -3207,7 +16773,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-context",
       "relPath": ".codex/skills/marketing-context",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1975,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.577Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "marketing-demand-acquisition",
@@ -3219,7 +16836,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-demand-acquisition",
       "relPath": ".gemini/skills/marketing-demand-acquisition",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2653,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.578Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "marketing-demand-acquisition",
@@ -3231,7 +16899,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-demand-acquisition",
       "relPath": ".codex/skills/marketing-demand-acquisition",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2653,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.579Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "marketing-ideas",
@@ -3243,7 +16962,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-ideas",
       "relPath": ".gemini/skills/marketing-ideas",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2271,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.580Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "marketing-ideas",
@@ -3255,7 +17025,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-ideas",
       "relPath": ".codex/skills/marketing-ideas",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2271,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.580Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "marketing-ops",
@@ -3267,7 +17088,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-ops",
       "relPath": ".gemini/skills/marketing-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2454,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.581Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "marketing-ops",
@@ -3279,7 +17151,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-ops",
       "relPath": ".codex/skills/marketing-ops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2454,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.582Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "marketing-psychology",
@@ -3291,7 +17214,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-psychology",
       "relPath": ".gemini/skills/marketing-psychology",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1884,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.583Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "marketing-psychology",
@@ -3303,7 +17277,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-psychology",
       "relPath": ".codex/skills/marketing-psychology",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1884,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.583Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "marketing-skills",
@@ -3315,7 +17340,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-bundle",
       "relPath": ".gemini/skills/marketing-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1105,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.584Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "marketing-skills",
@@ -3327,7 +17403,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-skill-bundle",
       "relPath": ".gemini/skills/marketing-skill-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1105,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.584Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "marketing-skills",
@@ -3339,7 +17466,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:marketing-skill",
       "relPath": "marketing-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1105,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.584Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "marketing-strategy-pmm",
@@ -3351,7 +17529,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-strategy-pmm",
       "relPath": ".gemini/skills/marketing-strategy-pmm",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3475,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.585Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "marketing-strategy-pmm",
@@ -3363,7 +17592,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-strategy-pmm",
       "relPath": ".codex/skills/marketing-strategy-pmm",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3475,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.586Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-server-builder",
@@ -3375,7 +17655,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/mcp-server-builder",
       "relPath": ".gemini/skills/mcp-server-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1447,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.587Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-server-builder",
@@ -3387,7 +17718,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/mcp-server-builder",
       "relPath": ".codex/skills/mcp-server-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1447,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.587Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mdr-745-specialist",
@@ -3399,7 +17781,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/mdr-745-specialist",
       "relPath": ".gemini/skills/mdr-745-specialist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2636,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.588Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mdr-745-specialist",
@@ -3411,7 +17844,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/mdr-745-specialist",
       "relPath": ".codex/skills/mdr-745-specialist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2636,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.589Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "meeting-analyzer",
@@ -3423,7 +17907,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/meeting-analyzer",
       "relPath": ".gemini/skills/meeting-analyzer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3442,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.590Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "meeting-analyzer",
@@ -3435,7 +17970,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/meeting-analyzer",
       "relPath": ".codex/skills/meeting-analyzer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3442,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.591Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "merge",
@@ -3447,7 +18033,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/merge",
       "relPath": ".gemini/skills/merge",
-      "verified": true
+      "verified": true,
+      "tokenCount": 579,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.591Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "migrate",
@@ -3459,7 +18096,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/migrate",
       "relPath": ".gemini/skills/migrate",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1112,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.592Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "migration-architect",
@@ -3471,7 +18159,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/migration-architect",
       "relPath": ".gemini/skills/migration-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4605,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.593Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "migration-architect",
@@ -3483,7 +18222,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/migration-architect",
       "relPath": ".codex/skills/migration-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4605,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.595Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "monorepo-navigator",
@@ -3495,7 +18285,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/monorepo-navigator",
       "relPath": ".gemini/skills/monorepo-navigator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1203,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.595Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "monorepo-navigator",
@@ -3507,7 +18348,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/monorepo-navigator",
       "relPath": ".codex/skills/monorepo-navigator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1203,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.595Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ms365-tenant-manager",
@@ -3519,7 +18411,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ms365-tenant-manager",
       "relPath": ".gemini/skills/ms365-tenant-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2154,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.596Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ms365-tenant-manager",
@@ -3531,7 +18474,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ms365-tenant-manager",
       "relPath": ".codex/skills/ms365-tenant-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2154,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.597Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "observability-designer",
@@ -3543,7 +18537,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/observability-designer",
       "relPath": ".gemini/skills/observability-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3024,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.598Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "observability-designer",
@@ -3555,7 +18600,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/observability-designer",
       "relPath": ".codex/skills/observability-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3024,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.599Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "okr",
@@ -3567,7 +18663,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/okr",
       "relPath": ".gemini/skills/okr",
-      "verified": true
+      "verified": true,
+      "tokenCount": 234,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.599Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "onboarding-cro",
@@ -3579,7 +18726,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/onboarding-cro",
       "relPath": ".gemini/skills/onboarding-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2487,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.600Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "onboarding-cro",
@@ -3591,7 +18789,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/onboarding-cro",
       "relPath": ".codex/skills/onboarding-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2487,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.601Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "org-health-diagnostic",
@@ -3603,7 +18852,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/org-health-diagnostic",
       "relPath": ".gemini/skills/org-health-diagnostic",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2414,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.601Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "org-health-diagnostic",
@@ -3615,7 +18915,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/org-health-diagnostic",
       "relPath": ".codex/skills/org-health-diagnostic",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2414,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.602Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "page-cro",
@@ -3627,7 +18978,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/page-cro",
       "relPath": ".gemini/skills/page-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2610,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.603Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "page-cro",
@@ -3639,7 +19041,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/page-cro",
       "relPath": ".codex/skills/page-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2610,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.604Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "paid-ads",
@@ -3651,7 +19104,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/paid-ads",
       "relPath": ".gemini/skills/paid-ads",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3420,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.605Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "paid-ads",
@@ -3663,7 +19167,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/paid-ads",
       "relPath": ".codex/skills/paid-ads",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3420,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.606Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "paywall-upgrade-cro",
@@ -3675,7 +19230,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/paywall-upgrade-cro",
       "relPath": ".gemini/skills/paywall-upgrade-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2280,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.606Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "paywall-upgrade-cro",
@@ -3687,7 +19293,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/paywall-upgrade-cro",
       "relPath": ".codex/skills/paywall-upgrade-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2280,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.607Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "performance-profiler",
@@ -3699,7 +19356,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/performance-profiler",
       "relPath": ".gemini/skills/performance-profiler",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1430,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.608Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "performance-profiler",
@@ -3711,7 +19419,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/performance-profiler",
       "relPath": ".codex/skills/performance-profiler",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1430,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.608Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "persona",
@@ -3723,7 +19482,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/persona",
       "relPath": ".gemini/skills/persona",
-      "verified": true
+      "verified": true,
+      "tokenCount": 284,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.608Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pipeline",
@@ -3735,7 +19545,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/pipeline",
       "relPath": ".gemini/skills/pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 205,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.609Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "playwright-pro",
@@ -3747,7 +19608,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/playwright-pro",
       "relPath": ".gemini/skills/playwright-pro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1357,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.609Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "playwright-pro",
@@ -3759,7 +19671,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro",
       "relPath": ".codex/skills/playwright-pro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1357,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.609Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "plugin-audit",
@@ -3771,7 +19734,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/plugin-audit",
       "relPath": ".gemini/skills/plugin-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3357,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.610Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pm-skills",
@@ -3783,7 +19797,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/project-management-bundle",
       "relPath": ".gemini/skills/project-management-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 405,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.611Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "pm-skills",
@@ -3795,7 +19860,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:project-management",
       "relPath": "project-management",
-      "verified": true
+      "verified": true,
+      "tokenCount": 405,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.611Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "popup-cro",
@@ -3807,7 +19923,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/popup-cro",
       "relPath": ".gemini/skills/popup-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2171,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.612Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "popup-cro",
@@ -3819,7 +19986,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/popup-cro",
       "relPath": ".codex/skills/popup-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2171,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.612Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "postmortem",
@@ -3831,7 +20049,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/postmortem",
       "relPath": ".gemini/skills/postmortem",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2369,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.613Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pr-review-expert",
@@ -3843,7 +20112,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/pr-review-expert",
       "relPath": ".gemini/skills/pr-review-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3301,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.614Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pr-review-expert",
@@ -3855,7 +20175,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/pr-review-expert",
       "relPath": ".codex/skills/pr-review-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3301,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.615Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "prd",
@@ -3867,7 +20238,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/prd",
       "relPath": ".gemini/skills/prd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 110,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.615Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pricing-strategy",
@@ -3879,7 +20301,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/pricing-strategy",
       "relPath": ".gemini/skills/pricing-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4384,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.617Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "pricing-strategy",
@@ -3891,7 +20364,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/pricing-strategy",
       "relPath": ".codex/skills/pricing-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4384,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.618Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "Product Manager",
@@ -3903,7 +20427,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-manager",
       "relPath": ".gemini/skills/product-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1520,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.618Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-analytics",
@@ -3915,7 +20490,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-analytics",
       "relPath": ".gemini/skills/product-analytics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1336,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.619Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-analytics",
@@ -3927,7 +20553,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-analytics",
       "relPath": ".codex/skills/product-analytics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1336,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.619Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-discovery",
@@ -3939,7 +20616,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-discovery",
       "relPath": ".gemini/skills/product-discovery",
-      "verified": true
+      "verified": true,
+      "tokenCount": 829,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.620Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-discovery",
@@ -3951,7 +20679,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-discovery",
       "relPath": ".codex/skills/product-discovery",
-      "verified": true
+      "verified": true,
+      "tokenCount": 829,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.620Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-manager-toolkit",
@@ -3963,7 +20742,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-manager-toolkit",
       "relPath": ".gemini/skills/product-manager-toolkit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2435,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.621Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-manager-toolkit",
@@ -3975,7 +20805,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-manager-toolkit",
       "relPath": ".codex/skills/product-manager-toolkit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2435,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.622Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-skills",
@@ -3987,7 +20868,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-team-bundle",
       "relPath": ".gemini/skills/product-team-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 465,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.622Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "product-skills",
@@ -3999,7 +20931,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-bundle",
       "relPath": ".gemini/skills/product-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 465,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.622Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "product-skills",
@@ -4011,7 +20994,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:product-team",
       "relPath": "product-team",
-      "verified": true
+      "verified": true,
+      "tokenCount": 465,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.622Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "product-strategist",
@@ -4023,7 +21057,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-strategist",
       "relPath": ".gemini/skills/product-strategist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1930,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.623Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "product-strategist",
@@ -4035,7 +21120,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-strategist",
       "relPath": ".codex/skills/product-strategist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1930,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.624Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "programmatic-seo",
@@ -4047,7 +21183,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/programmatic-seo",
       "relPath": ".gemini/skills/programmatic-seo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2913,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.624Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "programmatic-seo",
@@ -4059,7 +21246,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/programmatic-seo",
       "relPath": ".codex/skills/programmatic-seo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2913,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.625Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "project-health",
@@ -4071,7 +21309,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/project-health",
       "relPath": ".gemini/skills/project-health",
-      "verified": true
+      "verified": true,
+      "tokenCount": 277,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.625Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "promote",
@@ -4083,7 +21372,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/promote",
       "relPath": ".gemini/skills/promote",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1300,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.626Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "prompt-engineer-toolkit",
@@ -4095,7 +21435,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/prompt-engineer-toolkit",
       "relPath": ".gemini/skills/prompt-engineer-toolkit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1273,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.626Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "prompt-engineer-toolkit",
@@ -4107,7 +21498,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/prompt-engineer-toolkit",
       "relPath": ".codex/skills/prompt-engineer-toolkit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1273,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.627Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "prompt-governance",
@@ -4119,7 +21561,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/prompt-governance",
       "relPath": ".gemini/skills/prompt-governance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3267,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.628Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "prompt-governance",
@@ -4131,7 +21624,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/prompt-governance",
       "relPath": ".codex/skills/prompt-governance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3267,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.629Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qms-audit-expert",
@@ -4143,7 +21687,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/qms-audit-expert",
       "relPath": ".gemini/skills/qms-audit-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2583,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.630Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qms-audit-expert",
@@ -4155,7 +21750,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/qms-audit-expert",
       "relPath": ".codex/skills/qms-audit-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2583,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.630Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "quality-documentation-manager",
@@ -4167,7 +21813,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/quality-documentation-manager",
       "relPath": ".gemini/skills/quality-documentation-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3844,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.632Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "quality-documentation-manager",
@@ -4179,7 +21876,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/quality-documentation-manager",
       "relPath": ".codex/skills/quality-documentation-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3844,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.633Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "quality-manager-qmr",
@@ -4191,7 +21939,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/quality-manager-qmr",
       "relPath": ".gemini/skills/quality-manager-qmr",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5042,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.635Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "quality-manager-qmr",
@@ -4203,7 +22002,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/quality-manager-qmr",
       "relPath": ".codex/skills/quality-manager-qmr",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5042,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.636Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "quality-manager-qms-iso13485",
@@ -4215,7 +22065,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/quality-manager-qms-iso13485",
       "relPath": ".gemini/skills/quality-manager-qms-iso13485",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4728,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.637Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "quality-manager-qms-iso13485",
@@ -4227,7 +22128,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/quality-manager-qms-iso13485",
       "relPath": ".codex/skills/quality-manager-qms-iso13485",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4728,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.639Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ra-qm-skills",
@@ -4239,7 +22191,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ra-qm-team-main",
       "relPath": ".gemini/skills/ra-qm-team-main",
-      "verified": true
+      "verified": true,
+      "tokenCount": 556,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.639Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ra-qm-skills",
@@ -4251,7 +22254,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ra-qm-team-bundle",
       "relPath": ".gemini/skills/ra-qm-team-bundle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 556,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.639Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ra-qm-skills",
@@ -4263,7 +22317,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team",
       "relPath": "ra-qm-team",
-      "verified": true
+      "verified": true,
+      "tokenCount": 556,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.639Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "rag-architect",
@@ -4275,7 +22380,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/rag-architect",
       "relPath": ".gemini/skills/rag-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3691,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.640Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rag-architect",
@@ -4287,7 +22443,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/rag-architect",
       "relPath": ".codex/skills/rag-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3691,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.642Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "red-team",
@@ -4299,7 +22506,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/red-team",
       "relPath": ".gemini/skills/red-team",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4247,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.643Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "red-team",
@@ -4311,7 +22569,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/red-team",
       "relPath": ".codex/skills/red-team",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4247,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.644Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "referral-program",
@@ -4323,7 +22632,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/referral-program",
       "relPath": ".gemini/skills/referral-program",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4091,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.645Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "referral-program",
@@ -4335,7 +22695,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/referral-program",
       "relPath": ".codex/skills/referral-program",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4091,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.647Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "regulatory-affairs-head",
@@ -4347,7 +22758,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/regulatory-affairs-head",
       "relPath": ".gemini/skills/regulatory-affairs-head",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5864,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.648Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "regulatory-affairs-head",
@@ -4359,7 +22821,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/regulatory-affairs-head",
       "relPath": ".codex/skills/regulatory-affairs-head",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5864,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.649Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "release-manager",
@@ -4371,7 +22884,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/release-manager",
       "relPath": ".gemini/skills/release-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4071,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.651Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "release-manager",
@@ -4383,7 +22947,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/release-manager",
       "relPath": ".codex/skills/release-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4071,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.652Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "remember",
@@ -4395,7 +23010,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/remember",
       "relPath": ".gemini/skills/remember",
-      "verified": true
+      "verified": true,
+      "tokenCount": 922,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.653Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "report",
@@ -4407,7 +23073,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/report",
       "relPath": ".gemini/skills/report",
-      "verified": true
+      "verified": true,
+      "tokenCount": 844,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.653Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "research-summarizer",
@@ -4419,7 +23136,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/research-summarizer",
       "relPath": ".gemini/skills/research-summarizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2634,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.654Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "research-summarizer",
@@ -4431,7 +23199,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/research-summarizer",
       "relPath": ".codex/skills/research-summarizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2634,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.654Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "resume",
@@ -4443,7 +23262,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/resume",
       "relPath": ".gemini/skills/resume",
-      "verified": true
+      "verified": true,
+      "tokenCount": 573,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.655Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "retro",
@@ -4455,7 +23325,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/retro",
       "relPath": ".gemini/skills/retro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 250,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.655Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "revenue-operations",
@@ -4467,7 +23388,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/revenue-operations",
       "relPath": ".gemini/skills/revenue-operations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2362,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.656Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "revenue-operations",
@@ -4479,7 +23451,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/revenue-operations",
       "relPath": ".codex/skills/revenue-operations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2362,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.656Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "review",
@@ -4491,7 +23514,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/skills-review",
       "relPath": ".gemini/skills/skills-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 852,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.657Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "review",
@@ -4503,7 +23577,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/review",
       "relPath": ".gemini/skills/review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1161,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.657Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rice",
@@ -4515,7 +23640,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/rice",
       "relPath": ".gemini/skills/rice",
-      "verified": true
+      "verified": true,
+      "tokenCount": 219,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.657Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "risk-management-specialist",
@@ -4527,7 +23703,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/risk-management-specialist",
       "relPath": ".gemini/skills/risk-management-specialist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4612,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.659Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "risk-management-specialist",
@@ -4539,7 +23766,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/risk-management-specialist",
       "relPath": ".codex/skills/risk-management-specialist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4612,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.660Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "roadmap-communicator",
@@ -4551,7 +23829,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/roadmap-communicator",
       "relPath": ".gemini/skills/roadmap-communicator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 666,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.660Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "roadmap-communicator",
@@ -4563,7 +23892,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/roadmap-communicator",
       "relPath": ".codex/skills/roadmap-communicator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 666,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.660Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "run",
@@ -4575,7 +23955,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/skills-run",
       "relPath": ".gemini/skills/skills-run",
-      "verified": true
+      "verified": true,
+      "tokenCount": 649,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.661Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "run",
@@ -4587,7 +24018,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/run",
       "relPath": ".gemini/skills/run",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1035,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.661Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "runbook-generator",
@@ -4599,7 +24081,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/runbook-generator",
       "relPath": ".gemini/skills/runbook-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 431,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.661Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "runbook-generator",
@@ -4611,7 +24144,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/runbook-generator",
       "relPath": ".codex/skills/runbook-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 431,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.662Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "saas-health",
@@ -4623,7 +24207,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/saas-health",
       "relPath": ".gemini/skills/saas-health",
-      "verified": true
+      "verified": true,
+      "tokenCount": 282,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.662Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "saas-metrics-coach",
@@ -4635,7 +24270,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/saas-metrics-coach",
       "relPath": ".gemini/skills/saas-metrics-coach",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1563,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.662Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "saas-metrics-coach",
@@ -4647,7 +24333,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/saas-metrics-coach",
       "relPath": ".codex/skills/saas-metrics-coach",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1563,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.663Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "saas-scaffolder",
@@ -4659,7 +24396,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/saas-scaffolder",
       "relPath": ".gemini/skills/saas-scaffolder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2684,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.664Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "saas-scaffolder",
@@ -4671,7 +24459,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/saas-scaffolder",
       "relPath": ".codex/skills/saas-scaffolder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2684,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.665Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sales-engineer",
@@ -4683,7 +24522,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/sales-engineer",
       "relPath": ".gemini/skills/sales-engineer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2054,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.665Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sales-engineer",
@@ -4695,7 +24585,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/sales-engineer",
       "relPath": ".codex/skills/sales-engineer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2054,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.666Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sample-skill",
@@ -4707,7 +24648,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/sample-skill",
       "relPath": ".gemini/skills/sample-skill",
-      "verified": false
+      "verified": false,
+      "tokenCount": 1357,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.667Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scenario-war-room",
@@ -4719,7 +24711,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/scenario-war-room",
       "relPath": ".gemini/skills/scenario-war-room",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2391,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.667Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "scenario-war-room",
@@ -4731,7 +24774,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/scenario-war-room",
       "relPath": ".codex/skills/scenario-war-room",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2391,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.668Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "schema-markup",
@@ -4743,7 +24837,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/schema-markup",
       "relPath": ".gemini/skills/schema-markup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3431,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.670Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "schema-markup",
@@ -4755,7 +24900,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/schema-markup",
       "relPath": ".codex/skills/schema-markup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3431,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.671Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "scrum-master",
@@ -4767,7 +24963,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/scrum-master",
       "relPath": ".gemini/skills/scrum-master",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2374,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.672Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "scrum-master",
@@ -4779,7 +25026,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/scrum-master",
       "relPath": ".codex/skills/scrum-master",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2374,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.673Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "secrets-vault-manager",
@@ -4791,7 +25089,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/secrets-vault-manager",
       "relPath": ".gemini/skills/secrets-vault-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3720,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.674Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "secrets-vault-manager",
@@ -4803,7 +25152,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/secrets-vault-manager",
       "relPath": ".codex/skills/secrets-vault-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3720,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.675Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-pen-testing",
@@ -4815,7 +25215,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/security-pen-testing",
       "relPath": ".gemini/skills/security-pen-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3279,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.676Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-pen-testing",
@@ -4827,7 +25278,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/security-pen-testing",
       "relPath": ".codex/skills/security-pen-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3279,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.677Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "self-eval",
@@ -4839,7 +25341,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/self-eval",
       "relPath": ".gemini/skills/self-eval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2427,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.678Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "self-eval",
@@ -4851,7 +25404,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/self-eval",
       "relPath": ".codex/skills/self-eval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2427,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.679Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "self-improving-agent",
@@ -4863,7 +25467,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/self-improving-agent",
       "relPath": ".gemini/skills/self-improving-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1782,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.679Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "self-improving-agent",
@@ -4875,7 +25530,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/self-improving-agent",
       "relPath": ".codex/skills/self-improving-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1782,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.680Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-architect",
@@ -4887,7 +25593,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-architect",
       "relPath": ".gemini/skills/senior-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2487,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.681Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-architect",
@@ -4899,7 +25656,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-architect",
       "relPath": ".codex/skills/senior-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2487,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.682Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-backend",
@@ -4911,7 +25719,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-backend",
       "relPath": ".gemini/skills/senior-backend",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2343,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.683Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-backend",
@@ -4923,7 +25782,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-backend",
       "relPath": ".codex/skills/senior-backend",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2343,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.683Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-computer-vision",
@@ -4935,7 +25845,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-computer-vision",
       "relPath": ".gemini/skills/senior-computer-vision",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3507,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.685Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-computer-vision",
@@ -4947,7 +25908,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-computer-vision",
       "relPath": ".codex/skills/senior-computer-vision",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3507,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.686Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-data-engineer",
@@ -4959,7 +25971,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-data-engineer",
       "relPath": ".gemini/skills/senior-data-engineer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1529,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.686Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-data-engineer",
@@ -4971,7 +26034,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-data-engineer",
       "relPath": ".codex/skills/senior-data-engineer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1529,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.687Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-data-scientist",
@@ -4983,7 +26097,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-data-scientist",
       "relPath": ".gemini/skills/senior-data-scientist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2508,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.688Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-data-scientist",
@@ -4995,7 +26160,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-data-scientist",
       "relPath": ".codex/skills/senior-data-scientist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2508,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.689Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-devops",
@@ -5007,7 +26223,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-devops",
       "relPath": ".gemini/skills/senior-devops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2883,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.690Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-devops",
@@ -5019,7 +26286,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-devops",
       "relPath": ".codex/skills/senior-devops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2883,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.691Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-frontend",
@@ -5031,7 +26349,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-frontend",
       "relPath": ".gemini/skills/senior-frontend",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2800,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.692Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-frontend",
@@ -5043,7 +26412,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-frontend",
       "relPath": ".codex/skills/senior-frontend",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2800,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.692Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-fullstack",
@@ -5055,7 +26475,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-fullstack",
       "relPath": ".gemini/skills/senior-fullstack",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1977,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.693Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-fullstack",
@@ -5067,7 +26538,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-fullstack",
       "relPath": ".codex/skills/senior-fullstack",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1977,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.694Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-ml-engineer",
@@ -5079,7 +26601,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-ml-engineer",
       "relPath": ".gemini/skills/senior-ml-engineer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2365,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.695Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-ml-engineer",
@@ -5091,7 +26664,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-ml-engineer",
       "relPath": ".codex/skills/senior-ml-engineer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2365,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.695Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-pm",
@@ -5103,7 +26727,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-pm",
       "relPath": ".gemini/skills/senior-pm",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3863,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.697Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-pm",
@@ -5115,7 +26790,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-pm",
       "relPath": ".codex/skills/senior-pm",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3863,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.698Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-prompt-engineer",
@@ -5127,7 +26853,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-prompt-engineer",
       "relPath": ".gemini/skills/senior-prompt-engineer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3048,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.699Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-prompt-engineer",
@@ -5139,7 +26916,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-prompt-engineer",
       "relPath": ".codex/skills/senior-prompt-engineer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3048,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.700Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-qa",
@@ -5151,7 +26979,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-qa",
       "relPath": ".gemini/skills/senior-qa",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1955,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.701Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-qa",
@@ -5163,7 +27042,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-qa",
       "relPath": ".codex/skills/senior-qa",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1955,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.701Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-secops",
@@ -5175,7 +27105,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-secops",
       "relPath": ".gemini/skills/senior-secops",
-      "verified": false
+      "verified": false,
+      "tokenCount": 4070,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.702Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-secops",
@@ -5187,7 +27168,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-secops",
       "relPath": ".codex/skills/senior-secops",
-      "verified": false
+      "verified": false,
+      "tokenCount": 4070,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.704Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-security",
@@ -5199,7 +27231,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-security",
       "relPath": ".gemini/skills/senior-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4076,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.705Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "senior-security",
@@ -5211,7 +27294,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/senior-security",
       "relPath": ".codex/skills/senior-security",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4076,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.706Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "seo-audit",
@@ -5223,7 +27357,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/seo-audit",
       "relPath": ".gemini/skills/seo-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1723,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.707Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "seo-audit",
@@ -5235,7 +27420,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/seo-audit",
       "relPath": ".codex/skills/seo-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1723,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.707Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "seo-auditor",
@@ -5247,7 +27483,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/seo-auditor",
       "relPath": ".gemini/skills/seo-auditor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4668,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.709Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "setup",
@@ -5259,7 +27546,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/setup",
       "relPath": ".gemini/skills/setup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 780,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.709Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "signup-flow-cro",
@@ -5271,7 +27609,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/signup-flow-cro",
       "relPath": ".gemini/skills/signup-flow-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2604,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.710Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "signup-flow-cro",
@@ -5283,7 +27672,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/signup-flow-cro",
       "relPath": ".codex/skills/signup-flow-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2604,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.711Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "site-architecture",
@@ -5295,7 +27735,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/site-architecture",
       "relPath": ".gemini/skills/site-architecture",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4221,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.712Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "site-architecture",
@@ -5307,7 +27798,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/site-architecture",
       "relPath": ".codex/skills/site-architecture",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4221,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.713Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "skill-security-auditor",
@@ -5319,7 +27861,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/skill-security-auditor",
       "relPath": ".gemini/skills/skill-security-auditor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2029,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.714Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "skill-security-auditor",
@@ -5331,7 +27924,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/skill-security-auditor",
       "relPath": ".codex/skills/skill-security-auditor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2029,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.714Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "skill-tester",
@@ -5343,7 +27987,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/skill-tester",
       "relPath": ".gemini/skills/skill-tester",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3883,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.716Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "skill-tester",
@@ -5355,7 +28050,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/skill-tester",
       "relPath": ".codex/skills/skill-tester",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3883,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.717Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "snowflake-development",
@@ -5367,7 +28113,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/snowflake-development",
       "relPath": ".gemini/skills/snowflake-development",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3310,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.718Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "snowflake-development",
@@ -5379,7 +28176,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/snowflake-development",
       "relPath": ".codex/skills/snowflake-development",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3310,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.719Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "soc2-compliance",
@@ -5391,7 +28239,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/soc2-compliance",
       "relPath": ".gemini/skills/soc2-compliance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5016,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.721Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "soc2-compliance",
@@ -5403,7 +28302,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/soc2-compliance",
       "relPath": ".codex/skills/soc2-compliance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5016,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.722Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "social-content",
@@ -5415,7 +28365,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/social-content",
       "relPath": ".gemini/skills/social-content",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3227,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.723Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "social-content",
@@ -5427,7 +28428,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/social-content",
       "relPath": ".codex/skills/social-content",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3227,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.724Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "social-media-analyzer",
@@ -5439,7 +28491,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/social-media-analyzer",
       "relPath": ".gemini/skills/social-media-analyzer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2444,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.725Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "social-media-analyzer",
@@ -5451,7 +28554,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/social-media-analyzer",
       "relPath": ".codex/skills/social-media-analyzer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2444,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.726Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "social-media-manager",
@@ -5463,7 +28617,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/social-media-manager",
       "relPath": ".gemini/skills/social-media-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2643,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.727Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "social-media-manager",
@@ -5475,7 +28680,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/social-media-manager",
       "relPath": ".codex/skills/social-media-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2643,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.728Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "Solo Founder",
@@ -5487,7 +28743,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/solo-founder",
       "relPath": ".gemini/skills/solo-founder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3075,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.729Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "spawn",
@@ -5499,7 +28806,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/spawn",
       "relPath": ".gemini/skills/spawn",
-      "verified": true
+      "verified": true,
+      "tokenCount": 957,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.729Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "spec-driven-workflow",
@@ -5511,7 +28869,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/spec-driven-workflow",
       "relPath": ".gemini/skills/spec-driven-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4317,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.731Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "spec-driven-workflow",
@@ -5523,7 +28932,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/spec-driven-workflow",
       "relPath": ".codex/skills/spec-driven-workflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4317,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.732Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "spec-to-repo",
@@ -5535,7 +28995,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/spec-to-repo",
       "relPath": ".gemini/skills/spec-to-repo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3272,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.733Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "spec-to-repo",
@@ -5547,7 +29058,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/spec-to-repo",
       "relPath": ".codex/skills/spec-to-repo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3272,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.734Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sprint-health",
@@ -5559,7 +29121,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/sprint-health",
       "relPath": ".gemini/skills/sprint-health",
-      "verified": true
+      "verified": true,
+      "tokenCount": 266,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.734Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sprint-plan",
@@ -5571,7 +29184,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/sprint-plan",
       "relPath": ".gemini/skills/sprint-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 96,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.734Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sql-database-assistant",
@@ -5583,7 +29247,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/sql-database-assistant",
       "relPath": ".gemini/skills/sql-database-assistant",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4247,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.735Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sql-database-assistant",
@@ -5595,7 +29310,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/sql-database-assistant",
       "relPath": ".codex/skills/sql-database-assistant",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4247,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.737Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "Startup CTO",
@@ -5607,7 +29373,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/startup-cto",
       "relPath": ".gemini/skills/startup-cto",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2664,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 3,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.738Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "statistical-analyst",
@@ -5619,7 +29436,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/statistical-analyst",
       "relPath": ".gemini/skills/statistical-analyst",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2825,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.739Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "statistical-analyst",
@@ -5631,7 +29499,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/statistical-analyst",
       "relPath": ".codex/skills/statistical-analyst",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2825,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.740Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "status",
@@ -5643,7 +29562,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/status",
       "relPath": ".gemini/skills/status",
-      "verified": true
+      "verified": true,
+      "tokenCount": 818,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.740Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "status",
@@ -5655,7 +29625,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/skills-status",
       "relPath": ".gemini/skills/skills-status",
-      "verified": true
+      "verified": true,
+      "tokenCount": 591,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.740Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "strategic-alignment",
@@ -5667,7 +29688,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/strategic-alignment",
       "relPath": ".gemini/skills/strategic-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2757,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.741Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "strategic-alignment",
@@ -5679,7 +29751,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/strategic-alignment",
       "relPath": ".codex/skills/strategic-alignment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2757,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.742Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "stress-test",
@@ -5691,7 +29814,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/stress-test",
       "relPath": ".gemini/skills/stress-test",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2323,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.743Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "stripe-integration-expert",
@@ -5703,7 +29877,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/stripe-integration-expert",
       "relPath": ".gemini/skills/stripe-integration-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3903,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.744Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "stripe-integration-expert",
@@ -5715,7 +29940,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/stripe-integration-expert",
       "relPath": ".codex/skills/stripe-integration-expert",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3903,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.746Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tc",
@@ -5727,7 +30003,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tc",
       "relPath": ".gemini/skills/tc",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1755,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.746Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tc-tracker",
@@ -5739,7 +30066,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tc-tracker",
       "relPath": ".gemini/skills/tc-tracker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2838,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.747Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tc-tracker",
@@ -5751,7 +30129,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/tc-tracker",
       "relPath": ".codex/skills/tc-tracker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2838,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.748Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd",
@@ -5763,7 +30192,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tdd",
       "relPath": ".gemini/skills/tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 278,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.749Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd-guide",
@@ -5775,7 +30255,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tdd-guide",
       "relPath": ".gemini/skills/tdd-guide",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3721,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.750Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd-guide",
@@ -5787,7 +30318,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/tdd-guide",
       "relPath": ".codex/skills/tdd-guide",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3721,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.751Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "team-communications",
@@ -5799,7 +30381,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/team-communications",
       "relPath": ".gemini/skills/team-communications",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1264,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.751Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "team-communications",
@@ -5811,7 +30444,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/team-communications",
       "relPath": ".codex/skills/team-communications",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1264,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.752Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tech-debt",
@@ -5823,7 +30507,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tech-debt",
       "relPath": ".gemini/skills/tech-debt",
-      "verified": true
+      "verified": true,
+      "tokenCount": 231,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.752Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tech-debt-tracker",
@@ -5835,7 +30570,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tech-debt-tracker",
       "relPath": ".gemini/skills/tech-debt-tracker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1146,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.753Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tech-debt-tracker",
@@ -5847,7 +30633,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/tech-debt-tracker",
       "relPath": ".codex/skills/tech-debt-tracker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1146,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.753Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tech-stack-evaluator",
@@ -5859,7 +30696,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tech-stack-evaluator",
       "relPath": ".gemini/skills/tech-stack-evaluator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1008,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.753Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tech-stack-evaluator",
@@ -5871,7 +30759,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/tech-stack-evaluator",
       "relPath": ".codex/skills/tech-stack-evaluator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1008,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.754Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "terraform-patterns",
@@ -5883,7 +30822,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/terraform-patterns",
       "relPath": ".gemini/skills/terraform-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6331,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.756Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "terraform-patterns",
@@ -5895,7 +30885,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/terraform-patterns",
       "relPath": ".codex/skills/terraform-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6331,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.758Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "testrail",
@@ -5907,7 +30948,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/testrail",
       "relPath": ".gemini/skills/testrail",
-      "verified": true
+      "verified": true,
+      "tokenCount": 949,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.758Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "threat-detection",
@@ -5919,7 +31011,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/threat-detection",
       "relPath": ".gemini/skills/threat-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3798,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.759Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "threat-detection",
@@ -5931,7 +31074,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/threat-detection",
       "relPath": ".codex/skills/threat-detection",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3798,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.760Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ui-design-system",
@@ -5943,7 +31137,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ui-design-system",
       "relPath": ".gemini/skills/ui-design-system",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3181,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.761Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ui-design-system",
@@ -5955,7 +31200,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ui-design-system",
       "relPath": ".codex/skills/ui-design-system",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3181,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.762Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "user-story",
@@ -5967,7 +31263,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/user-story",
       "relPath": ".gemini/skills/user-story",
-      "verified": true
+      "verified": true,
+      "tokenCount": 296,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.762Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ux-researcher-designer",
@@ -5979,7 +31326,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ux-researcher-designer",
       "relPath": ".gemini/skills/ux-researcher-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3573,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.763Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ux-researcher-designer",
@@ -5991,7 +31389,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ux-researcher-designer",
       "relPath": ".codex/skills/ux-researcher-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3573,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.764Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "video-content-strategist",
@@ -6003,7 +31452,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/video-content-strategist",
       "relPath": ".gemini/skills/video-content-strategist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3402,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.765Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "video-content-strategist",
@@ -6015,7 +31515,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/video-content-strategist",
       "relPath": ".codex/skills/video-content-strategist",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3402,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.766Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "wiki-ingest",
@@ -6027,7 +31578,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/wiki-ingest",
       "relPath": ".gemini/skills/wiki-ingest",
-      "verified": true
+      "verified": true,
+      "tokenCount": 560,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.767Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "wiki-init",
@@ -6039,7 +31641,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/wiki-init",
       "relPath": ".gemini/skills/wiki-init",
-      "verified": true
+      "verified": true,
+      "tokenCount": 474,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.767Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "wiki-lint",
@@ -6051,7 +31704,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/wiki-lint",
       "relPath": ".gemini/skills/wiki-lint",
-      "verified": true
+      "verified": true,
+      "tokenCount": 614,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.767Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "wiki-log",
@@ -6063,7 +31767,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/wiki-log",
       "relPath": ".gemini/skills/wiki-log",
-      "verified": true
+      "verified": true,
+      "tokenCount": 542,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.767Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "wiki-query",
@@ -6075,7 +31830,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/wiki-query",
       "relPath": ".gemini/skills/wiki-query",
-      "verified": true
+      "verified": true,
+      "tokenCount": 633,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.768Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "x-twitter-growth",
@@ -6087,7 +31893,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/x-twitter-growth",
       "relPath": ".gemini/skills/x-twitter-growth",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2569,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.769Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "x-twitter-growth",
@@ -6099,7 +31956,58 @@
       "allowedTools": [],
       "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/x-twitter-growth",
       "relPath": ".codex/skills/x-twitter-growth",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2569,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:04.769Z",
+        "evaluatedVersion": "1.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/anthropics_skills.json
+++ b/data/skill-index/anthropics_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/anthropics/skills.git",
   "owner": "anthropics",
   "repo": "skills",
-  "updatedAt": "2026-04-20T06:32:41.501Z",
+  "updatedAt": "2026-04-20T07:44:24.940Z",
   "skillCount": 18,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/algorithmic-art",
       "relPath": "skills/algorithmic-art",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5351,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.896Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "brand-guidelines",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/brand-guidelines",
       "relPath": "skills/brand-guidelines",
-      "verified": true
+      "verified": true,
+      "tokenCount": 609,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.896Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "canvas-design",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/canvas-design",
       "relPath": "skills/canvas-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3415,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.897Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "claude-api",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/claude-api",
       "relPath": "skills/claude-api",
-      "verified": true
+      "verified": true,
+      "tokenCount": 9746,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.900Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "doc-coauthoring",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/doc-coauthoring",
       "relPath": "skills/doc-coauthoring",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4704,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.901Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "docx",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/docx",
       "relPath": "skills/docx",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5560,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.902Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-design",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/frontend-design",
       "relPath": "skills/frontend-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1136,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.903Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "internal-comms",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/internal-comms",
       "relPath": "skills/internal-comms",
-      "verified": true
+      "verified": true,
+      "tokenCount": 412,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.903Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-builder",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/mcp-builder",
       "relPath": "skills/mcp-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2173,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.904Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pdf",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/pdf",
       "relPath": "skills/pdf",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2015,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.905Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pptx",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/pptx",
       "relPath": "skills/pptx",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2666,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.905Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "skill-creator",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/skill-creator",
       "relPath": "skills/skill-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 10269,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.908Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "slack-gif-creator",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/slack-gif-creator",
       "relPath": "skills/slack-gif-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2145,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.908Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "template-skill",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:template",
       "relPath": "template",
-      "verified": true
+      "verified": true,
+      "tokenCount": 37,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.908Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "theme-factory",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/theme-factory",
       "relPath": "skills/theme-factory",
-      "verified": true
+      "verified": true,
+      "tokenCount": 929,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.909Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "web-artifacts-builder",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/web-artifacts-builder",
       "relPath": "skills/web-artifacts-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 841,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.909Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "webapp-testing",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/webapp-testing",
       "relPath": "skills/webapp-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1103,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.910Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "xlsx",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:anthropics/skills:skills/xlsx",
       "relPath": "skills/xlsx",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3146,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:24.910Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/bytedance_deer-flow.json
+++ b/data/skill-index/bytedance_deer-flow.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/bytedance/deer-flow.git",
   "owner": "bytedance",
   "repo": "deer-flow",
-  "updatedAt": "2026-04-20T06:33:27.424Z",
+  "updatedAt": "2026-04-20T07:44:17.295Z",
   "skillCount": 22,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/academic-paper-review",
       "relPath": "skills/public/academic-paper-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3314,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.202Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bootstrap",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/bootstrap",
       "relPath": "skills/public/bootstrap",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1478,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.202Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "chart-visualization",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/chart-visualization",
       "relPath": "skills/public/chart-visualization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 759,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.203Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "claude-to-deerflow",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/claude-to-deerflow",
       "relPath": "skills/public/claude-to-deerflow",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1919,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.204Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "code-documentation",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/code-documentation",
       "relPath": "skills/public/code-documentation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3811,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.205Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "consulting-analysis",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/consulting-analysis",
       "relPath": "skills/public/consulting-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 9313,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.208Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "data-analysis",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/data-analysis",
       "relPath": "skills/public/data-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2321,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.209Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "deep-research",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/deep-research",
       "relPath": "skills/public/deep-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2212,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.210Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "find-skills",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/find-skills",
       "relPath": "skills/public/find-skills",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1445,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.210Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "frontend-design",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/frontend-design",
       "relPath": "skills/public/frontend-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1932,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.211Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "github-deep-research",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/github-deep-research",
       "relPath": "skills/public/github-deep-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1278,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.211Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "image-generation",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/image-generation",
       "relPath": "skills/public/image-generation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2217,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.212Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "newsletter-generation",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/newsletter-generation",
       "relPath": "skills/public/newsletter-generation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3541,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.214Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "podcast-generation",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/podcast-generation",
       "relPath": "skills/public/podcast-generation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1934,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.214Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ppt-generation",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/ppt-generation",
       "relPath": "skills/public/ppt-generation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7130,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.217Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "skill-creator",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/skill-creator",
       "relPath": "skills/public/skill-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 10269,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.220Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "smoke-test",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:.agent/skills/smoke-test",
       "relPath": ".agent/skills/smoke-test",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2764,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.220Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "surprise-me",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/surprise-me",
       "relPath": "skills/public/surprise-me",
-      "verified": true
+      "verified": true,
+      "tokenCount": 768,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.221Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "systematic-literature-review",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/systematic-literature-review",
       "relPath": "skills/public/systematic-literature-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5299,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.222Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "vercel-deploy",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/vercel-deploy-claimable",
       "relPath": "skills/public/vercel-deploy-claimable",
-      "verified": true
+      "verified": true,
+      "tokenCount": 724,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.223Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "video-generation",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/video-generation",
       "relPath": "skills/public/video-generation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1319,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.223Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "web-design-guidelines",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:bytedance/deer-flow:skills/public/web-design-guidelines",
       "relPath": "skills/public/web-design-guidelines",
-      "verified": true
+      "verified": true,
+      "tokenCount": 330,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:17.224Z",
+        "evaluatedVersion": "1.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/coreyhaines31_marketingskills.json
+++ b/data/skill-index/coreyhaines31_marketingskills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/coreyhaines31/marketingskills.git",
   "owner": "coreyhaines31",
   "repo": "marketingskills",
-  "updatedAt": "2026-04-20T06:33:08.375Z",
+  "updatedAt": "2026-04-20T07:45:13.194Z",
   "skillCount": 36,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/ab-test-setup",
       "relPath": "skills/ab-test-setup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3068,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.137Z",
+        "evaluatedVersion": "1.2.0"
+      }
     },
     {
       "name": "ad-creative",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/ad-creative",
       "relPath": "skills/ad-creative",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3787,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.138Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "ai-seo",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/ai-seo",
       "relPath": "skills/ai-seo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5716,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.140Z",
+        "evaluatedVersion": "1.2.0"
+      }
     },
     {
       "name": "analytics-tracking",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/analytics-tracking",
       "relPath": "skills/analytics-tracking",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2167,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.140Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "aso-audit",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/aso-audit",
       "relPath": "skills/aso-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5207,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.142Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "churn-prevention",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/churn-prevention",
       "relPath": "skills/churn-prevention",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5842,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.143Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "cold-email",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/cold-email",
       "relPath": "skills/cold-email",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2064,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.144Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "community-marketing",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/community-marketing",
       "relPath": "skills/community-marketing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2579,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.144Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "competitor-alternatives",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/competitor-alternatives",
       "relPath": "skills/competitor-alternatives",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2146,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.145Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "content-strategy",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/content-strategy",
       "relPath": "skills/content-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3321,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.146Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "copy-editing",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/copy-editing",
       "relPath": "skills/copy-editing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4755,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.148Z",
+        "evaluatedVersion": "1.3.0"
+      }
     },
     {
       "name": "copywriting",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/copywriting",
       "relPath": "skills/copywriting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2102,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.148Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "customer-research",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/customer-research",
       "relPath": "skills/customer-research",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3394,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.149Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "email-sequence",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/email-sequence",
       "relPath": "skills/email-sequence",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2270,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.150Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "form-cro",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/form-cro",
       "relPath": "skills/form-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3116,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.151Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "free-tool-strategy",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/free-tool-strategy",
       "relPath": "skills/free-tool-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1688,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.152Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "launch-strategy",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/launch-strategy",
       "relPath": "skills/launch-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3541,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.153Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "lead-magnets",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/lead-magnets",
       "relPath": "skills/lead-magnets",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3218,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.154Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "marketing-ideas",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-ideas",
       "relPath": "skills/marketing-ideas",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1421,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.154Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "marketing-psychology",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/marketing-psychology",
       "relPath": "skills/marketing-psychology",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5767,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.156Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "onboarding-cro",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/onboarding-cro",
       "relPath": "skills/onboarding-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1861,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.156Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "page-cro",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/page-cro",
       "relPath": "skills/page-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1666,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.157Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "paid-ads",
@@ -279,7 +1401,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/paid-ads",
       "relPath": "skills/paid-ads",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2743,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.158Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "paywall-upgrade-cro",
@@ -291,7 +1464,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/paywall-upgrade-cro",
       "relPath": "skills/paywall-upgrade-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1642,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.159Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "popup-cro",
@@ -303,7 +1527,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/popup-cro",
       "relPath": "skills/popup-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3269,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.160Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "pricing-strategy",
@@ -315,7 +1590,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/pricing-strategy",
       "relPath": "skills/pricing-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1979,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.161Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "product-marketing-context",
@@ -327,7 +1653,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/product-marketing-context",
       "relPath": "skills/product-marketing-context",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2009,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.161Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "programmatic-seo",
@@ -339,7 +1716,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/programmatic-seo",
       "relPath": "skills/programmatic-seo",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1983,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.162Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "referral-program",
@@ -351,7 +1779,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/referral-program",
       "relPath": "skills/referral-program",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1955,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.163Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "revops",
@@ -363,7 +1842,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/revops",
       "relPath": "skills/revops",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4232,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.164Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "sales-enablement",
@@ -375,7 +1905,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/sales-enablement",
       "relPath": "skills/sales-enablement",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4310,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.165Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "schema-markup",
@@ -387,7 +1968,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/schema-markup",
       "relPath": "skills/schema-markup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1418,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.166Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "seo-audit",
@@ -399,7 +2031,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/seo-audit",
       "relPath": "skills/seo-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2895,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.166Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "signup-flow-cro",
@@ -411,7 +2094,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/signup-flow-cro",
       "relPath": "skills/signup-flow-cro",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2968,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.167Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "site-architecture",
@@ -423,7 +2157,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/site-architecture",
       "relPath": "skills/site-architecture",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3876,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.169Z",
+        "evaluatedVersion": "1.1.0"
+      }
     },
     {
       "name": "social-content",
@@ -435,7 +2220,58 @@
       "allowedTools": [],
       "installUrl": "github:coreyhaines31/marketingskills:skills/social-content",
       "relPath": "skills/social-content",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3234,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:13.170Z",
+        "evaluatedVersion": "1.2.0"
+      }
     }
   ]
 }

--- a/data/skill-index/github_awesome-copilot.json
+++ b/data/skill-index/github_awesome-copilot.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/github/awesome-copilot.git",
   "owner": "github",
   "repo": "awesome-copilot",
-  "updatedAt": "2026-04-20T06:33:43.344Z",
+  "updatedAt": "2026-04-20T07:44:54.629Z",
   "skillCount": 441,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/acquire-codebase-knowledge",
       "relPath": "skills/acquire-codebase-knowledge",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2282,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.128Z",
+        "evaluatedVersion": "1.3"
+      }
     },
     {
       "name": "add-educational-comments",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/add-educational-comments",
       "relPath": "skills/add-educational-comments",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1730,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.129Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-governance",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/agent-governance",
       "relPath": "skills/agent-governance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5572,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.130Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-owasp-compliance",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/agent-owasp-compliance",
       "relPath": "skills/agent-owasp-compliance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3234,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.131Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agent-supply-chain",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/agent-supply-chain",
       "relPath": "skills/agent-supply-chain",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3453,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.132Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "agentic-eval",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/agentic-eval",
       "relPath": "skills/agentic-eval",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1779,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.133Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ai-prompt-engineering-safety-review",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/security-best-practices/skills/ai-prompt-engineering-safety-review",
       "relPath": "plugins/security-best-practices/skills/ai-prompt-engineering-safety-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2497,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.134Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ai-prompt-engineering-safety-review",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/testing-automation/skills/ai-prompt-engineering-safety-review",
       "relPath": "plugins/testing-automation/skills/ai-prompt-engineering-safety-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2497,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.135Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ai-prompt-engineering-safety-review",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/ai-prompt-engineering-safety-review",
       "relPath": "skills/ai-prompt-engineering-safety-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2497,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.135Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "appinsights-instrumentation",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/appinsights-instrumentation",
       "relPath": "skills/appinsights-instrumentation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 744,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.136Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "apple-appstore-reviewer",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/apple-appstore-reviewer",
       "relPath": "skills/apple-appstore-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2570,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.136Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arch-linux-triage",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/arch-linux-triage",
       "relPath": "skills/arch-linux-triage",
-      "verified": true
+      "verified": true,
+      "tokenCount": 215,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.137Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "architecture-blueprint-generator",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/architecture-blueprint-generator",
       "relPath": "skills/architecture-blueprint-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3173,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.138Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-ai-provider-integration",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-ai-provider-integration",
       "relPath": "plugins/arize-ax/skills/arize-ai-provider-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2393,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.138Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-ai-provider-integration",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/arize-ai-provider-integration",
       "relPath": "skills/arize-ai-provider-integration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2393,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.139Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-annotation",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-annotation",
       "relPath": "plugins/arize-ax/skills/arize-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2124,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.140Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-annotation",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/arize-annotation",
       "relPath": "skills/arize-annotation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2124,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.140Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-dataset",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-dataset",
       "relPath": "plugins/arize-ax/skills/arize-dataset",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4117,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.141Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-dataset",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/arize-dataset",
       "relPath": "skills/arize-dataset",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4117,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.143Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-evaluator",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-evaluator",
       "relPath": "plugins/arize-ax/skills/arize-evaluator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7045,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.144Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-evaluator",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/arize-evaluator",
       "relPath": "skills/arize-evaluator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7045,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.147Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-experiment",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-experiment",
       "relPath": "plugins/arize-ax/skills/arize-experiment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3718,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.148Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-experiment",
@@ -279,7 +1401,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/arize-experiment",
       "relPath": "skills/arize-experiment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3718,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.149Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-instrumentation",
@@ -291,7 +1464,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-instrumentation",
       "relPath": "plugins/arize-ax/skills/arize-instrumentation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4466,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.150Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-instrumentation",
@@ -303,7 +1527,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/arize-instrumentation",
       "relPath": "skills/arize-instrumentation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4466,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.152Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-link",
@@ -315,7 +1590,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-link",
       "relPath": "plugins/arize-ax/skills/arize-link",
-      "verified": true
+      "verified": true,
+      "tokenCount": 964,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.152Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-link",
@@ -327,7 +1653,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/arize-link",
       "relPath": "skills/arize-link",
-      "verified": true
+      "verified": true,
+      "tokenCount": 964,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.153Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-prompt-optimization",
@@ -339,7 +1716,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-prompt-optimization",
       "relPath": "plugins/arize-ax/skills/arize-prompt-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5080,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.154Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-prompt-optimization",
@@ -351,7 +1779,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/arize-prompt-optimization",
       "relPath": "skills/arize-prompt-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5080,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.156Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-trace",
@@ -363,7 +1842,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-trace",
       "relPath": "plugins/arize-ax/skills/arize-trace",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5766,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.157Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "arize-trace",
@@ -375,7 +1905,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/arize-trace",
       "relPath": "skills/arize-trace",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5766,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.159Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "aspire",
@@ -387,7 +1968,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/aspire",
       "relPath": "skills/aspire",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2299,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.160Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "aspnet-minimal-api-openapi",
@@ -399,7 +2031,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/csharp-dotnet-development/skills/aspnet-minimal-api-openapi",
       "relPath": "plugins/csharp-dotnet-development/skills/aspnet-minimal-api-openapi",
-      "verified": true
+      "verified": true,
+      "tokenCount": 459,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.160Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "aspnet-minimal-api-openapi",
@@ -411,7 +2094,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/aspnet-minimal-api-openapi",
       "relPath": "skills/aspnet-minimal-api-openapi",
-      "verified": true
+      "verified": true,
+      "tokenCount": 459,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.160Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "automate-this",
@@ -423,7 +2157,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/automate-this/skills/automate-this",
       "relPath": "plugins/automate-this/skills/automate-this",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3688,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.161Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "automate-this",
@@ -435,7 +2220,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/automate-this",
       "relPath": "skills/automate-this",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3688,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.162Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "autoresearch",
@@ -447,7 +2283,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/autoresearch",
       "relPath": "skills/autoresearch",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3644,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.163Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "aws-cdk-python-setup",
@@ -459,7 +2346,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/aws-cdk-python-setup",
       "relPath": "skills/aws-cdk-python-setup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 672,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.163Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "az-cost-optimize",
@@ -471,7 +2409,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/azure-cloud-development/skills/az-cost-optimize",
       "relPath": "plugins/azure-cloud-development/skills/az-cost-optimize",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3871,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.164Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "az-cost-optimize",
@@ -483,7 +2472,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/az-cost-optimize",
       "relPath": "skills/az-cost-optimize",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3871,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.166Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-architecture-autopilot",
@@ -495,7 +2535,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/azure-architecture-autopilot",
       "relPath": "skills/azure-architecture-autopilot",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2033,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.166Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-deployment-preflight",
@@ -507,7 +2598,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/azure-deployment-preflight",
       "relPath": "skills/azure-deployment-preflight",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1999,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.167Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-devops-cli",
@@ -519,7 +2661,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/azure-devops-cli",
       "relPath": "skills/azure-devops-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1183,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.167Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-pricing",
@@ -531,7 +2724,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/azure-cloud-development/skills/azure-pricing",
       "relPath": "plugins/azure-cloud-development/skills/azure-pricing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2569,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.168Z",
+        "evaluatedVersion": "1.2"
+      }
     },
     {
       "name": "azure-pricing",
@@ -543,7 +2787,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/azure-pricing",
       "relPath": "skills/azure-pricing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2569,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.169Z",
+        "evaluatedVersion": "1.2"
+      }
     },
     {
       "name": "azure-resource-health-diagnose",
@@ -555,7 +2850,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/azure-cloud-development/skills/azure-resource-health-diagnose",
       "relPath": "plugins/azure-cloud-development/skills/azure-resource-health-diagnose",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3227,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.170Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-resource-health-diagnose",
@@ -567,7 +2913,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/devops-oncall/skills/azure-resource-health-diagnose",
       "relPath": "plugins/devops-oncall/skills/azure-resource-health-diagnose",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3227,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.171Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-resource-health-diagnose",
@@ -579,7 +2976,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/azure-resource-health-diagnose",
       "relPath": "skills/azure-resource-health-diagnose",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3227,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.172Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-resource-visualizer",
@@ -591,7 +3039,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/azure-resource-visualizer",
       "relPath": "skills/azure-resource-visualizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2752,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.173Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-role-selector",
@@ -612,7 +3111,58 @@
       ],
       "installUrl": "github:github/awesome-copilot:skills/azure-role-selector",
       "relPath": "skills/azure-role-selector",
-      "verified": true
+      "verified": true,
+      "tokenCount": 266,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.173Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "azure-static-web-apps",
@@ -624,7 +3174,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/azure-static-web-apps",
       "relPath": "skills/azure-static-web-apps",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2796,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.174Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "bigquery-pipeline-audit",
@@ -636,7 +3237,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/bigquery-pipeline-audit",
       "relPath": "skills/bigquery-pipeline-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1522,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.174Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "boost-prompt",
@@ -648,7 +3300,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/boost-prompt",
       "relPath": "skills/boost-prompt",
-      "verified": true
+      "verified": true,
+      "tokenCount": 397,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.175Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "breakdown-epic-arch",
@@ -660,7 +3363,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/project-planning/skills/breakdown-epic-arch",
       "relPath": "plugins/project-planning/skills/breakdown-epic-arch",
-      "verified": true
+      "verified": true,
+      "tokenCount": 757,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.175Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "breakdown-epic-arch",
@@ -672,7 +3426,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-arch",
       "relPath": "skills/breakdown-epic-arch",
-      "verified": true
+      "verified": true,
+      "tokenCount": 757,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.175Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "breakdown-epic-pm",
@@ -684,7 +3489,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/project-planning/skills/breakdown-epic-pm",
       "relPath": "plugins/project-planning/skills/breakdown-epic-pm",
-      "verified": true
+      "verified": true,
+      "tokenCount": 673,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.175Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "breakdown-epic-pm",
@@ -696,7 +3552,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/breakdown-epic-pm",
       "relPath": "skills/breakdown-epic-pm",
-      "verified": true
+      "verified": true,
+      "tokenCount": 673,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.176Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "breakdown-feature-implementation",
@@ -708,7 +3615,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/project-planning/skills/breakdown-feature-implementation",
       "relPath": "plugins/project-planning/skills/breakdown-feature-implementation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1218,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.176Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "breakdown-feature-implementation",
@@ -720,7 +3678,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/breakdown-feature-implementation",
       "relPath": "skills/breakdown-feature-implementation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1218,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.177Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "breakdown-feature-prd",
@@ -732,7 +3741,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/project-planning/skills/breakdown-feature-prd",
       "relPath": "plugins/project-planning/skills/breakdown-feature-prd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 742,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.177Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "breakdown-feature-prd",
@@ -744,7 +3804,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/breakdown-feature-prd",
       "relPath": "skills/breakdown-feature-prd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 742,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.177Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "breakdown-plan",
@@ -756,7 +3867,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/breakdown-plan",
       "relPath": "skills/breakdown-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4152,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.178Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "breakdown-test",
@@ -768,7 +3930,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/breakdown-test",
       "relPath": "skills/breakdown-test",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3605,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.180Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "centos-linux-triage",
@@ -780,7 +3993,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/centos-linux-triage",
       "relPath": "skills/centos-linux-triage",
-      "verified": true
+      "verified": true,
+      "tokenCount": 215,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.180Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "chrome-devtools",
@@ -792,7 +4056,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/chrome-devtools",
       "relPath": "skills/chrome-devtools",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1064,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.180Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cli-mastery",
@@ -804,7 +4119,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/cli-mastery",
       "relPath": "skills/cli-mastery",
-      "verified": true
+      "verified": true,
+      "tokenCount": 538,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.180Z",
+        "evaluatedVersion": "1.2.0"
+      }
     },
     {
       "name": "cloud-design-patterns",
@@ -816,7 +4182,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/cloud-design-patterns",
       "relPath": "skills/cloud-design-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1066,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.181Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "code-exemplars-blueprint-generator",
@@ -828,7 +4245,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/code-exemplars-blueprint-generator",
       "relPath": "skills/code-exemplars-blueprint-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1607,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.181Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "code-tour",
@@ -840,7 +4308,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/code-tour",
       "relPath": "skills/code-tour",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6711,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.183Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "codeql",
@@ -852,7 +4371,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/codeql",
       "relPath": "skills/codeql",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3527,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.185Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "comment-code-generate-a-tutorial",
@@ -864,7 +4434,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/comment-code-generate-a-tutorial",
       "relPath": "skills/comment-code-generate-a-tutorial",
-      "verified": true
+      "verified": true,
+      "tokenCount": 442,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.185Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "containerize-aspnet-framework",
@@ -876,7 +4497,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/containerize-aspnet-framework",
       "relPath": "skills/containerize-aspnet-framework",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5828,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.186Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "containerize-aspnetcore",
@@ -888,7 +4560,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/containerize-aspnetcore",
       "relPath": "skills/containerize-aspnetcore",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4498,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.188Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "context-map",
@@ -900,7 +4623,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/context-engineering/skills/context-map",
       "relPath": "plugins/context-engineering/skills/context-map",
-      "verified": true
+      "verified": true,
+      "tokenCount": 320,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.188Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "context-map",
@@ -912,7 +4686,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/context-map",
       "relPath": "skills/context-map",
-      "verified": true
+      "verified": true,
+      "tokenCount": 320,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.188Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "conventional-commit",
@@ -924,7 +4749,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/conventional-commit",
       "relPath": "skills/conventional-commit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 531,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.188Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "convert-plaintext-to-md",
@@ -936,7 +4812,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/convert-plaintext-to-md",
       "relPath": "skills/convert-plaintext-to-md",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3457,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.189Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "copilot-cli-quickstart",
@@ -948,7 +4875,58 @@
       "allowedTools": ["ask_user", "sql", "fetch_copilot_cli_documentation"],
       "installUrl": "github:github/awesome-copilot:skills/copilot-cli-quickstart",
       "relPath": "skills/copilot-cli-quickstart",
-      "verified": true
+      "verified": true,
+      "tokenCount": 9417,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.192Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "copilot-instructions-blueprint-generator",
@@ -960,7 +4938,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/copilot-instructions-blueprint-generator",
       "relPath": "skills/copilot-instructions-blueprint-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3879,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.193Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "copilot-sdk",
@@ -972,7 +5001,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/copilot-sdk/skills/copilot-sdk",
       "relPath": "plugins/copilot-sdk/skills/copilot-sdk",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6476,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.195Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "copilot-sdk",
@@ -984,7 +5064,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/copilot-sdk",
       "relPath": "skills/copilot-sdk",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6476,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.197Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "copilot-spaces",
@@ -996,7 +5127,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/copilot-spaces",
       "relPath": "skills/copilot-spaces",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2362,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.198Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "copilot-usage-metrics",
@@ -1008,7 +5190,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/copilot-usage-metrics",
       "relPath": "skills/copilot-usage-metrics",
-      "verified": true
+      "verified": true,
+      "tokenCount": 689,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.198Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "cosmosdb-datamodeling",
@@ -1020,7 +5253,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/cosmosdb-datamodeling",
       "relPath": "skills/cosmosdb-datamodeling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 12957,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.202Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-agentsmd",
@@ -1032,7 +5316,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-agentsmd",
       "relPath": "skills/create-agentsmd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2175,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.202Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-architectural-decision-record",
@@ -1044,7 +5379,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-architectural-decision-record",
       "relPath": "skills/create-architectural-decision-record",
-      "verified": true
+      "verified": true,
+      "tokenCount": 687,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.203Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-github-action-workflow-specification",
@@ -1056,7 +5442,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-github-action-workflow-specification",
       "relPath": "skills/create-github-action-workflow-specification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1883,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.203Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-github-issue-feature-from-specification",
@@ -1068,7 +5505,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-github-issue-feature-from-specification",
       "relPath": "skills/create-github-issue-feature-from-specification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 214,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.203Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-github-issues-feature-from-implementation-plan",
@@ -1080,7 +5568,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/project-planning/skills/create-github-issues-feature-from-implementation-plan",
       "relPath": "plugins/project-planning/skills/create-github-issues-feature-from-implementation-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 226,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.203Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-github-issues-feature-from-implementation-plan",
@@ -1092,7 +5631,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-github-issues-feature-from-implementation-plan",
       "relPath": "skills/create-github-issues-feature-from-implementation-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 226,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.204Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-github-issues-for-unmet-specification-requirements",
@@ -1104,7 +5694,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-github-issues-for-unmet-specification-requirements",
       "relPath": "skills/create-github-issues-for-unmet-specification-requirements",
-      "verified": true
+      "verified": true,
+      "tokenCount": 291,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.204Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-github-pull-request-from-specification",
@@ -1116,7 +5757,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-github-pull-request-from-specification",
       "relPath": "skills/create-github-pull-request-from-specification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 421,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.204Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-implementation-plan",
@@ -1128,7 +5820,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/project-planning/skills/create-implementation-plan",
       "relPath": "plugins/project-planning/skills/create-implementation-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1682,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.204Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-implementation-plan",
@@ -1140,7 +5883,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-implementation-plan",
       "relPath": "skills/create-implementation-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1682,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.205Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-llms",
@@ -1152,7 +5946,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-llms",
       "relPath": "skills/create-llms",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1850,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.206Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-readme",
@@ -1164,7 +6009,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-readme",
       "relPath": "skills/create-readme",
-      "verified": true
+      "verified": true,
+      "tokenCount": 299,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.206Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-specification",
@@ -1176,7 +6072,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-specification",
       "relPath": "skills/create-specification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1377,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.207Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-spring-boot-java-project",
@@ -1188,7 +6135,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/java-development/skills/create-spring-boot-java-project",
       "relPath": "plugins/java-development/skills/create-spring-boot-java-project",
-      "verified": true
+      "verified": true,
+      "tokenCount": 910,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.207Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-spring-boot-java-project",
@@ -1200,7 +6198,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-spring-boot-java-project",
       "relPath": "skills/create-spring-boot-java-project",
-      "verified": true
+      "verified": true,
+      "tokenCount": 910,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.207Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-spring-boot-kotlin-project",
@@ -1212,7 +6261,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-spring-boot-kotlin-project",
       "relPath": "skills/create-spring-boot-kotlin-project",
-      "verified": true
+      "verified": true,
+      "tokenCount": 836,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.208Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-technical-spike",
@@ -1224,7 +6324,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/project-planning/skills/create-technical-spike",
       "relPath": "plugins/project-planning/skills/create-technical-spike",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1503,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.208Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-technical-spike",
@@ -1236,7 +6387,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/technical-spike/skills/create-technical-spike",
       "relPath": "plugins/technical-spike/skills/create-technical-spike",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1503,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.209Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-technical-spike",
@@ -1248,7 +6450,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-technical-spike",
       "relPath": "skills/create-technical-spike",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1503,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.209Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "create-tldr-page",
@@ -1260,7 +6513,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/create-tldr-page",
       "relPath": "skills/create-tldr-page",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1581,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.210Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "creating-oracle-to-postgres-master-migration-plan",
@@ -1272,7 +6576,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/oracle-to-postgres-migration-expert/skills/creating-oracle-to-postgres-master-migration-plan",
       "relPath": "plugins/oracle-to-postgres-migration-expert/skills/creating-oracle-to-postgres-master-migration-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 828,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.210Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "creating-oracle-to-postgres-master-migration-plan",
@@ -1284,7 +6639,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/creating-oracle-to-postgres-master-migration-plan",
       "relPath": "skills/creating-oracle-to-postgres-master-migration-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 828,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.211Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "creating-oracle-to-postgres-migration-bug-report",
@@ -1296,7 +6702,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/oracle-to-postgres-migration-expert/skills/creating-oracle-to-postgres-migration-bug-report",
       "relPath": "plugins/oracle-to-postgres-migration-expert/skills/creating-oracle-to-postgres-migration-bug-report",
-      "verified": true
+      "verified": true,
+      "tokenCount": 571,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.211Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "creating-oracle-to-postgres-migration-bug-report",
@@ -1308,7 +6765,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/creating-oracle-to-postgres-migration-bug-report",
       "relPath": "skills/creating-oracle-to-postgres-migration-bug-report",
-      "verified": true
+      "verified": true,
+      "tokenCount": 571,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.211Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "creating-oracle-to-postgres-migration-integration-tests",
@@ -1320,7 +6828,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/oracle-to-postgres-migration-expert/skills/creating-oracle-to-postgres-migration-integration-tests",
       "relPath": "plugins/oracle-to-postgres-migration-expert/skills/creating-oracle-to-postgres-migration-integration-tests",
-      "verified": true
+      "verified": true,
+      "tokenCount": 864,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.211Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "creating-oracle-to-postgres-migration-integration-tests",
@@ -1332,7 +6891,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/creating-oracle-to-postgres-migration-integration-tests",
       "relPath": "skills/creating-oracle-to-postgres-migration-integration-tests",
-      "verified": true
+      "verified": true,
+      "tokenCount": 864,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.212Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-async",
@@ -1344,7 +6954,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/csharp-dotnet-development/skills/csharp-async",
       "relPath": "plugins/csharp-dotnet-development/skills/csharp-async",
-      "verified": true
+      "verified": true,
+      "tokenCount": 492,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.212Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-async",
@@ -1356,7 +7017,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/csharp-async",
       "relPath": "skills/csharp-async",
-      "verified": true
+      "verified": true,
+      "tokenCount": 492,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.212Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-docs",
@@ -1368,7 +7080,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/csharp-docs",
       "relPath": "skills/csharp-docs",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1274,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.212Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-mcp-server-generator",
@@ -1380,7 +7143,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/csharp-mcp-development/skills/csharp-mcp-server-generator",
       "relPath": "plugins/csharp-mcp-development/skills/csharp-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 571,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.213Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-mcp-server-generator",
@@ -1392,7 +7206,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/csharp-mcp-server-generator",
       "relPath": "skills/csharp-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 571,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.213Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-mstest",
@@ -1404,7 +7269,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/csharp-dotnet-development/skills/csharp-mstest",
       "relPath": "plugins/csharp-dotnet-development/skills/csharp-mstest",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2934,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.214Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-mstest",
@@ -1416,7 +7332,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/csharp-mstest",
       "relPath": "skills/csharp-mstest",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2934,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.216Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-nunit",
@@ -1428,7 +7395,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/csharp-dotnet-development/skills/csharp-nunit",
       "relPath": "plugins/csharp-dotnet-development/skills/csharp-nunit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 747,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.216Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-nunit",
@@ -1440,7 +7458,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/testing-automation/skills/csharp-nunit",
       "relPath": "plugins/testing-automation/skills/csharp-nunit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 747,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.216Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-nunit",
@@ -1452,7 +7521,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/csharp-nunit",
       "relPath": "skills/csharp-nunit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 747,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.216Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-tunit",
@@ -1464,7 +7584,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/csharp-dotnet-development/skills/csharp-tunit",
       "relPath": "plugins/csharp-dotnet-development/skills/csharp-tunit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1220,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.217Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-tunit",
@@ -1476,7 +7647,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/csharp-tunit",
       "relPath": "skills/csharp-tunit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1220,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.217Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-xunit",
@@ -1488,7 +7710,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/csharp-dotnet-development/skills/csharp-xunit",
       "relPath": "plugins/csharp-dotnet-development/skills/csharp-xunit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 706,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.218Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "csharp-xunit",
@@ -1500,7 +7773,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/csharp-xunit",
       "relPath": "skills/csharp-xunit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 706,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.218Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "daily-prep",
@@ -1512,7 +7836,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/daily-prep",
       "relPath": "skills/daily-prep",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2576,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.219Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "datanalysis-credit-risk",
@@ -1524,7 +7899,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/datanalysis-credit-risk",
       "relPath": "skills/datanalysis-credit-risk",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1570,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.219Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dataverse-python-advanced-patterns",
@@ -1536,7 +7962,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/dataverse-sdk-for-python/skills/dataverse-python-advanced-patterns",
       "relPath": "plugins/dataverse-sdk-for-python/skills/dataverse-python-advanced-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 284,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.219Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dataverse-python-advanced-patterns",
@@ -1548,7 +8025,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/dataverse-python-advanced-patterns",
       "relPath": "skills/dataverse-python-advanced-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 284,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.219Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dataverse-python-production-code",
@@ -1560,7 +8088,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/dataverse-sdk-for-python/skills/dataverse-python-production-code",
       "relPath": "plugins/dataverse-sdk-for-python/skills/dataverse-python-production-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1041,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.220Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dataverse-python-production-code",
@@ -1572,7 +8151,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/dataverse-python-production-code",
       "relPath": "skills/dataverse-python-production-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1041,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.220Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dataverse-python-quickstart",
@@ -1584,7 +8214,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/dataverse-sdk-for-python/skills/dataverse-python-quickstart",
       "relPath": "plugins/dataverse-sdk-for-python/skills/dataverse-python-quickstart",
-      "verified": true
+      "verified": true,
+      "tokenCount": 165,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.220Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dataverse-python-quickstart",
@@ -1596,7 +8277,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/dataverse-python-quickstart",
       "relPath": "skills/dataverse-python-quickstart",
-      "verified": true
+      "verified": true,
+      "tokenCount": 165,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.220Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dataverse-python-usecase-builder",
@@ -1608,7 +8340,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/dataverse-sdk-for-python/skills/dataverse-python-usecase-builder",
       "relPath": "plugins/dataverse-sdk-for-python/skills/dataverse-python-usecase-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1808,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.221Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dataverse-python-usecase-builder",
@@ -1620,7 +8403,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/dataverse-python-usecase-builder",
       "relPath": "skills/dataverse-python-usecase-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1808,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.222Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "debian-linux-triage",
@@ -1632,7 +8466,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/debian-linux-triage",
       "relPath": "skills/debian-linux-triage",
-      "verified": true
+      "verified": true,
+      "tokenCount": 223,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.222Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "declarative-agents",
@@ -1644,7 +8529,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/declarative-agents",
       "relPath": "skills/declarative-agents",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1019,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.222Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dependabot",
@@ -1656,7 +8592,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/dependabot",
       "relPath": "skills/dependabot",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3013,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.223Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "devops-rollout-plan",
@@ -1668,7 +8655,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/devops-rollout-plan",
       "relPath": "skills/devops-rollout-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 946,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.224Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "documentation-writer",
@@ -1680,7 +8718,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/documentation-writer",
       "relPath": "skills/documentation-writer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 741,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.224Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dotnet-best-practices",
@@ -1692,7 +8781,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/csharp-dotnet-development/skills/dotnet-best-practices",
       "relPath": "plugins/csharp-dotnet-development/skills/dotnet-best-practices",
-      "verified": true
+      "verified": true,
+      "tokenCount": 791,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.224Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dotnet-best-practices",
@@ -1704,7 +8844,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/dotnet-best-practices",
       "relPath": "skills/dotnet-best-practices",
-      "verified": true
+      "verified": true,
+      "tokenCount": 791,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.224Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dotnet-design-pattern-review",
@@ -1716,7 +8907,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/dotnet-design-pattern-review",
       "relPath": "skills/dotnet-design-pattern-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 685,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.225Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dotnet-timezone",
@@ -1728,7 +8970,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/dotnet-timezone",
       "relPath": "skills/dotnet-timezone",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1006,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.225Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dotnet-upgrade",
@@ -1740,7 +9033,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/csharp-dotnet-development/skills/dotnet-upgrade",
       "relPath": "plugins/csharp-dotnet-development/skills/dotnet-upgrade",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1862,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.226Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dotnet-upgrade",
@@ -1752,7 +9096,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/dotnet-upgrade",
       "relPath": "skills/dotnet-upgrade",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1862,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.226Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "doublecheck",
@@ -1764,7 +9159,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/doublecheck/skills/doublecheck",
       "relPath": "plugins/doublecheck/skills/doublecheck",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4666,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.228Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "doublecheck",
@@ -1776,7 +9222,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/doublecheck",
       "relPath": "skills/doublecheck",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4666,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.229Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "draw-io-diagram-generator",
@@ -1788,7 +9285,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/draw-io-diagram-generator",
       "relPath": "skills/draw-io-diagram-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4857,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.231Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "editorconfig",
@@ -1800,7 +9348,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/editorconfig",
       "relPath": "skills/editorconfig",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1157,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.231Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ef-core",
@@ -1812,7 +9411,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/ef-core",
       "relPath": "skills/ef-core",
-      "verified": true
+      "verified": true,
+      "tokenCount": 716,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.231Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "email-drafter",
@@ -1824,7 +9474,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/email-drafter",
       "relPath": "skills/email-drafter",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1345,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.232Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "entra-agent-user",
@@ -1836,7 +9537,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/entra-agent-user",
       "relPath": "skills/entra-agent-user",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2074,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.233Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "eval-driven-dev",
@@ -1848,7 +9600,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/eval-driven-dev",
       "relPath": "skills/eval-driven-dev",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3002,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.233Z",
+        "evaluatedVersion": "0.6.1"
+      }
     },
     {
       "name": "exam-ready",
@@ -1860,7 +9663,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/exam-ready",
       "relPath": "skills/exam-ready",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1298,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.234Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "excalidraw-diagram-generator",
@@ -1872,7 +9726,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/excalidraw-diagram-generator",
       "relPath": "skills/excalidraw-diagram-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6171,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.236Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "fabric-lakehouse",
@@ -1884,7 +9789,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/fabric-lakehouse",
       "relPath": "skills/fabric-lakehouse",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1776,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.236Z",
+        "evaluatedVersion": "1.0"
+      }
     },
     {
       "name": "fedora-linux-triage",
@@ -1896,7 +9852,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/fedora-linux-triage",
       "relPath": "skills/fedora-linux-triage",
-      "verified": true
+      "verified": true,
+      "tokenCount": 209,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.236Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "finalize-agent-prompt",
@@ -1908,7 +9915,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/finalize-agent-prompt",
       "relPath": "skills/finalize-agent-prompt",
-      "verified": true
+      "verified": true,
+      "tokenCount": 277,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.236Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "finnish-humanizer",
@@ -1920,7 +9978,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/finnish-humanizer",
       "relPath": "skills/finnish-humanizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1541,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.237Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "first-ask",
@@ -1932,7 +10041,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/first-ask",
       "relPath": "skills/first-ask",
-      "verified": true
+      "verified": true,
+      "tokenCount": 468,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.237Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowstudio-power-automate-build",
@@ -1944,7 +10104,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/flowstudio-power-automate/skills/flowstudio-power-automate-build",
       "relPath": "plugins/flowstudio-power-automate/skills/flowstudio-power-automate-build",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4744,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.238Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowstudio-power-automate-build",
@@ -1956,7 +10167,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-build",
       "relPath": "skills/flowstudio-power-automate-build",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4744,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.240Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowstudio-power-automate-debug",
@@ -1968,7 +10230,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/flowstudio-power-automate/skills/flowstudio-power-automate-debug",
       "relPath": "plugins/flowstudio-power-automate/skills/flowstudio-power-automate-debug",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4105,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.241Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowstudio-power-automate-debug",
@@ -1980,7 +10293,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-debug",
       "relPath": "skills/flowstudio-power-automate-debug",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4105,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.242Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowstudio-power-automate-governance",
@@ -1992,7 +10356,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/flowstudio-power-automate/skills/flowstudio-power-automate-governance",
       "relPath": "plugins/flowstudio-power-automate/skills/flowstudio-power-automate-governance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6175,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.244Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowstudio-power-automate-governance",
@@ -2004,7 +10419,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-governance",
       "relPath": "skills/flowstudio-power-automate-governance",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6175,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.245Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowstudio-power-automate-mcp",
@@ -2016,7 +10482,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/flowstudio-power-automate/skills/flowstudio-power-automate-mcp",
       "relPath": "plugins/flowstudio-power-automate/skills/flowstudio-power-automate-mcp",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4688,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.247Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowstudio-power-automate-mcp",
@@ -2028,7 +10545,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-mcp",
       "relPath": "skills/flowstudio-power-automate-mcp",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4688,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.249Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowstudio-power-automate-monitoring",
@@ -2040,7 +10608,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/flowstudio-power-automate/skills/flowstudio-power-automate-monitoring",
       "relPath": "plugins/flowstudio-power-automate/skills/flowstudio-power-automate-monitoring",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3253,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.250Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "flowstudio-power-automate-monitoring",
@@ -2052,7 +10671,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/flowstudio-power-automate-monitoring",
       "relPath": "skills/flowstudio-power-automate-monitoring",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3253,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.251Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "fluentui-blazor",
@@ -2064,7 +10734,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/fluentui-blazor",
       "relPath": "skills/fluentui-blazor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1805,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.251Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "folder-structure-blueprint-generator",
@@ -2076,7 +10797,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/folder-structure-blueprint-generator",
       "relPath": "skills/folder-structure-blueprint-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3549,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.252Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "foundry-agent-sync",
@@ -2088,7 +10860,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/foundry-agent-sync",
       "relPath": "skills/foundry-agent-sync",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2184,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.253Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "freecad-scripts",
@@ -2100,7 +10923,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/freecad-scripts",
       "relPath": "skills/freecad-scripts",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5433,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.255Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "from-the-other-side-vega",
@@ -2112,7 +10986,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/ember/skills/from-the-other-side-vega",
       "relPath": "plugins/ember/skills/from-the-other-side-vega",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1187,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.255Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "from-the-other-side-vega",
@@ -2124,7 +11049,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/from-the-other-side-vega",
       "relPath": "skills/from-the-other-side-vega",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1187,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.256Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "game-engine",
@@ -2136,7 +11112,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/game-engine",
       "relPath": "skills/game-engine",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1794,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.256Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gdpr-compliant",
@@ -2148,7 +11175,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gdpr-compliant",
       "relPath": "skills/gdpr-compliant",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3508,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.257Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gen-specs-as-issues",
@@ -2160,7 +11238,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gen-specs-as-issues",
       "relPath": "skills/gen-specs-as-issues",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1587,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.258Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "generate-custom-instructions-from-codebase",
@@ -2172,7 +11301,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/generate-custom-instructions-from-codebase",
       "relPath": "skills/generate-custom-instructions-from-codebase",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2051,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.258Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "geofeed-tuner",
@@ -2184,7 +11364,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/fastah-ip-geo-tools/skills/geofeed-tuner",
       "relPath": "plugins/fastah-ip-geo-tools/skills/geofeed-tuner",
-      "verified": true
+      "verified": true,
+      "tokenCount": 16665,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.261Z",
+        "evaluatedVersion": "0.0.9"
+      }
     },
     {
       "name": "geofeed-tuner",
@@ -2196,7 +11427,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/geofeed-tuner",
       "relPath": "skills/geofeed-tuner",
-      "verified": true
+      "verified": true,
+      "tokenCount": 16665,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.265Z",
+        "evaluatedVersion": "0.0.9"
+      }
     },
     {
       "name": "gh-cli",
@@ -2208,7 +11490,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gh-cli",
       "relPath": "skills/gh-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 12128,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.268Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "git-commit",
@@ -2220,7 +11553,58 @@
       "allowedTools": ["Bash"],
       "installUrl": "github:github/awesome-copilot:skills/git-commit",
       "relPath": "skills/git-commit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1020,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.268Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "git-flow-branch-creator",
@@ -2232,7 +11616,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/git-flow-branch-creator",
       "relPath": "skills/git-flow-branch-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1501,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.269Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "github-copilot-starter",
@@ -2244,7 +11679,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/github-copilot-starter",
       "relPath": "skills/github-copilot-starter",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3804,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.270Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "github-issues",
@@ -2256,7 +11742,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/github-issues",
       "relPath": "skills/github-issues",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2266,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.271Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "go-mcp-server-generator",
@@ -2268,7 +11805,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/go-mcp-development/skills/go-mcp-server-generator",
       "relPath": "plugins/go-mcp-development/skills/go-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1946,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.272Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "go-mcp-server-generator",
@@ -2280,7 +11868,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/go-mcp-server-generator",
       "relPath": "skills/go-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1946,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.272Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gsap-framer-scroll-animation",
@@ -2292,7 +11931,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gsap-framer-scroll-animation",
       "relPath": "skills/gsap-framer-scroll-animation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1759,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.273Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-0-to-1-launch",
@@ -2304,7 +11994,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-0-to-1-launch",
       "relPath": "skills/gtm-0-to-1-launch",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3703,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.274Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-ai-gtm",
@@ -2316,7 +12057,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-ai-gtm",
       "relPath": "skills/gtm-ai-gtm",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6059,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.276Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-board-and-investor-communication",
@@ -2328,7 +12120,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-board-and-investor-communication",
       "relPath": "skills/gtm-board-and-investor-communication",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5649,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.277Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-developer-ecosystem",
@@ -2340,7 +12183,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-developer-ecosystem",
       "relPath": "skills/gtm-developer-ecosystem",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2409,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.278Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-enterprise-account-planning",
@@ -2352,7 +12246,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-enterprise-account-planning",
       "relPath": "skills/gtm-enterprise-account-planning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4727,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.280Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-enterprise-onboarding",
@@ -2364,7 +12309,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-enterprise-onboarding",
       "relPath": "skills/gtm-enterprise-onboarding",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4029,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.281Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-operating-cadence",
@@ -2376,7 +12372,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-operating-cadence",
       "relPath": "skills/gtm-operating-cadence",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4639,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.282Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-partnership-architecture",
@@ -2388,7 +12435,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-partnership-architecture",
       "relPath": "skills/gtm-partnership-architecture",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4293,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.284Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-positioning-strategy",
@@ -2400,7 +12498,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-positioning-strategy",
       "relPath": "skills/gtm-positioning-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3792,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.285Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-product-led-growth",
@@ -2412,7 +12561,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-product-led-growth",
       "relPath": "skills/gtm-product-led-growth",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3598,
+      "evalSummary": {
+        "overallScore": 90,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.286Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "gtm-technical-product-pricing",
@@ -2424,7 +12624,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/gtm-technical-product-pricing",
       "relPath": "skills/gtm-technical-product-pricing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3722,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.287Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "image-manipulation-image-magick",
@@ -2436,7 +12687,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/image-manipulation-image-magick",
       "relPath": "skills/image-manipulation-image-magick",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1825,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.288Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "import-infrastructure-as-code",
@@ -2448,7 +12750,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/azure-cloud-development/skills/import-infrastructure-as-code",
       "relPath": "plugins/azure-cloud-development/skills/import-infrastructure-as-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4694,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.289Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "import-infrastructure-as-code",
@@ -2460,7 +12813,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/import-infrastructure-as-code",
       "relPath": "skills/import-infrastructure-as-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4694,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.291Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "integrate-context-matic",
@@ -2472,7 +12876,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/context-matic/skills/integrate-context-matic",
       "relPath": "plugins/context-matic/skills/integrate-context-matic",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1887,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.291Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "integrate-context-matic",
@@ -2484,7 +12939,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/integrate-context-matic",
       "relPath": "skills/integrate-context-matic",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1887,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.292Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "issue-fields-migration",
@@ -2496,7 +13002,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/issue-fields-migration",
       "relPath": "skills/issue-fields-migration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7245,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.294Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-add-graalvm-native-image-support",
@@ -2508,7 +13065,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/java-add-graalvm-native-image-support",
       "relPath": "skills/java-add-graalvm-native-image-support",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3138,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.295Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-docs",
@@ -2520,7 +13128,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/java-development/skills/java-docs",
       "relPath": "plugins/java-development/skills/java-docs",
-      "verified": true
+      "verified": true,
+      "tokenCount": 445,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.295Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-docs",
@@ -2532,7 +13191,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/java-docs",
       "relPath": "skills/java-docs",
-      "verified": true
+      "verified": true,
+      "tokenCount": 445,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.295Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-junit",
@@ -2544,7 +13254,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/testing-automation/skills/java-junit",
       "relPath": "plugins/testing-automation/skills/java-junit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 805,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.295Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-junit",
@@ -2556,7 +13317,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/java-development/skills/java-junit",
       "relPath": "plugins/java-development/skills/java-junit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 805,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.296Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-junit",
@@ -2568,7 +13380,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/java-junit",
       "relPath": "skills/java-junit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 805,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.296Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-mcp-server-generator",
@@ -2580,7 +13443,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/java-mcp-development/skills/java-mcp-server-generator",
       "relPath": "plugins/java-mcp-development/skills/java-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7284,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.298Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-mcp-server-generator",
@@ -2592,7 +13506,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/java-mcp-server-generator",
       "relPath": "skills/java-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7284,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.300Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-refactoring-extract-method",
@@ -2604,7 +13569,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/java-refactoring-extract-method",
       "relPath": "skills/java-refactoring-extract-method",
-      "verified": true
+      "verified": true,
+      "tokenCount": 947,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.301Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-refactoring-remove-parameter",
@@ -2616,7 +13632,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/java-refactoring-remove-parameter",
       "relPath": "skills/java-refactoring-remove-parameter",
-      "verified": true
+      "verified": true,
+      "tokenCount": 840,
+      "evalSummary": {
+        "overallScore": 47,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.301Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-springboot",
@@ -2628,7 +13695,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/java-development/skills/java-springboot",
       "relPath": "plugins/java-development/skills/java-springboot",
-      "verified": true
+      "verified": true,
+      "tokenCount": 987,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.301Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "java-springboot",
@@ -2640,7 +13758,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/java-springboot",
       "relPath": "skills/java-springboot",
-      "verified": true
+      "verified": true,
+      "tokenCount": 987,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.302Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "javascript-typescript-jest",
@@ -2652,7 +13821,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/javascript-typescript-jest",
       "relPath": "skills/javascript-typescript-jest",
-      "verified": true
+      "verified": true,
+      "tokenCount": 492,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.302Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-mcp-server-generator",
@@ -2664,7 +13884,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/kotlin-mcp-development/skills/kotlin-mcp-server-generator",
       "relPath": "plugins/kotlin-mcp-development/skills/kotlin-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2939,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.303Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-mcp-server-generator",
@@ -2676,7 +13947,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/kotlin-mcp-server-generator",
       "relPath": "skills/kotlin-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2939,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.304Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "kotlin-springboot",
@@ -2688,7 +14010,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/kotlin-springboot",
       "relPath": "skills/kotlin-springboot",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1100,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.304Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "legacy-circuit-mockups",
@@ -2700,7 +14073,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/legacy-circuit-mockups",
       "relPath": "skills/legacy-circuit-mockups",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2778,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.305Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "linkedin-post-formatter",
@@ -2712,7 +14136,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/linkedin-post-formatter",
       "relPath": "skills/linkedin-post-formatter",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1599,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.306Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "lsp-setup",
@@ -2724,7 +14199,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/lsp-setup",
       "relPath": "skills/lsp-setup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1158,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.306Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "make-repo-contribution",
@@ -2744,7 +14270,58 @@
       ],
       "installUrl": "github:github/awesome-copilot:skills/make-repo-contribution",
       "relPath": "skills/make-repo-contribution",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2029,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.307Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "make-skill-template",
@@ -2756,7 +14333,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/make-skill-template",
       "relPath": "skills/make-skill-template",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1601,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.307Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "markdown-to-html",
@@ -2768,7 +14396,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/markdown-to-html",
       "relPath": "skills/markdown-to-html",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6525,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.309Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-cli",
@@ -2780,7 +14459,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/mcp-cli",
       "relPath": "skills/mcp-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 848,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.309Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-copilot-studio-server-generator",
@@ -2792,7 +14522,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/power-platform-mcp-connector-development/skills/mcp-copilot-studio-server-generator",
       "relPath": "plugins/power-platform-mcp-connector-development/skills/mcp-copilot-studio-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1236,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.310Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-copilot-studio-server-generator",
@@ -2804,7 +14585,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/mcp-copilot-studio-server-generator",
       "relPath": "skills/mcp-copilot-studio-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1236,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.310Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-create-adaptive-cards",
@@ -2816,7 +14648,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/mcp-m365-copilot/skills/mcp-create-adaptive-cards",
       "relPath": "plugins/mcp-m365-copilot/skills/mcp-create-adaptive-cards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5000,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.311Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-create-adaptive-cards",
@@ -2828,7 +14711,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/mcp-create-adaptive-cards",
       "relPath": "skills/mcp-create-adaptive-cards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5000,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.312Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-create-declarative-agent",
@@ -2840,7 +14774,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/mcp-m365-copilot/skills/mcp-create-declarative-agent",
       "relPath": "plugins/mcp-m365-copilot/skills/mcp-create-declarative-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2078,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.313Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-create-declarative-agent",
@@ -2852,7 +14837,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/mcp-create-declarative-agent",
       "relPath": "skills/mcp-create-declarative-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2078,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.314Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-deploy-manage-agents",
@@ -2864,7 +14900,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/mcp-m365-copilot/skills/mcp-deploy-manage-agents",
       "relPath": "plugins/mcp-m365-copilot/skills/mcp-deploy-manage-agents",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2518,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.315Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-deploy-manage-agents",
@@ -2876,7 +14963,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/mcp-deploy-manage-agents",
       "relPath": "skills/mcp-deploy-manage-agents",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2518,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.316Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mcp-security-audit",
@@ -2888,7 +15026,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/mcp-security-audit",
       "relPath": "skills/mcp-security-audit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2630,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.317Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "meeting-minutes",
@@ -2900,7 +15089,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/meeting-minutes",
       "relPath": "skills/meeting-minutes",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2324,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.317Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "memory-merger",
@@ -2912,7 +15152,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/memory-merger",
       "relPath": "skills/memory-merger",
-      "verified": true
+      "verified": true,
+      "tokenCount": 961,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.318Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mentoring-juniors",
@@ -2924,7 +15215,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/mentoring-juniors",
       "relPath": "skills/mentoring-juniors",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4234,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.319Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "microsoft-agent-framework",
@@ -2936,7 +15278,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/microsoft-agent-framework",
       "relPath": "skills/microsoft-agent-framework",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1036,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.319Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "microsoft-code-reference",
@@ -2948,7 +15341,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/microsoft-code-reference",
       "relPath": "skills/microsoft-code-reference",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1000,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.320Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "microsoft-docs",
@@ -2960,7 +15404,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/microsoft-docs",
       "relPath": "skills/microsoft-docs",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1455,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.320Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "microsoft-skill-creator",
@@ -2972,7 +15467,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/microsoft-skill-creator",
       "relPath": "skills/microsoft-skill-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2149,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.321Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "migrating-oracle-to-postgres-stored-procedures",
@@ -2984,7 +15530,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/oracle-to-postgres-migration-expert/skills/migrating-oracle-to-postgres-stored-procedures",
       "relPath": "plugins/oracle-to-postgres-migration-expert/skills/migrating-oracle-to-postgres-stored-procedures",
-      "verified": true
+      "verified": true,
+      "tokenCount": 544,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.321Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "migrating-oracle-to-postgres-stored-procedures",
@@ -2996,7 +15593,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/migrating-oracle-to-postgres-stored-procedures",
       "relPath": "skills/migrating-oracle-to-postgres-stored-procedures",
-      "verified": true
+      "verified": true,
+      "tokenCount": 544,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.321Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mkdocs-translations",
@@ -3008,7 +15656,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/mkdocs-translations",
       "relPath": "skills/mkdocs-translations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1313,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.322Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "model-recommendation",
@@ -3020,7 +15719,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/model-recommendation",
       "relPath": "skills/model-recommendation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 7592,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.323Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "msstore-cli",
@@ -3032,7 +15782,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/msstore-cli",
       "relPath": "skills/msstore-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4227,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.325Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "multi-stage-dockerfile",
@@ -3044,7 +15845,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/devops-oncall/skills/multi-stage-dockerfile",
       "relPath": "plugins/devops-oncall/skills/multi-stage-dockerfile",
-      "verified": true
+      "verified": true,
+      "tokenCount": 647,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.325Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "multi-stage-dockerfile",
@@ -3056,7 +15908,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/multi-stage-dockerfile",
       "relPath": "skills/multi-stage-dockerfile",
-      "verified": true
+      "verified": true,
+      "tokenCount": 647,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.325Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "my-issues",
@@ -3068,7 +15971,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/my-issues",
       "relPath": "skills/my-issues",
-      "verified": true
+      "verified": true,
+      "tokenCount": 106,
+      "evalSummary": {
+        "overallScore": 31,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.325Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "my-pull-requests",
@@ -3080,7 +16034,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/my-pull-requests",
       "relPath": "skills/my-pull-requests",
-      "verified": true
+      "verified": true,
+      "tokenCount": 169,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.325Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nano-banana-pro-openrouter",
@@ -3092,7 +16097,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/nano-banana-pro-openrouter",
       "relPath": "skills/nano-banana-pro-openrouter",
-      "verified": true
+      "verified": true,
+      "tokenCount": 694,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.325Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "napkin",
@@ -3104,7 +16160,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/napkin/skills/napkin",
       "relPath": "plugins/napkin/skills/napkin",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2274,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.326Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "napkin",
@@ -3116,7 +16223,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/napkin",
       "relPath": "skills/napkin",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2274,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.327Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "next-intl-add-language",
@@ -3128,7 +16286,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/next-intl-add-language",
       "relPath": "skills/next-intl-add-language",
-      "verified": true
+      "verified": true,
+      "tokenCount": 211,
+      "evalSummary": {
+        "overallScore": 41,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.327Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "noob-mode",
@@ -3140,7 +16349,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/noob-mode/skills/noob-mode",
       "relPath": "plugins/noob-mode/skills/noob-mode",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3589,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.328Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "noob-mode",
@@ -3152,7 +16412,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/noob-mode",
       "relPath": "skills/noob-mode",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3589,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.329Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "nuget-manager",
@@ -3164,7 +16475,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/nuget-manager",
       "relPath": "skills/nuget-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 894,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.329Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "onboard-context-matic",
@@ -3176,7 +16538,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/context-matic/skills/onboard-context-matic",
       "relPath": "plugins/context-matic/skills/onboard-context-matic",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4288,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.330Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "onboard-context-matic",
@@ -3188,7 +16601,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/onboard-context-matic",
       "relPath": "skills/onboard-context-matic",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4288,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.332Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "oo-component-documentation",
@@ -3200,7 +16664,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/oo-component-documentation",
       "relPath": "skills/oo-component-documentation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1361,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.332Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "openapi-to-application-code",
@@ -3212,7 +16727,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/openapi-to-application-python-fastapi/skills/openapi-to-application-code",
       "relPath": "plugins/openapi-to-application-python-fastapi/skills/openapi-to-application-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1367,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.332Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "openapi-to-application-code",
@@ -3224,7 +16790,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/openapi-to-application-csharp-dotnet/skills/openapi-to-application-code",
       "relPath": "plugins/openapi-to-application-csharp-dotnet/skills/openapi-to-application-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1367,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.333Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "openapi-to-application-code",
@@ -3236,7 +16853,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/openapi-to-application-go/skills/openapi-to-application-code",
       "relPath": "plugins/openapi-to-application-go/skills/openapi-to-application-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1367,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.333Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "openapi-to-application-code",
@@ -3248,7 +16916,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/openapi-to-application-nodejs-nestjs/skills/openapi-to-application-code",
       "relPath": "plugins/openapi-to-application-nodejs-nestjs/skills/openapi-to-application-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1367,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.334Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "openapi-to-application-code",
@@ -3260,7 +16979,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/openapi-to-application-java-spring-boot/skills/openapi-to-application-code",
       "relPath": "plugins/openapi-to-application-java-spring-boot/skills/openapi-to-application-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1367,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.334Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "openapi-to-application-code",
@@ -3272,7 +17042,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/openapi-to-application-code",
       "relPath": "skills/openapi-to-application-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1367,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.334Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pdftk-server",
@@ -3284,7 +17105,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/pdftk-server",
       "relPath": "skills/pdftk-server",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1261,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.335Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "penpot-uiux-design",
@@ -3296,7 +17168,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/penpot-uiux-design",
       "relPath": "skills/penpot-uiux-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3516,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.336Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "phoenix-cli",
@@ -3308,7 +17231,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/phoenix/skills/phoenix-cli",
       "relPath": "plugins/phoenix/skills/phoenix-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1839,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.337Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "phoenix-cli",
@@ -3320,7 +17294,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/phoenix-cli",
       "relPath": "skills/phoenix-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1839,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.337Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "phoenix-evals",
@@ -3332,7 +17357,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/phoenix/skills/phoenix-evals",
       "relPath": "plugins/phoenix/skills/phoenix-evals",
-      "verified": true
+      "verified": true,
+      "tokenCount": 653,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.338Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "phoenix-evals",
@@ -3344,7 +17420,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/phoenix-evals",
       "relPath": "skills/phoenix-evals",
-      "verified": true
+      "verified": true,
+      "tokenCount": 653,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.338Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "phoenix-tracing",
@@ -3356,7 +17483,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/phoenix/skills/phoenix-tracing",
       "relPath": "plugins/phoenix/skills/phoenix-tracing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1452,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.338Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "phoenix-tracing",
@@ -3368,7 +17546,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/phoenix-tracing",
       "relPath": "skills/phoenix-tracing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1452,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.339Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "php-mcp-server-generator",
@@ -3380,7 +17609,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/php-mcp-development/skills/php-mcp-server-generator",
       "relPath": "plugins/php-mcp-development/skills/php-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3163,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.340Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "php-mcp-server-generator",
@@ -3392,7 +17672,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/php-mcp-server-generator",
       "relPath": "skills/php-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3163,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.341Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "planning-oracle-to-postgres-migration-integration-testing",
@@ -3404,7 +17735,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/oracle-to-postgres-migration-expert/skills/planning-oracle-to-postgres-migration-integration-testing",
       "relPath": "plugins/oracle-to-postgres-migration-expert/skills/planning-oracle-to-postgres-migration-integration-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 558,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.341Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "planning-oracle-to-postgres-migration-integration-testing",
@@ -3416,7 +17798,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/planning-oracle-to-postgres-migration-integration-testing",
       "relPath": "skills/planning-oracle-to-postgres-migration-integration-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 558,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.341Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "plantuml-ascii",
@@ -3428,7 +17861,58 @@
       "allowedTools": ["Bash", "Write", "Read"],
       "installUrl": "github:github/awesome-copilot:skills/plantuml-ascii",
       "relPath": "skills/plantuml-ascii",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1741,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.342Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "playwright-automation-fill-in-form",
@@ -3440,7 +17924,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/playwright-automation-fill-in-form",
       "relPath": "skills/playwright-automation-fill-in-form",
-      "verified": true
+      "verified": true,
+      "tokenCount": 177,
+      "evalSummary": {
+        "overallScore": 47,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.342Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "playwright-explore-website",
@@ -3452,7 +17987,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/frontend-web-dev/skills/playwright-explore-website",
       "relPath": "plugins/frontend-web-dev/skills/playwright-explore-website",
-      "verified": true
+      "verified": true,
+      "tokenCount": 195,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.342Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "playwright-explore-website",
@@ -3464,7 +18050,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/testing-automation/skills/playwright-explore-website",
       "relPath": "plugins/testing-automation/skills/playwright-explore-website",
-      "verified": true
+      "verified": true,
+      "tokenCount": 195,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.342Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "playwright-explore-website",
@@ -3476,7 +18113,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/playwright-explore-website",
       "relPath": "skills/playwright-explore-website",
-      "verified": true
+      "verified": true,
+      "tokenCount": 195,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.342Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "playwright-generate-test",
@@ -3488,7 +18176,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/frontend-web-dev/skills/playwright-generate-test",
       "relPath": "plugins/frontend-web-dev/skills/playwright-generate-test",
-      "verified": true
+      "verified": true,
+      "tokenCount": 279,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.342Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "playwright-generate-test",
@@ -3500,7 +18239,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/testing-automation/skills/playwright-generate-test",
       "relPath": "plugins/testing-automation/skills/playwright-generate-test",
-      "verified": true
+      "verified": true,
+      "tokenCount": 279,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.343Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "playwright-generate-test",
@@ -3512,7 +18302,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/playwright-generate-test",
       "relPath": "skills/playwright-generate-test",
-      "verified": true
+      "verified": true,
+      "tokenCount": 279,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.343Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "polyglot-test-agent",
@@ -3524,7 +18365,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/polyglot-test-agent/skills/polyglot-test-agent",
       "relPath": "plugins/polyglot-test-agent/skills/polyglot-test-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2043,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.343Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "polyglot-test-agent",
@@ -3536,7 +18428,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/polyglot-test-agent",
       "relPath": "skills/polyglot-test-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2043,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.344Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgresql-code-review",
@@ -3548,7 +18491,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/database-data-management/skills/postgresql-code-review",
       "relPath": "plugins/database-data-management/skills/postgresql-code-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1914,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.345Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgresql-code-review",
@@ -3560,7 +18554,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/postgresql-code-review",
       "relPath": "skills/postgresql-code-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1914,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.345Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgresql-optimization",
@@ -3572,7 +18617,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/database-data-management/skills/postgresql-optimization",
       "relPath": "plugins/database-data-management/skills/postgresql-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2969,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.346Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "postgresql-optimization",
@@ -3584,7 +18680,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/postgresql-optimization",
       "relPath": "skills/postgresql-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2969,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.347Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-apps-code-app-scaffold",
@@ -3596,7 +18743,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/power-apps-code-apps/skills/power-apps-code-app-scaffold",
       "relPath": "plugins/power-apps-code-apps/skills/power-apps-code-app-scaffold",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1886,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.348Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-apps-code-app-scaffold",
@@ -3608,7 +18806,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/power-apps-code-app-scaffold",
       "relPath": "skills/power-apps-code-app-scaffold",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1886,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.349Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-bi-dax-optimization",
@@ -3620,7 +18869,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/power-bi-development/skills/power-bi-dax-optimization",
       "relPath": "plugins/power-bi-development/skills/power-bi-dax-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1408,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.349Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-bi-dax-optimization",
@@ -3632,7 +18932,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/power-bi-dax-optimization",
       "relPath": "skills/power-bi-dax-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1408,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.350Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-bi-model-design-review",
@@ -3644,7 +18995,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/power-bi-development/skills/power-bi-model-design-review",
       "relPath": "plugins/power-bi-development/skills/power-bi-model-design-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2592,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.351Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-bi-model-design-review",
@@ -3656,7 +19058,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/power-bi-model-design-review",
       "relPath": "skills/power-bi-model-design-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2592,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.352Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-bi-performance-troubleshooting",
@@ -3668,7 +19121,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/power-bi-development/skills/power-bi-performance-troubleshooting",
       "relPath": "plugins/power-bi-development/skills/power-bi-performance-troubleshooting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2504,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.353Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-bi-performance-troubleshooting",
@@ -3680,7 +19184,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/power-bi-performance-troubleshooting",
       "relPath": "skills/power-bi-performance-troubleshooting",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2504,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.354Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-bi-report-design-consultation",
@@ -3692,7 +19247,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/power-bi-development/skills/power-bi-report-design-consultation",
       "relPath": "plugins/power-bi-development/skills/power-bi-report-design-consultation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2760,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.355Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-bi-report-design-consultation",
@@ -3704,7 +19310,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/power-bi-report-design-consultation",
       "relPath": "skills/power-bi-report-design-consultation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2760,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.356Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-platform-architect",
@@ -3716,7 +19373,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/power-platform-architect/skills/power-platform-architect",
       "relPath": "plugins/power-platform-architect/skills/power-platform-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4294,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.357Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-platform-architect",
@@ -3728,7 +19436,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/power-platform-architect",
       "relPath": "skills/power-platform-architect",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4294,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.359Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-platform-mcp-connector-suite",
@@ -3740,7 +19499,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/power-platform-mcp-connector-development/skills/power-platform-mcp-connector-suite",
       "relPath": "plugins/power-platform-mcp-connector-development/skills/power-platform-mcp-connector-suite",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1625,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.359Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "power-platform-mcp-connector-suite",
@@ -3752,7 +19562,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/power-platform-mcp-connector-suite",
       "relPath": "skills/power-platform-mcp-connector-suite",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1625,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.360Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "powerbi-modeling",
@@ -3764,7 +19625,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/powerbi-modeling",
       "relPath": "skills/powerbi-modeling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1419,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.360Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "prd",
@@ -3776,7 +19688,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/prd",
       "relPath": "skills/prd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1210,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.361Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "premium-frontend-ui",
@@ -3788,7 +19751,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/premium-frontend-ui",
       "relPath": "skills/premium-frontend-ui",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1847,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.361Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "project-workflow-analysis-blueprint-generator",
@@ -3800,7 +19814,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/project-workflow-analysis-blueprint-generator",
       "relPath": "skills/project-workflow-analysis-blueprint-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2843,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 4,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.362Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "prompt-builder",
@@ -3812,7 +19877,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/prompt-builder",
       "relPath": "skills/prompt-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1604,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.363Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "publish-to-pages",
@@ -3824,7 +19940,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/publish-to-pages",
       "relPath": "skills/publish-to-pages",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1216,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.363Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pytest-coverage",
@@ -3836,7 +20003,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/pytest-coverage",
       "relPath": "skills/pytest-coverage",
-      "verified": true
+      "verified": true,
+      "tokenCount": 327,
+      "evalSummary": {
+        "overallScore": 49,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.363Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-mcp-server-generator",
@@ -3848,7 +20066,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/python-mcp-development/skills/python-mcp-server-generator",
       "relPath": "plugins/python-mcp-development/skills/python-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1088,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.364Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-mcp-server-generator",
@@ -3860,7 +20129,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/python-mcp-server-generator",
       "relPath": "skills/python-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1088,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.364Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "python-pypi-package-builder",
@@ -3872,7 +20192,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/python-pypi-package-builder",
       "relPath": "skills/python-pypi-package-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5527,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.366Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qdrant-clients-sdk",
@@ -3884,7 +20255,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/qdrant-clients-sdk",
       "relPath": "skills/qdrant-clients-sdk",
-      "verified": true
+      "verified": true,
+      "tokenCount": 753,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.366Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qdrant-deployment-options",
@@ -3896,7 +20318,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/qdrant-deployment-options",
       "relPath": "skills/qdrant-deployment-options",
-      "verified": true
+      "verified": true,
+      "tokenCount": 716,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.366Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qdrant-model-migration",
@@ -3908,7 +20381,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/qdrant-model-migration",
       "relPath": "skills/qdrant-model-migration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1397,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.367Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qdrant-monitoring",
@@ -3920,7 +20444,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/qdrant-monitoring",
       "relPath": "skills/qdrant-monitoring",
-      "verified": true
+      "verified": true,
+      "tokenCount": 267,
+      "evalSummary": {
+        "overallScore": 43,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.367Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qdrant-performance-optimization",
@@ -3932,7 +20507,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/qdrant-performance-optimization",
       "relPath": "skills/qdrant-performance-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 507,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.367Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qdrant-scaling",
@@ -3944,7 +20570,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/qdrant-scaling",
       "relPath": "skills/qdrant-scaling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 535,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.368Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qdrant-search-quality",
@@ -3956,7 +20633,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/qdrant-search-quality",
       "relPath": "skills/qdrant-search-quality",
-      "verified": true
+      "verified": true,
+      "tokenCount": 343,
+      "evalSummary": {
+        "overallScore": 46,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.368Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qdrant-version-upgrade",
@@ -3968,7 +20696,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/qdrant-version-upgrade",
       "relPath": "skills/qdrant-version-upgrade",
-      "verified": true
+      "verified": true,
+      "tokenCount": 570,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.368Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "quality-playbook",
@@ -3980,7 +20759,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/quality-playbook",
       "relPath": "skills/quality-playbook",
-      "verified": true
+      "verified": true,
+      "tokenCount": 12879,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.371Z",
+        "evaluatedVersion": "1.2.0"
+      }
     },
     {
       "name": "quasi-coder",
@@ -3992,7 +20822,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/quasi-coder",
       "relPath": "skills/quasi-coder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3998,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.372Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react-audit-grep-patterns",
@@ -4004,7 +20885,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/react18-upgrade/skills/react-audit-grep-patterns",
       "relPath": "plugins/react18-upgrade/skills/react-audit-grep-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 478,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.373Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react-audit-grep-patterns",
@@ -4016,7 +20948,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/react-audit-grep-patterns",
       "relPath": "skills/react-audit-grep-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 478,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.373Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-batching-patterns",
@@ -4028,7 +21011,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/react18-upgrade/skills/react18-batching-patterns",
       "relPath": "plugins/react18-upgrade/skills/react18-batching-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 722,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.373Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-batching-patterns",
@@ -4040,7 +21074,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/react18-batching-patterns",
       "relPath": "skills/react18-batching-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 722,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.373Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-dep-compatibility",
@@ -4052,7 +21137,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/react18-upgrade/skills/react18-dep-compatibility",
       "relPath": "plugins/react18-upgrade/skills/react18-dep-compatibility",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1434,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.374Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-dep-compatibility",
@@ -4064,7 +21200,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/react18-dep-compatibility",
       "relPath": "skills/react18-dep-compatibility",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1434,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.374Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-enzyme-to-rtl",
@@ -4076,7 +21263,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/react18-upgrade/skills/react18-enzyme-to-rtl",
       "relPath": "plugins/react18-upgrade/skills/react18-enzyme-to-rtl",
-      "verified": true
+      "verified": true,
+      "tokenCount": 894,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.375Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-enzyme-to-rtl",
@@ -4088,7 +21326,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/react18-enzyme-to-rtl",
       "relPath": "skills/react18-enzyme-to-rtl",
-      "verified": true
+      "verified": true,
+      "tokenCount": 894,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.375Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-legacy-context",
@@ -4100,7 +21389,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/react18-upgrade/skills/react18-legacy-context",
       "relPath": "plugins/react18-upgrade/skills/react18-legacy-context",
-      "verified": true
+      "verified": true,
+      "tokenCount": 660,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.375Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-legacy-context",
@@ -4112,7 +21452,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/react18-legacy-context",
       "relPath": "skills/react18-legacy-context",
-      "verified": true
+      "verified": true,
+      "tokenCount": 660,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.375Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-lifecycle-patterns",
@@ -4124,7 +21515,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/react18-upgrade/skills/react18-lifecycle-patterns",
       "relPath": "plugins/react18-upgrade/skills/react18-lifecycle-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 871,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.376Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-lifecycle-patterns",
@@ -4136,7 +21578,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/react18-lifecycle-patterns",
       "relPath": "skills/react18-lifecycle-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 871,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.376Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-string-refs",
@@ -4148,7 +21641,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/react18-upgrade/skills/react18-string-refs",
       "relPath": "plugins/react18-upgrade/skills/react18-string-refs",
-      "verified": true
+      "verified": true,
+      "tokenCount": 534,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.376Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react18-string-refs",
@@ -4160,7 +21704,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/react18-string-refs",
       "relPath": "skills/react18-string-refs",
-      "verified": true
+      "verified": true,
+      "tokenCount": 534,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.377Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react19-concurrent-patterns",
@@ -4172,7 +21767,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/react19-upgrade/skills/react19-concurrent-patterns",
       "relPath": "plugins/react19-upgrade/skills/react19-concurrent-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 729,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.377Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react19-concurrent-patterns",
@@ -4184,7 +21830,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/react19-concurrent-patterns",
       "relPath": "skills/react19-concurrent-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 729,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.377Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react19-source-patterns",
@@ -4196,7 +21893,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/react19-upgrade/skills/react19-source-patterns",
       "relPath": "plugins/react19-upgrade/skills/react19-source-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 494,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.377Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react19-source-patterns",
@@ -4208,7 +21956,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/react19-source-patterns",
       "relPath": "skills/react19-source-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 494,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.378Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react19-test-patterns",
@@ -4220,7 +22019,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/react19-upgrade/skills/react19-test-patterns",
       "relPath": "plugins/react19-upgrade/skills/react19-test-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 783,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.378Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "react19-test-patterns",
@@ -4232,7 +22082,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/react19-test-patterns",
       "relPath": "skills/react19-test-patterns",
-      "verified": true
+      "verified": true,
+      "tokenCount": 783,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.378Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "readme-blueprint-generator",
@@ -4244,7 +22145,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/readme-blueprint-generator",
       "relPath": "skills/readme-blueprint-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 751,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.378Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "refactor",
@@ -4256,7 +22208,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/refactor",
       "relPath": "skills/refactor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5787,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.380Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "refactor-method-complexity-reduce",
@@ -4268,7 +22271,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/refactor-method-complexity-reduce",
       "relPath": "skills/refactor-method-complexity-reduce",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1317,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.380Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "refactor-plan",
@@ -4280,7 +22334,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/context-engineering/skills/refactor-plan",
       "relPath": "plugins/context-engineering/skills/refactor-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 420,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.380Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "refactor-plan",
@@ -4292,7 +22397,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/refactor-plan",
       "relPath": "skills/refactor-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 420,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.381Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "remember",
@@ -4304,7 +22460,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/remember",
       "relPath": "skills/remember",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1694,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.381Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "remember-interactive-programming",
@@ -4316,7 +22523,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/clojure-interactive-programming/skills/remember-interactive-programming",
       "relPath": "plugins/clojure-interactive-programming/skills/remember-interactive-programming",
-      "verified": true
+      "verified": true,
+      "tokenCount": 289,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.381Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "remember-interactive-programming",
@@ -4328,7 +22586,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/remember-interactive-programming",
       "relPath": "skills/remember-interactive-programming",
-      "verified": true
+      "verified": true,
+      "tokenCount": 289,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.382Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "repo-story-time",
@@ -4340,7 +22649,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/repo-story-time",
       "relPath": "skills/repo-story-time",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1757,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.382Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "review-and-refactor",
@@ -4352,7 +22712,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/review-and-refactor",
       "relPath": "skills/review-and-refactor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 216,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.382Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "reviewing-oracle-to-postgres-migration",
@@ -4364,7 +22775,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/oracle-to-postgres-migration-expert/skills/reviewing-oracle-to-postgres-migration",
       "relPath": "plugins/oracle-to-postgres-migration-expert/skills/reviewing-oracle-to-postgres-migration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 776,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.383Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "reviewing-oracle-to-postgres-migration",
@@ -4376,7 +22838,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/reviewing-oracle-to-postgres-migration",
       "relPath": "skills/reviewing-oracle-to-postgres-migration",
-      "verified": true
+      "verified": true,
+      "tokenCount": 776,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.383Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "roundup",
@@ -4388,7 +22901,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/roundup/skills/roundup",
       "relPath": "plugins/roundup/skills/roundup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3250,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.384Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "roundup",
@@ -4400,7 +22964,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/roundup",
       "relPath": "skills/roundup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3250,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.385Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "roundup-setup",
@@ -4412,7 +23027,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/roundup/skills/roundup-setup",
       "relPath": "plugins/roundup/skills/roundup-setup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4587,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.387Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "roundup-setup",
@@ -4424,7 +23090,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/roundup-setup",
       "relPath": "skills/roundup-setup",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4587,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.388Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ruby-mcp-server-generator",
@@ -4436,7 +23153,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/ruby-mcp-development/skills/ruby-mcp-server-generator",
       "relPath": "plugins/ruby-mcp-development/skills/ruby-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5162,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.389Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ruby-mcp-server-generator",
@@ -4448,7 +23216,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/ruby-mcp-server-generator",
       "relPath": "skills/ruby-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5162,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.391Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ruff-recursive-fix",
@@ -4460,7 +23279,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/ruff-recursive-fix",
       "relPath": "skills/ruff-recursive-fix",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1705,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.391Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rust-mcp-server-generator",
@@ -4472,7 +23342,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/rust-mcp-development/skills/rust-mcp-server-generator",
       "relPath": "plugins/rust-mcp-development/skills/rust-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3940,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.393Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "rust-mcp-server-generator",
@@ -4484,7 +23405,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/rust-mcp-server-generator",
       "relPath": "skills/rust-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3940,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.394Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "salesforce-apex-quality",
@@ -4496,7 +23468,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/salesforce-development/skills/salesforce-apex-quality",
       "relPath": "plugins/salesforce-development/skills/salesforce-apex-quality",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2171,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.395Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "salesforce-apex-quality",
@@ -4508,7 +23531,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/salesforce-apex-quality",
       "relPath": "skills/salesforce-apex-quality",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2171,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.395Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "salesforce-component-standards",
@@ -4520,7 +23594,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/salesforce-development/skills/salesforce-component-standards",
       "relPath": "plugins/salesforce-development/skills/salesforce-component-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2803,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.396Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "salesforce-component-standards",
@@ -4532,7 +23657,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/salesforce-component-standards",
       "relPath": "skills/salesforce-component-standards",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2803,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.397Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "salesforce-flow-design",
@@ -4544,7 +23720,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/salesforce-development/skills/salesforce-flow-design",
       "relPath": "plugins/salesforce-development/skills/salesforce-flow-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2244,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.397Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "salesforce-flow-design",
@@ -4556,7 +23783,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/salesforce-flow-design",
       "relPath": "skills/salesforce-flow-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2244,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.398Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sandbox-npm-install",
@@ -4568,7 +23846,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/sandbox-npm-install",
       "relPath": "skills/sandbox-npm-install",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1128,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.398Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scaffolding-oracle-to-postgres-migration-test-project",
@@ -4580,7 +23909,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/oracle-to-postgres-migration-expert/skills/scaffolding-oracle-to-postgres-migration-test-project",
       "relPath": "plugins/oracle-to-postgres-migration-expert/skills/scaffolding-oracle-to-postgres-migration-test-project",
-      "verified": true
+      "verified": true,
+      "tokenCount": 744,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.399Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scaffolding-oracle-to-postgres-migration-test-project",
@@ -4592,7 +23972,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/scaffolding-oracle-to-postgres-migration-test-project",
       "relPath": "skills/scaffolding-oracle-to-postgres-migration-test-project",
-      "verified": true
+      "verified": true,
+      "tokenCount": 744,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.399Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scoutqa-test",
@@ -4604,7 +24035,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/scoutqa-test",
       "relPath": "skills/scoutqa-test",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3891,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.400Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "secret-scanning",
@@ -4616,7 +24098,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/secret-scanning",
       "relPath": "skills/secret-scanning",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2575,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.401Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "security-review",
@@ -4628,7 +24161,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/security-review",
       "relPath": "skills/security-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2466,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.402Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "semantic-kernel",
@@ -4640,7 +24224,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/semantic-kernel",
       "relPath": "skills/semantic-kernel",
-      "verified": true
+      "verified": true,
+      "tokenCount": 777,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.402Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "shuffle-json-data",
@@ -4652,7 +24287,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/shuffle-json-data",
       "relPath": "skills/shuffle-json-data",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1248,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.402Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "snowflake-semanticview",
@@ -4664,7 +24350,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/snowflake-semanticview",
       "relPath": "skills/snowflake-semanticview",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1186,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.403Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sponsor-finder",
@@ -4676,7 +24413,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/ospo-sponsorship/skills/sponsor-finder",
       "relPath": "plugins/ospo-sponsorship/skills/sponsor-finder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3285,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.404Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sponsor-finder",
@@ -4688,7 +24476,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/sponsor-finder",
       "relPath": "skills/sponsor-finder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3285,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.405Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "spring-boot-testing",
@@ -4700,7 +24539,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/spring-boot-testing",
       "relPath": "skills/spring-boot-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1401,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.405Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sql-code-review",
@@ -4712,7 +24602,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/database-data-management/skills/sql-code-review",
       "relPath": "plugins/database-data-management/skills/sql-code-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2455,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.406Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sql-code-review",
@@ -4724,7 +24665,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/sql-code-review",
       "relPath": "skills/sql-code-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2455,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.407Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sql-optimization",
@@ -4736,7 +24728,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/database-data-management/skills/sql-optimization",
       "relPath": "plugins/database-data-management/skills/sql-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2447,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.408Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sql-optimization",
@@ -4748,7 +24791,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/sql-optimization",
       "relPath": "skills/sql-optimization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2447,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.409Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "structured-autonomy-generate",
@@ -4760,7 +24854,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/structured-autonomy/skills/structured-autonomy-generate",
       "relPath": "plugins/structured-autonomy/skills/structured-autonomy-generate",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1180,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.409Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "structured-autonomy-generate",
@@ -4772,7 +24917,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/structured-autonomy-generate",
       "relPath": "skills/structured-autonomy-generate",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1180,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.410Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "structured-autonomy-implement",
@@ -4784,7 +24980,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/structured-autonomy/skills/structured-autonomy-implement",
       "relPath": "plugins/structured-autonomy/skills/structured-autonomy-implement",
-      "verified": true
+      "verified": true,
+      "tokenCount": 335,
+      "evalSummary": {
+        "overallScore": 47,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.410Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "structured-autonomy-implement",
@@ -4796,7 +25043,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/structured-autonomy-implement",
       "relPath": "skills/structured-autonomy-implement",
-      "verified": true
+      "verified": true,
+      "tokenCount": 335,
+      "evalSummary": {
+        "overallScore": 47,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.410Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "structured-autonomy-plan",
@@ -4808,7 +25106,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/structured-autonomy/skills/structured-autonomy-plan",
       "relPath": "plugins/structured-autonomy/skills/structured-autonomy-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 767,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.410Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "structured-autonomy-plan",
@@ -4820,7 +25169,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/structured-autonomy-plan",
       "relPath": "skills/structured-autonomy-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 767,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.410Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "suggest-awesome-github-copilot-agents",
@@ -4832,7 +25232,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/awesome-copilot/skills/suggest-awesome-github-copilot-agents",
       "relPath": "plugins/awesome-copilot/skills/suggest-awesome-github-copilot-agents",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2291,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.411Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "suggest-awesome-github-copilot-agents",
@@ -4844,7 +25295,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/suggest-awesome-github-copilot-agents",
       "relPath": "skills/suggest-awesome-github-copilot-agents",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2291,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.412Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "suggest-awesome-github-copilot-instructions",
@@ -4856,7 +25358,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/awesome-copilot/skills/suggest-awesome-github-copilot-instructions",
       "relPath": "plugins/awesome-copilot/skills/suggest-awesome-github-copilot-instructions",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1733,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.412Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "suggest-awesome-github-copilot-instructions",
@@ -4868,7 +25421,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/suggest-awesome-github-copilot-instructions",
       "relPath": "skills/suggest-awesome-github-copilot-instructions",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1733,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 6,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.413Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "suggest-awesome-github-copilot-skills",
@@ -4880,7 +25484,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/awesome-copilot/skills/suggest-awesome-github-copilot-skills",
       "relPath": "plugins/awesome-copilot/skills/suggest-awesome-github-copilot-skills",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2001,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.414Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "suggest-awesome-github-copilot-skills",
@@ -4892,7 +25547,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/suggest-awesome-github-copilot-skills",
       "relPath": "skills/suggest-awesome-github-copilot-skills",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2001,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.414Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "swift-mcp-server-generator",
@@ -4904,7 +25610,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/swift-mcp-development/skills/swift-mcp-server-generator",
       "relPath": "plugins/swift-mcp-development/skills/swift-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6295,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.416Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "swift-mcp-server-generator",
@@ -4916,7 +25673,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/swift-mcp-server-generator",
       "relPath": "skills/swift-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6295,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.418Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "technology-stack-blueprint-generator",
@@ -4928,7 +25736,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/technology-stack-blueprint-generator",
       "relPath": "skills/technology-stack-blueprint-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2364,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.418Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "terraform-azurerm-set-diff-analyzer",
@@ -4940,7 +25799,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/terraform-azurerm-set-diff-analyzer",
       "relPath": "skills/terraform-azurerm-set-diff-analyzer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 539,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.419Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "threat-model-analyst",
@@ -4952,7 +25862,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/threat-model-analyst",
       "relPath": "skills/threat-model-analyst",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1446,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.419Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tldr-prompt",
@@ -4964,7 +25925,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/tldr-prompt",
       "relPath": "skills/tldr-prompt",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3093,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.420Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "transloadit-media-processing",
@@ -4976,7 +25988,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/transloadit-media-processing",
       "relPath": "skills/transloadit-media-processing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1476,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.421Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "typescript-mcp-server-generator",
@@ -4988,7 +26051,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/typescript-mcp-development/skills/typescript-mcp-server-generator",
       "relPath": "plugins/typescript-mcp-development/skills/typescript-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 935,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.421Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "typescript-mcp-server-generator",
@@ -5000,7 +26114,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/typescript-mcp-server-generator",
       "relPath": "skills/typescript-mcp-server-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 935,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.421Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "typespec-api-operations",
@@ -5012,7 +26177,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/typespec-m365-copilot/skills/typespec-api-operations",
       "relPath": "plugins/typespec-m365-copilot/skills/typespec-api-operations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2564,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.422Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "typespec-api-operations",
@@ -5024,7 +26240,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/typespec-api-operations",
       "relPath": "skills/typespec-api-operations",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2564,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.423Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "typespec-create-agent",
@@ -5036,7 +26303,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/typespec-m365-copilot/skills/typespec-create-agent",
       "relPath": "plugins/typespec-m365-copilot/skills/typespec-create-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 778,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.423Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "typespec-create-agent",
@@ -5048,7 +26366,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/typespec-create-agent",
       "relPath": "skills/typespec-create-agent",
-      "verified": true
+      "verified": true,
+      "tokenCount": 778,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.424Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "typespec-create-api-plugin",
@@ -5060,7 +26429,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/typespec-m365-copilot/skills/typespec-create-api-plugin",
       "relPath": "plugins/typespec-m365-copilot/skills/typespec-create-api-plugin",
-      "verified": true
+      "verified": true,
+      "tokenCount": 931,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.424Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "typespec-create-api-plugin",
@@ -5072,7 +26492,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/typespec-create-api-plugin",
       "relPath": "skills/typespec-create-api-plugin",
-      "verified": true
+      "verified": true,
+      "tokenCount": 931,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.424Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "unit-test-vue-pinia",
@@ -5084,7 +26555,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/unit-test-vue-pinia",
       "relPath": "skills/unit-test-vue-pinia",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1784,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.425Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "update-avm-modules-in-bicep",
@@ -5096,7 +26618,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/update-avm-modules-in-bicep",
       "relPath": "skills/update-avm-modules-in-bicep",
-      "verified": true
+      "verified": true,
+      "tokenCount": 580,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.425Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "update-implementation-plan",
@@ -5108,7 +26681,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/project-planning/skills/update-implementation-plan",
       "relPath": "plugins/project-planning/skills/update-implementation-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1708,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.426Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "update-implementation-plan",
@@ -5120,7 +26744,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/update-implementation-plan",
       "relPath": "skills/update-implementation-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1708,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.426Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "update-llms",
@@ -5132,7 +26807,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/update-llms",
       "relPath": "skills/update-llms",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2166,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.427Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "update-markdown-file-index",
@@ -5144,7 +26870,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/update-markdown-file-index",
       "relPath": "skills/update-markdown-file-index",
-      "verified": true
+      "verified": true,
+      "tokenCount": 679,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.428Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "update-specification",
@@ -5156,7 +26933,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/update-specification",
       "relPath": "skills/update-specification",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1403,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.428Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "vscode-ext-commands",
@@ -5168,7 +26996,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/vscode-ext-commands",
       "relPath": "skills/vscode-ext-commands",
-      "verified": true
+      "verified": true,
+      "tokenCount": 461,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.428Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "vscode-ext-localization",
@@ -5180,7 +27059,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/vscode-ext-localization",
       "relPath": "skills/vscode-ext-localization",
-      "verified": true
+      "verified": true,
+      "tokenCount": 376,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.428Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "web-coder",
@@ -5192,7 +27122,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/web-coder",
       "relPath": "skills/web-coder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5171,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.430Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "web-design-reviewer",
@@ -5204,7 +27185,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/web-design-reviewer",
       "relPath": "skills/web-design-reviewer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3047,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.431Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "webapp-testing",
@@ -5216,7 +27248,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/webapp-testing",
       "relPath": "skills/webapp-testing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 978,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.431Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "what-context-needed",
@@ -5228,7 +27311,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/context-engineering/skills/what-context-needed",
       "relPath": "plugins/context-engineering/skills/what-context-needed",
-      "verified": true
+      "verified": true,
+      "tokenCount": 258,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.431Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "what-context-needed",
@@ -5240,7 +27374,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/what-context-needed",
       "relPath": "skills/what-context-needed",
-      "verified": true
+      "verified": true,
+      "tokenCount": 258,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.431Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "winapp-cli",
@@ -5252,7 +27437,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/winapp-cli",
       "relPath": "skills/winapp-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2318,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.432Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "winmd-api-search",
@@ -5264,7 +27500,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/winmd-api-search",
       "relPath": "skills/winmd-api-search",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2219,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.433Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "winui3-migration-guide",
@@ -5276,7 +27563,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:plugins/winui3-development/skills/winui3-migration-guide",
       "relPath": "plugins/winui3-development/skills/winui3-migration-guide",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2059,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.434Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "winui3-migration-guide",
@@ -5288,7 +27626,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/winui3-migration-guide",
       "relPath": "skills/winui3-migration-guide",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2059,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.434Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "workiq-copilot",
@@ -5300,7 +27689,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/workiq-copilot",
       "relPath": "skills/workiq-copilot",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1809,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.435Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "write-coding-standards-from-file",
@@ -5312,7 +27752,58 @@
       "allowedTools": [],
       "installUrl": "github:github/awesome-copilot:skills/write-coding-standards-from-file",
       "relPath": "skills/write-coding-standards-from-file",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4316,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:54.436Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/heygen-com_hyperframes.json
+++ b/data/skill-index/heygen-com_hyperframes.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/heygen-com/hyperframes.git",
   "owner": "heygen-com",
   "repo": "hyperframes",
-  "updatedAt": "2026-04-20T06:25:42.873Z",
+  "updatedAt": "2026-04-20T07:45:58.376Z",
   "skillCount": 5,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:heygen-com/hyperframes:skills/gsap",
       "relPath": "skills/gsap",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1710,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:58.147Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "hyperframes",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:heygen-com/hyperframes:skills/hyperframes",
       "relPath": "skills/hyperframes",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5797,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:58.149Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "hyperframes-cli",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-cli",
       "relPath": "skills/hyperframes-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1811,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:58.150Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "hyperframes-registry",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-registry",
       "relPath": "skills/hyperframes-registry",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1025,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:58.150Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "website-to-hyperframes",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:heygen-com/hyperframes:skills/website-to-hyperframes",
       "relPath": "skills/website-to-hyperframes",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2461,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:58.151Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/himself65_finance-skills.json
+++ b/data/skill-index/himself65_finance-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/himself65/finance-skills.git",
   "owner": "himself65",
   "repo": "finance-skills",
-  "updatedAt": "2026-04-20T06:33:23.558Z",
+  "updatedAt": "2026-04-20T07:44:18.402Z",
   "skillCount": 21,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/discord-reader",
       "relPath": "plugins/social-readers/skills/discord-reader",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2163,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.368Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "earnings-preview",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-preview",
       "relPath": "plugins/market-analysis/skills/earnings-preview",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1858,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.369Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "earnings-recap",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/earnings-recap",
       "relPath": "plugins/market-analysis/skills/earnings-recap",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2129,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.370Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "estimate-analysis",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/estimate-analysis",
       "relPath": "plugins/market-analysis/skills/estimate-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2948,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.371Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "etf-premium",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/etf-premium",
       "relPath": "plugins/market-analysis/skills/etf-premium",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6352,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.373Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "finance-sentiment",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/finance-sentiment",
       "relPath": "plugins/data-providers/skills/finance-sentiment",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1390,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.373Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "funda-data",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/funda-data",
       "relPath": "plugins/data-providers/skills/funda-data",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2844,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.375Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "generative-ui",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/ui-tools/skills/generative-ui",
       "relPath": "plugins/ui-tools/skills/generative-ui",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3254,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.376Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "hormuz-strait",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/data-providers/skills/hormuz-strait",
       "relPath": "plugins/data-providers/skills/hormuz-strait",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1681,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.376Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "linkedin-reader",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/linkedin-reader",
       "relPath": "plugins/social-readers/skills/linkedin-reader",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1949,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.377Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "options-payoff",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/options-payoff",
       "relPath": "plugins/market-analysis/skills/options-payoff",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2160,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.378Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "saas-valuation-compression",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/saas-valuation-compression",
       "relPath": "plugins/market-analysis/skills/saas-valuation-compression",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3133,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.379Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "sepa-strategy",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/sepa-strategy",
       "relPath": "plugins/market-analysis/skills/sepa-strategy",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3962,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.380Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "skill-creator",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/skill-creator/skills/skill-creator",
       "relPath": "plugins/skill-creator/skills/skill-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3981,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.381Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "startup-analysis",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/startup-tools/skills/startup-analysis",
       "relPath": "plugins/startup-tools/skills/startup-analysis",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2641,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.382Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "stock-correlation",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/stock-correlation",
       "relPath": "plugins/market-analysis/skills/stock-correlation",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3771,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.383Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "stock-liquidity",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/stock-liquidity",
       "relPath": "plugins/market-analysis/skills/stock-liquidity",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5943,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.385Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "telegram-reader",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/telegram-reader",
       "relPath": "plugins/social-readers/skills/telegram-reader",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2485,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.386Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "twitter-reader",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/twitter-reader",
       "relPath": "plugins/social-readers/skills/twitter-reader",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2009,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.387Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "yc-reader",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/social-readers/skills/yc-reader",
       "relPath": "plugins/social-readers/skills/yc-reader",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2008,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.388Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "yfinance-data",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:himself65/finance-skills:plugins/market-analysis/skills/yfinance-data",
       "relPath": "plugins/market-analysis/skills/yfinance-data",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1398,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:18.388Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/kemiljk_fluid-design.json
+++ b/data/skill-index/kemiljk_fluid-design.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/kemiljk/fluid-design.git",
   "owner": "kemiljk",
   "repo": "fluid-design",
-  "updatedAt": "2026-04-20T06:33:15.790Z",
+  "updatedAt": "2026-04-20T07:44:45.883Z",
   "skillCount": 1,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:kemiljk/fluid-design:skills/fluid-design",
       "relPath": "skills/fluid-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6596,
+      "evalSummary": {
+        "overallScore": 51,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.879Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/kepano_obsidian-skills.json
+++ b/data/skill-index/kepano_obsidian-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/kepano/obsidian-skills.git",
   "owner": "kepano",
   "repo": "obsidian-skills",
-  "updatedAt": "2026-04-20T06:33:18.931Z",
+  "updatedAt": "2026-04-20T07:46:00.964Z",
   "skillCount": 5,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:kepano/obsidian-skills:skills/defuddle",
       "relPath": "skills/defuddle",
-      "verified": true
+      "verified": true,
+      "tokenCount": 339,
+      "evalSummary": {
+        "overallScore": 54,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:00.955Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "json-canvas",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:kepano/obsidian-skills:skills/json-canvas",
       "relPath": "skills/json-canvas",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2344,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:00.956Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-bases",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:kepano/obsidian-skills:skills/obsidian-bases",
       "relPath": "skills/obsidian-bases",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3986,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:00.957Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-cli",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:kepano/obsidian-skills:skills/obsidian-cli",
       "relPath": "skills/obsidian-cli",
-      "verified": true
+      "verified": true,
+      "tokenCount": 848,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:00.958Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-markdown",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:kepano/obsidian-skills:skills/obsidian-markdown",
       "relPath": "skills/obsidian-markdown",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1472,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:46:00.959Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/luongnv89_skills.json
+++ b/data/skill-index/luongnv89_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/luongnv89/skills.git",
   "owner": "luongnv89",
   "repo": "skills",
-  "updatedAt": "2026-04-20T06:33:12.504Z",
+  "updatedAt": "2026-04-20T07:44:43.988Z",
   "skillCount": 36,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/agent-config",
       "relPath": "skills/agent-config",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3157,
+      "evalSummary": {
+        "overallScore": 89,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.929Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "appstore-review-checker",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/appstore-review-checker",
       "relPath": "skills/appstore-review-checker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4956,
+      "evalSummary": {
+        "overallScore": 91,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.930Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "aso-marketing",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/aso-marketing",
       "relPath": "skills/aso-marketing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 9263,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.933Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "auto-push",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/auto-push",
       "relPath": "skills/auto-push",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1936,
+      "evalSummary": {
+        "overallScore": 89,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.934Z",
+        "evaluatedVersion": "1.0.1"
+      }
     },
     {
       "name": "cli-builder",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/cli-builder",
       "relPath": "skills/cli-builder",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3049,
+      "evalSummary": {
+        "overallScore": 97,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.934Z",
+        "evaluatedVersion": "1.0.2"
+      }
     },
     {
       "name": "code-optimizer",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/code-optimizer",
       "relPath": "skills/code-optimizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1691,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.935Z",
+        "evaluatedVersion": "1.2.1"
+      }
     },
     {
       "name": "code-review",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/code-review",
       "relPath": "skills/code-review",
-      "verified": false
+      "verified": false,
+      "tokenCount": 3844,
+      "evalSummary": {
+        "overallScore": 91,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.936Z",
+        "evaluatedVersion": "1.1.2"
+      }
     },
     {
       "name": "context-hub",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/context-hub",
       "relPath": "skills/context-hub",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1660,
+      "evalSummary": {
+        "overallScore": 91,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.937Z",
+        "evaluatedVersion": "1.0.1"
+      }
     },
     {
       "name": "devops-pipeline",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/devops-pipeline",
       "relPath": "skills/devops-pipeline",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3175,
+      "evalSummary": {
+        "overallScore": 89,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.938Z",
+        "evaluatedVersion": "2.0.0"
+      }
     },
     {
       "name": "docs-generator",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/docs-generator",
       "relPath": "skills/docs-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1684,
+      "evalSummary": {
+        "overallScore": 93,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.938Z",
+        "evaluatedVersion": "1.2.1"
+      }
     },
     {
       "name": "dont-make-me-think",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/dont-make-me-think",
       "relPath": "skills/dont-make-me-think",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3112,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.939Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "drawio-generator",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/drawio-generator",
       "relPath": "skills/drawio-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4077,
+      "evalSummary": {
+        "overallScore": 91,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.940Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "excalidraw-generator",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/excalidraw-generator",
       "relPath": "skills/excalidraw-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5956,
+      "evalSummary": {
+        "overallScore": 91,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.942Z",
+        "evaluatedVersion": "1.2.0"
+      }
     },
     {
       "name": "frontend-design",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/frontend-design",
       "relPath": "skills/frontend-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3295,
+      "evalSummary": {
+        "overallScore": 90,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.943Z",
+        "evaluatedVersion": "1.2.1"
+      }
     },
     {
       "name": "github-issue-creator",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/github-issue-creator",
       "relPath": "skills/github-issue-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4284,
+      "evalSummary": {
+        "overallScore": 96,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.944Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "idea-validator",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/idea-validator",
       "relPath": "skills/idea-validator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3921,
+      "evalSummary": {
+        "overallScore": 94,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.945Z",
+        "evaluatedVersion": "1.3.0"
+      }
     },
     {
       "name": "install-script-generator",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/install-script-generator",
       "relPath": "skills/install-script-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4301,
+      "evalSummary": {
+        "overallScore": 91,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.946Z",
+        "evaluatedVersion": "2.0.1"
+      }
     },
     {
       "name": "logo-designer",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/logo-designer",
       "relPath": "skills/logo-designer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6379,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.948Z",
+        "evaluatedVersion": "1.2.0"
+      }
     },
     {
       "name": "name-checker",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/name-checker",
       "relPath": "skills/name-checker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3683,
+      "evalSummary": {
+        "overallScore": 91,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.949Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "note-taker",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/note-taker",
       "relPath": "skills/note-taker",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2641,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.950Z",
+        "evaluatedVersion": "1.4.2"
+      }
     },
     {
       "name": "ollama-optimizer",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/ollama-optimizer",
       "relPath": "skills/ollama-optimizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2300,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.951Z",
+        "evaluatedVersion": "1.0.2"
+      }
     },
     {
       "name": "opencode-runner",
@@ -267,7 +1338,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/opencode-runner",
       "relPath": "skills/opencode-runner",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5409,
+      "evalSummary": {
+        "overallScore": 91,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.952Z",
+        "evaluatedVersion": "1.2.1"
+      }
     },
     {
       "name": "openspec-task-loop",
@@ -279,7 +1401,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/openspec-task-loop",
       "relPath": "skills/openspec-task-loop",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2646,
+      "evalSummary": {
+        "overallScore": 93,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.953Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "oss-ready",
@@ -291,7 +1464,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/oss-ready",
       "relPath": "skills/oss-ready",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1821,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.953Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "prd-generator",
@@ -303,7 +1527,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/prd-generator",
       "relPath": "skills/prd-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2136,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.954Z",
+        "evaluatedVersion": "1.2.3"
+      }
     },
     {
       "name": "readme-to-landing-page",
@@ -315,7 +1590,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/readme-to-landing-page",
       "relPath": "skills/readme-to-landing-page",
-      "verified": true
+      "verified": true,
+      "tokenCount": 5201,
+      "evalSummary": {
+        "overallScore": 89,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.955Z",
+        "evaluatedVersion": "2.0.1"
+      }
     },
     {
       "name": "release-manager",
@@ -327,7 +1653,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/release-manager",
       "relPath": "skills/release-manager",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4720,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.957Z",
+        "evaluatedVersion": "2.4.0"
+      }
     },
     {
       "name": "seo-ai-optimizer",
@@ -339,7 +1716,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/seo-ai-optimizer",
       "relPath": "skills/seo-ai-optimizer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4393,
+      "evalSummary": {
+        "overallScore": 94,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.958Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "skill-creator",
@@ -351,7 +1779,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/skill-creator",
       "relPath": "skills/skill-creator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 13818,
+      "evalSummary": {
+        "overallScore": 90,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.961Z",
+        "evaluatedVersion": "1.2.2"
+      }
     },
     {
       "name": "skill-inventory-auditor",
@@ -363,7 +1842,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/skill-inventory-auditor",
       "relPath": "skills/skill-inventory-auditor",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1953,
+      "evalSummary": {
+        "overallScore": 94,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.962Z",
+        "evaluatedVersion": "1.0.1"
+      }
     },
     {
       "name": "slop-code",
@@ -375,7 +1905,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/slop-code",
       "relPath": "skills/slop-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 4460,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.963Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "system-design",
@@ -387,7 +1968,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/system-design",
       "relPath": "skills/system-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2514,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.963Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "tasks-generator",
@@ -399,7 +2031,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/tasks-generator",
       "relPath": "skills/tasks-generator",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2235,
+      "evalSummary": {
+        "overallScore": 89,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.964Z",
+        "evaluatedVersion": "1.1.1"
+      }
     },
     {
       "name": "test-coverage",
@@ -411,7 +2094,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/test-coverage",
       "relPath": "skills/test-coverage",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1922,
+      "evalSummary": {
+        "overallScore": 89,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.965Z",
+        "evaluatedVersion": "1.2.1"
+      }
     },
     {
       "name": "theme-transformer",
@@ -423,7 +2157,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/theme-transformer",
       "relPath": "skills/theme-transformer",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2164,
+      "evalSummary": {
+        "overallScore": 99,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.965Z",
+        "evaluatedVersion": "1.0.1"
+      }
     },
     {
       "name": "vscode-extension-publisher",
@@ -435,7 +2220,58 @@
       "allowedTools": [],
       "installUrl": "github:luongnv89/skills:skills/vscode-extension-publisher",
       "relPath": "skills/vscode-extension-publisher",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2629,
+      "evalSummary": {
+        "overallScore": 89,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:43.966Z",
+        "evaluatedVersion": "1.0.1"
+      }
     }
   ]
 }

--- a/data/skill-index/mattpocock_skills.json
+++ b/data/skill-index/mattpocock_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/mattpocock/skills.git",
   "owner": "mattpocock",
   "repo": "skills",
-  "updatedAt": "2026-04-20T06:33:18.182Z",
+  "updatedAt": "2026-04-20T07:45:05.099Z",
   "skillCount": 21,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:caveman",
       "relPath": "caveman",
-      "verified": true
+      "verified": true,
+      "tokenCount": 526,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.083Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "design-an-interface",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:design-an-interface",
       "relPath": "design-an-interface",
-      "verified": true
+      "verified": true,
+      "tokenCount": 925,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.083Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "domain-model",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:domain-model",
       "relPath": "domain-model",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1020,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.084Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "edit-article",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:edit-article",
       "relPath": "edit-article",
-      "verified": true
+      "verified": true,
+      "tokenCount": 215,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.084Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "git-guardrails-claude-code",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:git-guardrails-claude-code",
       "relPath": "git-guardrails-claude-code",
-      "verified": true
+      "verified": true,
+      "tokenCount": 719,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.084Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "github-triage",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:github-triage",
       "relPath": "github-triage",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3337,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.086Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "grill-me",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:grill-me",
       "relPath": "grill-me",
-      "verified": true
+      "verified": true,
+      "tokenCount": 189,
+      "evalSummary": {
+        "overallScore": 40,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.086Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "improve-codebase-architecture",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:improve-codebase-architecture",
       "relPath": "improve-codebase-architecture",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1204,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.086Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "migrate-to-shoehorn",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:migrate-to-shoehorn",
       "relPath": "migrate-to-shoehorn",
-      "verified": true
+      "verified": true,
+      "tokenCount": 888,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.087Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "obsidian-vault",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:obsidian-vault",
       "relPath": "obsidian-vault",
-      "verified": true
+      "verified": true,
+      "tokenCount": 415,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.087Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "qa",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:qa",
       "relPath": "qa",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1529,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.088Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "request-refactor-plan",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:request-refactor-plan",
       "relPath": "request-refactor-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 842,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.088Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "scaffold-exercises",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:scaffold-exercises",
       "relPath": "scaffold-exercises",
-      "verified": true
+      "verified": true,
+      "tokenCount": 810,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.088Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "setup-pre-commit",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:setup-pre-commit",
       "relPath": "setup-pre-commit",
-      "verified": true
+      "verified": true,
+      "tokenCount": 619,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.089Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "tdd",
@@ -183,7 +897,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:tdd",
       "relPath": "tdd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1235,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.089Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "to-issues",
@@ -195,7 +960,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:to-issues",
       "relPath": "to-issues",
-      "verified": true
+      "verified": true,
+      "tokenCount": 834,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.090Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "to-prd",
@@ -207,7 +1023,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:to-prd",
       "relPath": "to-prd",
-      "verified": true
+      "verified": true,
+      "tokenCount": 773,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.090Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "triage-issue",
@@ -219,7 +1086,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:triage-issue",
       "relPath": "triage-issue",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1181,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.091Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "ubiquitous-language",
@@ -231,7 +1149,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:ubiquitous-language",
       "relPath": "ubiquitous-language",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1474,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.091Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "write-a-skill",
@@ -243,7 +1212,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:write-a-skill",
       "relPath": "write-a-skill",
-      "verified": true
+      "verified": true,
+      "tokenCount": 909,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.092Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "zoom-out",
@@ -255,7 +1275,58 @@
       "allowedTools": [],
       "installUrl": "github:mattpocock/skills:zoom-out",
       "relPath": "zoom-out",
-      "verified": true
+      "verified": true,
+      "tokenCount": 126,
+      "evalSummary": {
+        "overallScore": 34,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 7,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:05.092Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/nextlevelbuilder_ui-ux-pro-max-skill.json
+++ b/data/skill-index/nextlevelbuilder_ui-ux-pro-max-skill.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill.git",
   "owner": "nextlevelbuilder",
   "repo": "ui-ux-pro-max-skill",
-  "updatedAt": "2026-04-20T06:32:54.585Z",
+  "updatedAt": "2026-04-20T07:45:15.186Z",
   "skillCount": 7,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/banner-design",
       "relPath": ".claude/skills/banner-design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2225,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:15.156Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ckm:brand",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/brand",
       "relPath": ".claude/skills/brand",
-      "verified": true
+      "verified": true,
+      "tokenCount": 614,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:15.156Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ckm:design",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design",
       "relPath": ".claude/skills/design",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2772,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:15.157Z",
+        "evaluatedVersion": "2.1.0"
+      }
     },
     {
       "name": "ckm:design-system",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/design-system",
       "relPath": ".claude/skills/design-system",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1648,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:15.158Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ckm:slides",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/slides",
       "relPath": ".claude/skills/slides",
-      "verified": true
+      "verified": true,
+      "tokenCount": 247,
+      "evalSummary": {
+        "overallScore": 47,
+        "grade": "F",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:15.158Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ckm:ui-styling",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-styling",
       "relPath": ".claude/skills/ui-styling",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2372,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:15.159Z",
+        "evaluatedVersion": "1.0.0"
+      }
     },
     {
       "name": "ui-ux-pro-max",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:nextlevelbuilder/ui-ux-pro-max-skill:.claude/skills/ui-ux-pro-max",
       "relPath": ".claude/skills/ui-ux-pro-max",
-      "verified": true
+      "verified": true,
+      "tokenCount": 12401,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:45:15.162Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/obra_superpowers.json
+++ b/data/skill-index/obra_superpowers.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/obra/superpowers.git",
   "owner": "obra",
   "repo": "superpowers",
-  "updatedAt": "2026-04-20T06:32:42.596Z",
+  "updatedAt": "2026-04-20T07:44:45.119Z",
   "skillCount": 14,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/brainstorming",
       "relPath": "skills/brainstorming",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3085,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.097Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "dispatching-parallel-agents",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/dispatching-parallel-agents",
       "relPath": "skills/dispatching-parallel-agents",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1770,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.098Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "executing-plans",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/executing-plans",
       "relPath": "skills/executing-plans",
-      "verified": true
+      "verified": true,
+      "tokenCount": 670,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.098Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "finishing-a-development-branch",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/finishing-a-development-branch",
       "relPath": "skills/finishing-a-development-branch",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1221,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.098Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "receiving-code-review",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/receiving-code-review",
       "relPath": "skills/receiving-code-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1748,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.099Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "requesting-code-review",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/requesting-code-review",
       "relPath": "skills/requesting-code-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 747,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.099Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "subagent-driven-development",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/subagent-driven-development",
       "relPath": "skills/subagent-driven-development",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3110,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.100Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "systematic-debugging",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/systematic-debugging",
       "relPath": "skills/systematic-debugging",
-      "verified": true
+      "verified": true,
+      "tokenCount": 3090,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.101Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "test-driven-development",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/test-driven-development",
       "relPath": "skills/test-driven-development",
-      "verified": true
+      "verified": true,
+      "tokenCount": 2883,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.102Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "using-git-worktrees",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/using-git-worktrees",
       "relPath": "skills/using-git-worktrees",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1446,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.103Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "using-superpowers",
@@ -135,7 +645,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/using-superpowers",
       "relPath": "skills/using-superpowers",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1583,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.103Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "verification-before-completion",
@@ -147,7 +708,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/verification-before-completion",
       "relPath": "skills/verification-before-completion",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1236,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.104Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "writing-plans",
@@ -159,7 +771,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/writing-plans",
       "relPath": "skills/writing-plans",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1741,
+      "evalSummary": {
+        "overallScore": 87,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.104Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "writing-skills",
@@ -171,7 +834,58 @@
       "allowedTools": [],
       "installUrl": "github:obra/superpowers:skills/writing-skills",
       "relPath": "skills/writing-skills",
-      "verified": true
+      "verified": true,
+      "tokenCount": 6070,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:45.106Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/data/skill-index/slavingia_skills.json
+++ b/data/skill-index/slavingia_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/slavingia/skills.git",
   "owner": "slavingia",
   "repo": "skills",
-  "updatedAt": "2026-04-20T06:33:15.046Z",
+  "updatedAt": "2026-04-20T07:44:12.386Z",
   "skillCount": 10,
   "skills": [
     {
@@ -15,7 +15,58 @@
       "allowedTools": [],
       "installUrl": "github:slavingia/skills:skills/company-values",
       "relPath": "skills/company-values",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1347,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:12.374Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "find-community",
@@ -27,7 +78,58 @@
       "allowedTools": [],
       "installUrl": "github:slavingia/skills:skills/find-community",
       "relPath": "skills/find-community",
-      "verified": true
+      "verified": true,
+      "tokenCount": 896,
+      "evalSummary": {
+        "overallScore": 50,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:12.375Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "first-customers",
@@ -39,7 +141,58 @@
       "allowedTools": [],
       "installUrl": "github:slavingia/skills:skills/first-customers",
       "relPath": "skills/first-customers",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1380,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:12.376Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "grow-sustainably",
@@ -51,7 +204,58 @@
       "allowedTools": [],
       "installUrl": "github:slavingia/skills:skills/grow-sustainably",
       "relPath": "skills/grow-sustainably",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1427,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:12.377Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "marketing-plan",
@@ -63,7 +267,58 @@
       "allowedTools": [],
       "installUrl": "github:slavingia/skills:skills/marketing-plan",
       "relPath": "skills/marketing-plan",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1437,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:12.378Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "minimalist-review",
@@ -75,7 +330,58 @@
       "allowedTools": [],
       "installUrl": "github:slavingia/skills:skills/minimalist-review",
       "relPath": "skills/minimalist-review",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1130,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:12.378Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "mvp",
@@ -87,7 +393,58 @@
       "allowedTools": [],
       "installUrl": "github:slavingia/skills:skills/mvp",
       "relPath": "skills/mvp",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1251,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:12.379Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "pricing",
@@ -99,7 +456,58 @@
       "allowedTools": [],
       "installUrl": "github:slavingia/skills:skills/pricing",
       "relPath": "skills/pricing",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1003,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:12.380Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "processize",
@@ -111,7 +519,58 @@
       "allowedTools": [],
       "installUrl": "github:slavingia/skills:skills/processize",
       "relPath": "skills/processize",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1529,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:12.380Z",
+        "evaluatedVersion": "0.0.0"
+      }
     },
     {
       "name": "validate-idea",
@@ -123,7 +582,58 @@
       "allowedTools": [],
       "installUrl": "github:slavingia/skills:skills/validate-idea",
       "relPath": "skills/validate-idea",
-      "verified": true
+      "verified": true,
+      "tokenCount": 1015,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-20T07:44:12.381Z",
+        "evaluatedVersion": "0.0.0"
+      }
     }
   ]
 }

--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -231,6 +231,14 @@ function categorizeSkill(name: string, description: string): string[] {
 
 // ─── Interfaces ──────────────────────────────────────────────────────────────
 
+interface SkillEvalSummary {
+  overallScore: number;
+  grade: "A" | "B" | "C" | "D" | "F";
+  categories: Array<{ id: string; name: string; score: number; max: number }>;
+  evaluatedAt: string;
+  evaluatedVersion?: string;
+}
+
 interface IndexedSkill {
   name: string;
   description: string;
@@ -242,6 +250,8 @@ interface IndexedSkill {
   installUrl: string;
   relPath: string;
   verified?: boolean;
+  tokenCount?: number;
+  evalSummary?: SkillEvalSummary;
 }
 
 interface RepoIndex {
@@ -268,6 +278,15 @@ interface CatalogSkill {
   repo: string;
   categories: string[];
   verified: boolean;
+  /**
+   * Estimated token count for SKILL.md content (`words + spaces`).
+   * Surfaced in the website card and modal so users can gauge context cost.
+   */
+  tokenCount?: number;
+  /**
+   * Slim eval summary captured at index time. Surfaced in the modal.
+   */
+  evalSummary?: SkillEvalSummary;
 }
 
 interface CatalogRepo {
@@ -368,6 +387,9 @@ for (const file of files) {
       repo: repoIndex.repo,
       categories,
       verified: skill.verified === true,
+      tokenCount:
+        typeof skill.tokenCount === "number" ? skill.tokenCount : undefined,
+      evalSummary: skill.evalSummary,
     });
   }
 }

--- a/scripts/enrich-index.ts
+++ b/scripts/enrich-index.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env bun
+/**
+ * Enrich existing `data/skill-index/*.json` files with `tokenCount` and
+ * `evalSummary` fields for every indexed skill.
+ *
+ * This is a one-shot migration helper for issue #188 (token count) and
+ * #187 (eval scores). It clones each repo (same codepath as preindex),
+ * reads each SKILL.md, computes the heuristic token count and runs the
+ * evaluator, and writes the enriched index back in place.
+ *
+ * Use it once after landing the initial pipeline changes so the website,
+ * TUI, and CLI inspect start showing values immediately without a full
+ * re-ingest. `preindex` already produces the same fields end-to-end for
+ * new runs.
+ *
+ * Usage:
+ *   bun run scripts/enrich-index.ts
+ *   bun run scripts/enrich-index.ts --only anthropics/skills
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from "fs";
+import { resolve, join } from "path";
+import { readFile } from "fs/promises";
+import { cloneToTemp, cleanupTemp, parseSource } from "../src/installer";
+import { estimateTokenCount } from "../src/utils/token-count";
+import { evaluateSkillContent } from "../src/evaluator";
+import type { RepoIndex, SkillEvalSummary } from "../src/utils/types";
+
+const root = resolve(import.meta.dir, "..");
+const indexDir = resolve(root, "data", "skill-index");
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let only: string | null = null;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--only" && args[i + 1]) {
+      only = args[i + 1];
+      i++;
+    }
+  }
+  return { only };
+}
+
+async function enrichSkill(
+  tempDir: string,
+  relPath: string,
+  version: string,
+): Promise<{ tokenCount: number; evalSummary?: SkillEvalSummary } | null> {
+  const skillMdPath = join(tempDir, relPath, "SKILL.md");
+  let content: string;
+  try {
+    content = await readFile(skillMdPath, "utf-8");
+  } catch {
+    return null;
+  }
+  const tokenCount = estimateTokenCount(content);
+
+  let evalSummary: SkillEvalSummary | undefined;
+  try {
+    const report = evaluateSkillContent({
+      content,
+      skillPath: relPath || "skill",
+      skillMdPath,
+    });
+    evalSummary = {
+      overallScore: report.overallScore,
+      grade: report.grade,
+      categories: report.categories.map((c) => ({
+        id: c.id,
+        name: c.name,
+        score: c.score,
+        max: c.max,
+      })),
+      evaluatedAt: report.evaluatedAt,
+      evaluatedVersion: version || undefined,
+    };
+  } catch {
+    // Eval is best-effort
+  }
+
+  return { tokenCount, evalSummary };
+}
+
+async function enrichFile(filePath: string): Promise<{
+  file: string;
+  enriched: number;
+  skipped: number;
+}> {
+  const fileName = filePath.split("/").pop()!;
+  const raw = readFileSync(filePath, "utf-8");
+  const data: RepoIndex = JSON.parse(raw);
+  if (!data.skills || data.skills.length === 0) {
+    return { file: fileName, enriched: 0, skipped: 0 };
+  }
+
+  let source;
+  try {
+    source = parseSource(`github:${data.owner}/${data.repo}`);
+  } catch (e) {
+    console.error(`  skip: could not parse source — ${e}`);
+    return { file: fileName, enriched: 0, skipped: data.skills.length };
+  }
+
+  let tempDir: string | null = null;
+  let enriched = 0;
+  let skipped = 0;
+  try {
+    tempDir = await cloneToTemp(source);
+    for (const skill of data.skills) {
+      const result = await enrichSkill(tempDir, skill.relPath, skill.version);
+      if (!result) {
+        skipped++;
+        continue;
+      }
+      skill.tokenCount = result.tokenCount;
+      if (result.evalSummary) {
+        skill.evalSummary = result.evalSummary;
+      }
+      enriched++;
+    }
+  } catch (e) {
+    console.error(`  skip: clone failed — ${(e as Error).message}`);
+    skipped = data.skills.length;
+  } finally {
+    if (tempDir) await cleanupTemp(tempDir);
+  }
+
+  data.updatedAt = new Date().toISOString();
+  writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+  return { file: fileName, enriched, skipped };
+}
+
+async function main() {
+  const { only } = parseArgs();
+
+  const files = readdirSync(indexDir)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => join(indexDir, f));
+
+  let onlyKey: string | null = null;
+  if (only) {
+    // Match either "owner/repo" or "owner_repo"
+    onlyKey = only.replace("/", "_");
+  }
+
+  console.log(
+    `Enriching ${files.length} index file(s) in ${indexDir}${only ? ` (filter: ${only})` : ""}\n`,
+  );
+
+  let total = 0;
+  let totalEnriched = 0;
+  let totalSkipped = 0;
+
+  for (const file of files) {
+    const base = file
+      .split("/")
+      .pop()!
+      .replace(/\.json$/, "");
+    if (onlyKey && base !== onlyKey) continue;
+    total++;
+    process.stdout.write(`  ${base} ... `);
+    const result = await enrichFile(file);
+    totalEnriched += result.enriched;
+    totalSkipped += result.skipped;
+    console.log(`${result.enriched} enriched, ${result.skipped} skipped`);
+  }
+
+  console.log(
+    `\nDone: ${totalEnriched} skills enriched, ${totalSkipped} skipped across ${total} repo(s).`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -1067,3 +1067,76 @@ describe("formatAvailableSearchResults", () => {
     expect(output).toContain("asm install github:owner/repo:skill-beta");
   });
 });
+
+// ─── Token count + eval display (issues #188 + #187) ────────────────────────
+
+describe("formatSkillDetail token count + eval", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("renders Est. Tokens line when tokenCount is set", async () => {
+    const output = await formatSkillDetail(makeSkill({ tokenCount: 1234 }));
+    expect(output).toContain("Est. Tokens:");
+    expect(output).toContain("~1.2k tokens");
+  });
+
+  test("omits Est. Tokens line when tokenCount is undefined", async () => {
+    const output = await formatSkillDetail(makeSkill());
+    expect(output).not.toContain("Est. Tokens:");
+  });
+
+  test("renders empty-state for Eval Score when summary is missing", async () => {
+    const output = await formatSkillDetail(makeSkill());
+    expect(output).toContain("Eval Score:");
+    expect(output).toContain("Not available");
+    expect(output).toContain("asm eval");
+  });
+
+  test("renders Eval Score block with overall + grade + categories", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({
+        evalSummary: {
+          overallScore: 87,
+          grade: "B",
+          categories: [
+            { id: "structure", name: "Structure", score: 9, max: 10 },
+            { id: "safety", name: "Safety", score: 7, max: 10 },
+          ],
+          evaluatedAt: "2026-04-20T10:00:00.000Z",
+          evaluatedVersion: "0.3.0",
+        },
+      }),
+    );
+    expect(output).toContain("Eval Score:");
+    expect(output).toContain("Overall: 87 / 100");
+    expect(output).toContain("(B)");
+    expect(output).toContain("version 0.3.0");
+    expect(output).toContain("Structure");
+    expect(output).toContain("9/10");
+    expect(output).toContain("Safety");
+    expect(output).toContain("7/10");
+  });
+});
+
+describe("formatGroupedTable token column", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("renders token count when at least one skill has it", () => {
+    const skills = [
+      makeSkill({ name: "tiny", tokenCount: 42 }),
+      makeSkill({ name: "no-tokens", dirName: "no-tokens" }),
+    ];
+    const output = formatGroupedTable(skills);
+    // "~42 tokens" should appear somewhere for the tiny skill row
+    expect(output).toContain("~42 tokens");
+  });
+});

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,5 +1,6 @@
 import type { SkillInfo } from "./utils/types";
 import { countFiles } from "./scanner";
+import { formatTokenCount } from "./utils/token-count";
 
 // ─── Color helpers ──────────────────────────────────────────────────────────
 
@@ -150,6 +151,7 @@ interface GroupedSkill {
   version: string;
   creator: string;
   effort: string;
+  tokens: string;
   providers: Array<{ provider: string; label: string }>;
   scope: "global" | "project" | "mixed";
   type: "symlink" | "directory" | "mixed";
@@ -180,6 +182,10 @@ function groupSkills(skills: SkillInfo[]): GroupedSkill[] {
       version: ref.version,
       creator: ref.creator || "",
       effort: ref.effort || "",
+      tokens:
+        typeof ref.tokenCount === "number"
+          ? formatTokenCount(ref.tokenCount)
+          : "",
       providers: members.map((m) => ({
         provider: m.provider,
         label: m.providerLabel,
@@ -216,6 +222,12 @@ export function formatGroupedTable(skills: SkillInfo[]): string {
     6,
     ...grouped.map((g) => (g.effort || "\u2014").length),
   );
+  // Tokens column — render `~N tokens` directly (e.g. "~1.2k tokens").
+  // Width follows the longest cell; header label fallback `Tokens` is 6.
+  const hasAnyTokens = grouped.some((g) => g.tokens.length > 0);
+  const tokensW = hasAnyTokens
+    ? Math.max(6, ...grouped.map((g) => (g.tokens || "\u2014").length))
+    : 0;
   const scopeW = 7; // "project" is longest
   const typeW = 9; // "directory" is longest
 
@@ -231,10 +243,12 @@ export function formatGroupedTable(skills: SkillInfo[]): string {
   const pad = (s: string, w: number) => s.padEnd(w);
 
   // Header
-  const header = `${pad("Name", nameW)}  ${pad("Version", versionW)}  ${pad("Creator", creatorW)}  ${pad("Effort", effortW)}  ${pad("Tools", providerW)}  ${pad("Scope", scopeW)}  ${pad("Type", typeW)}`;
+  const tokensHeader = hasAnyTokens ? `  ${pad("Tokens", tokensW)}` : "";
+  const header = `${pad("Name", nameW)}  ${pad("Version", versionW)}  ${pad("Creator", creatorW)}  ${pad("Effort", effortW)}${tokensHeader}  ${pad("Tools", providerW)}  ${pad("Scope", scopeW)}  ${pad("Type", typeW)}`;
   lines.push(useColor() ? ansi.bold(header) : header);
+  const tokensSep = hasAnyTokens ? `  ${"-".repeat(tokensW)}` : "";
   lines.push(
-    `${"-".repeat(nameW)}  ${"-".repeat(versionW)}  ${"-".repeat(creatorW)}  ${"-".repeat(effortW)}  ${"-".repeat(providerW)}  ${"-".repeat(scopeW)}  ${"-".repeat(typeW)}`,
+    `${"-".repeat(nameW)}  ${"-".repeat(versionW)}  ${"-".repeat(creatorW)}  ${"-".repeat(effortW)}${tokensSep}  ${"-".repeat(providerW)}  ${"-".repeat(scopeW)}  ${"-".repeat(typeW)}`,
   );
 
   // Data rows
@@ -248,6 +262,9 @@ export function formatGroupedTable(skills: SkillInfo[]): string {
     const effortColored = g.effort ? colorEffort(g.effort) : "\u2014";
     const effortPad = effortW - effortPlain.length;
     const effort = effortColored + " ".repeat(Math.max(0, effortPad));
+    const tokensCell = hasAnyTokens
+      ? `  ${pad(g.tokens || "\u2014", tokensW)}`
+      : "";
     // Provider badges have ANSI codes, so we pad based on plain text width
     const provPadding = providerW - providerPlain[i].length;
     const prov = providerStrs[i] + " ".repeat(Math.max(0, provPadding));
@@ -259,7 +276,7 @@ export function formatGroupedTable(skills: SkillInfo[]): string {
         : "";
 
     lines.push(
-      `${name}  ${version}  ${creator}  ${effort}  ${prov}  ${scope}  ${type}${warn}`,
+      `${name}  ${version}  ${creator}  ${effort}${tokensCell}  ${prov}  ${scope}  ${type}${warn}`,
     );
   }
 
@@ -476,6 +493,9 @@ export async function formatSkillDetail(skill: SkillInfo): Promise<string> {
   }
   const fileCount = skill.fileCount ?? (await countFiles(skill.path));
   lines.push(label("File Count", String(fileCount)));
+  if (typeof skill.tokenCount === "number") {
+    lines.push(label("Est. Tokens", formatTokenCount(skill.tokenCount)));
+  }
   if (skill.description) {
     lines.push("");
     lines.push(label("Description", skill.description));
@@ -491,6 +511,41 @@ export async function formatSkillDetail(skill: SkillInfo): Promise<string> {
     }
   }
 
+  // Eval summary section — fulfills issue #187 acceptance criteria.
+  // Show empty state explicitly when not available so it never reads as
+  // "broken or missing".
+  lines.push("");
+  lines.push(useColor() ? ansi.bold("Eval Score:") : "Eval Score:");
+  if (skill.evalSummary) {
+    const ev = skill.evalSummary;
+    const overallColored = colorEvalScore(ev.overallScore);
+    lines.push(`  Overall: ${overallColored} / 100  (${ev.grade})`);
+    const evVer = ev.evaluatedVersion
+      ? ` — version ${ev.evaluatedVersion}`
+      : "";
+    lines.push(
+      `  ${useColor() ? ansi.dim("Evaluated:") : "Evaluated:"} ${ev.evaluatedAt}${evVer}`,
+    );
+    if (ev.categories.length > 0) {
+      lines.push(useColor() ? ansi.dim("  Categories:") : "  Categories:");
+      for (const c of ev.categories) {
+        lines.push(`    ${c.name.padEnd(28)} ${c.score}/${c.max}`);
+      }
+    }
+  } else {
+    lines.push(
+      useColor()
+        ? ansi.dim(
+            "  Not available — run `asm eval " +
+              skill.path +
+              "` to generate one.",
+          )
+        : "  Not available — run `asm eval " +
+            skill.path +
+            "` to generate one.",
+    );
+  }
+
   if (skill.warnings && skill.warnings.length > 0) {
     lines.push("");
     lines.push(useColor() ? ansi.bold("Warnings:") : "Warnings:");
@@ -502,6 +557,19 @@ export async function formatSkillDetail(skill: SkillInfo): Promise<string> {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Color an `asm eval` overall score (0..100) by quality tier.
+ *   90+ green, 80+ cyan, 65+ yellow, else red.
+ */
+export function colorEvalScore(score: number): string {
+  const txt = String(score);
+  if (!useColor()) return txt;
+  if (score >= 90) return ansi.green(txt);
+  if (score >= 80) return ansi.cyan(txt);
+  if (score >= 65) return ansi.yellow(txt);
+  return ansi.red(txt);
 }
 
 // ─── Multi-instance detail formatter ────────────────────────────────────────
@@ -539,12 +607,43 @@ export async function formatSkillInspect(skills: SkillInfo[]): Promise<string> {
 
   const fileCount = ref.fileCount ?? (await countFiles(ref.path));
   lines.push(label("  File Count", String(fileCount)));
+  if (typeof ref.tokenCount === "number") {
+    lines.push(label("  Est. Tokens", formatTokenCount(ref.tokenCount)));
+  }
 
   // Provider badges
   const badges = skills
     .map((s) => providerBadge(s.provider, s.providerLabel))
     .join(" ");
   lines.push(label("  Installed in", badges));
+
+  // Eval summary block
+  lines.push("");
+  lines.push(useColor() ? ansi.bold("  Eval Score:") : "  Eval Score:");
+  if (ref.evalSummary) {
+    const ev = ref.evalSummary;
+    const overallColored = colorEvalScore(ev.overallScore);
+    lines.push(`    Overall: ${overallColored} / 100  (${ev.grade})`);
+    const evVer = ev.evaluatedVersion
+      ? ` — version ${ev.evaluatedVersion}`
+      : "";
+    lines.push(
+      `    ${useColor() ? ansi.dim("Evaluated:") : "Evaluated:"} ${ev.evaluatedAt}${evVer}`,
+    );
+    if (ev.categories.length > 0) {
+      for (const c of ev.categories) {
+        lines.push(`      ${c.name.padEnd(28)} ${c.score}/${c.max}`);
+      }
+    }
+  } else {
+    lines.push(
+      useColor()
+        ? ansi.dim(
+            `    Not available — run \`asm eval ${ref.path}\` to generate one.`,
+          )
+        : `    Not available — run \`asm eval ${ref.path}\` to generate one.`,
+    );
+  }
 
   // ── Description ──
   if (ref.description) {

--- a/src/ingester.test.ts
+++ b/src/ingester.test.ts
@@ -242,3 +242,108 @@ x`,
     expect(bad!.verified).toBe(false);
   });
 });
+
+describe("ingester enrichment (issue #188 + #187)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-ingest-enrich-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("populates tokenCount on every DiscoveredSkill", async () => {
+    const skillDir = join(tempDir, "token-skill");
+    await mkdir(skillDir, { recursive: true });
+    const body = "Hello world. This is a test.";
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      `---
+name: token-skill
+description: A skill for token counting
+version: 0.1.0
+---
+
+# Token Skill
+
+${body}
+`,
+      "utf-8",
+    );
+
+    const discovered = await discoverSkills(tempDir);
+    expect(discovered.length).toBe(1);
+    expect(typeof discovered[0].tokenCount).toBe("number");
+    expect(discovered[0].tokenCount!).toBeGreaterThan(0);
+  });
+
+  it("ingester runs eval and produces a slim evalSummary", async () => {
+    // Use the inline path the ingester takes — read content + call
+    // evaluator + project the slim shape — to validate the contract
+    // without needing a real git clone.
+    const { evaluateSkillContent } = await import("./evaluator");
+    const skillDir = join(tempDir, "eval-skill");
+    await mkdir(skillDir, { recursive: true });
+    const skillMd = `---
+name: eval-skill
+description: A skill we will evaluate inline
+version: 0.2.0
+license: MIT
+creator: Tester
+---
+
+## Instructions
+
+Use this skill when you need an example.
+
+- Step 1
+- Step 2
+
+\`\`\`
+example
+\`\`\`
+`;
+    const skillMdPath = join(skillDir, "SKILL.md");
+    await writeFile(skillMdPath, skillMd, "utf-8");
+
+    const report = evaluateSkillContent({
+      content: skillMd,
+      skillPath: skillDir,
+      skillMdPath,
+    });
+
+    // Project the slim shape the ingester writes into IndexedSkill.
+    const slim = {
+      overallScore: report.overallScore,
+      grade: report.grade,
+      categories: report.categories.map((c) => ({
+        id: c.id,
+        name: c.name,
+        score: c.score,
+        max: c.max,
+      })),
+      evaluatedAt: report.evaluatedAt,
+      evaluatedVersion: "0.2.0",
+    };
+
+    expect(typeof slim.overallScore).toBe("number");
+    expect(slim.overallScore).toBeGreaterThanOrEqual(0);
+    expect(slim.overallScore).toBeLessThanOrEqual(100);
+    expect(["A", "B", "C", "D", "F"].includes(slim.grade)).toBe(true);
+    expect(Array.isArray(slim.categories)).toBe(true);
+    expect(slim.categories.length).toBeGreaterThan(0);
+    for (const c of slim.categories) {
+      expect(typeof c.id).toBe("string");
+      expect(typeof c.name).toBe("string");
+      expect(typeof c.score).toBe("number");
+      expect(typeof c.max).toBe("number");
+      // Findings/suggestions intentionally NOT in the slim shape.
+      expect((c as any).findings).toBeUndefined();
+      expect((c as any).suggestions).toBeUndefined();
+    }
+    expect(typeof slim.evaluatedAt).toBe("string");
+    expect(slim.evaluatedVersion).toBe("0.2.0");
+  });
+});

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -11,7 +11,14 @@ import { getIndexDir } from "./config";
 import { loadAllIndices } from "./skill-index";
 import { debug } from "./logger";
 import { verifySkill } from "./verifier";
-import type { RepoIndex, IndexedSkill, ParsedSource } from "./utils/types";
+import { estimateTokenCount } from "./utils/token-count";
+import { evaluateSkillContent } from "./evaluator";
+import type {
+  RepoIndex,
+  IndexedSkill,
+  ParsedSource,
+  SkillEvalSummary,
+} from "./utils/types";
 
 export interface IngestResult {
   success: boolean;
@@ -73,6 +80,47 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
         );
       }
 
+      // Token count: prefer the value populated during discovery; recompute
+      // here as a safe fallback when discovery did not set it (e.g., older
+      // discovery code paths in tests).
+      const tokenCount =
+        typeof skill.tokenCount === "number"
+          ? skill.tokenCount
+          : skillMdContent
+            ? estimateTokenCount(skillMdContent)
+            : undefined;
+
+      // Eval summary — captured at index time so the website + TUI + CLI
+      // inspect surfaces can show "what would I be installing" before the
+      // user runs `asm install`. We intentionally drop findings/suggestions
+      // from the catalog payload to keep catalog.json small.
+      let evalSummary: SkillEvalSummary | undefined;
+      if (skillMdContent) {
+        try {
+          const report = evaluateSkillContent({
+            content: skillMdContent,
+            skillPath: skill.relPath || skill.name,
+            skillMdPath,
+          });
+          evalSummary = {
+            overallScore: report.overallScore,
+            grade: report.grade,
+            categories: report.categories.map((c) => ({
+              id: c.id,
+              name: c.name,
+              score: c.score,
+              max: c.max,
+            })),
+            evaluatedAt: report.evaluatedAt,
+            evaluatedVersion: skill.version || undefined,
+          };
+        } catch (err) {
+          // Eval is best-effort during indexing — never fail the whole
+          // ingest because one skill produced a malformed evaluator result.
+          debug(`ingester: eval failed for ${skill.name}: ${err}`);
+        }
+      }
+
       skills.push({
         name: skill.name,
         description: skill.description,
@@ -84,6 +132,8 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
         installUrl: `github:${source.owner}/${source.repo}${source.ref ? `#${source.ref}` : ""}${skill.relPath ? `:${skill.relPath}` : ""}`,
         relPath: skill.relPath,
         verified: verification.verified,
+        tokenCount,
+        evalSummary,
       });
     }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -21,6 +21,7 @@ import {
   resolveVersion,
   resolveAllowedTools,
 } from "./utils/frontmatter";
+import { estimateTokenCount } from "./utils/token-count";
 import { resolveProviderPath } from "./config";
 import { debug } from "./logger";
 import { readFilesRecursive } from "./utils/fs";
@@ -470,6 +471,7 @@ export async function discoverSkills(
           creator: (fm["metadata.creator"] || "").trim(),
           compatibility: (fm.compatibility || "").trim(),
           allowedTools: resolveAllowedTools(fm),
+          tokenCount: estimateTokenCount(content),
         });
         // Don't recurse into directories that have SKILL.md
       } catch {

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -329,6 +329,9 @@ describe("scanAllSkills", () => {
     expect(found!.scope).toBe("global");
     expect(found!.provider).toBe("test");
     expect(found!.isSymlink).toBe(false);
+    // Issue #188: scanner populates tokenCount for installed skills.
+    expect(typeof found!.tokenCount).toBe("number");
+    expect(found!.tokenCount!).toBeGreaterThan(0);
   });
 
   it("skips entries without SKILL.md", async () => {

--- a/src/scanner.test.ts
+++ b/src/scanner.test.ts
@@ -521,6 +521,11 @@ describe("scanPluginMarketplaces", () => {
     expect(skill.scope).toBe("global");
     expect(skill.location).toBe("global-plugin-my-marketplace");
     expect(skill.dirName).toBe("my-skill");
+    // Issue #188: scanPluginMarketplaces populates tokenCount for plugin
+    // marketplace skills, matching the parallel scanDirectory codepath so
+    // users with Claude plugin-marketplace skills also see Est. Tokens.
+    expect(typeof skill.tokenCount).toBe("number");
+    expect(skill.tokenCount!).toBeGreaterThan(0);
   });
 
   it("discovers official bundled plugin skills (plugins/.../skills/ layout)", async () => {

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -13,6 +13,7 @@ import {
   resolveVersion,
   resolveAllowedTools,
 } from "./utils/frontmatter";
+import { estimateTokenCount } from "./utils/token-count";
 import { resolveProviderPath } from "./config";
 import { debug } from "./logger";
 import type {
@@ -186,6 +187,7 @@ async function scanDirectory(loc: ScanLocation): Promise<SkillInfo[]> {
       isSymlink,
       symlinkTarget,
       realPath: resolvedRealPath,
+      tokenCount: estimateTokenCount(content),
     });
   }
 

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -322,6 +322,7 @@ export async function scanPluginMarketplaces(
         symlinkTarget: null,
         realPath: resolvedRealPath,
         marketplace,
+        tokenCount: estimateTokenCount(content),
       });
     }
   }

--- a/src/utils/token-count.test.ts
+++ b/src/utils/token-count.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { estimateTokenCount, formatTokenCount } from "./token-count";
+
+describe("estimateTokenCount", () => {
+  it("returns 0 for empty string", () => {
+    expect(estimateTokenCount("")).toBe(0);
+  });
+
+  it("counts only literal spaces in whitespace-only string", () => {
+    // 0 words + 5 literal U+0020 chars in `   \n\t  `
+    expect(estimateTokenCount("   \n\t  ")).toBe(5);
+  });
+
+  it("counts a single word as one token", () => {
+    expect(estimateTokenCount("hello")).toBe(1);
+  });
+
+  it("counts words plus spaces — `hello world` = 2 words + 1 space = 3", () => {
+    expect(estimateTokenCount("hello world")).toBe(3);
+  });
+
+  it("counts multiple spaces between words individually", () => {
+    // 2 words + 3 spaces
+    expect(estimateTokenCount("hello   world")).toBe(5);
+  });
+
+  it("does not count newlines or tabs as spaces", () => {
+    // 3 words ("a","b","c") + 0 literal spaces = 3
+    expect(estimateTokenCount("a\nb\tc")).toBe(3);
+  });
+
+  it("scales for a realistic sentence", () => {
+    const text = "Use this skill to do X.";
+    // words: Use, this, skill, to, do, X. = 6
+    // spaces: 5
+    expect(estimateTokenCount(text)).toBe(11);
+  });
+
+  it("handles paragraph with mixed whitespace", () => {
+    const text = "First line.\nSecond line with two  spaces.";
+    // Words split on /\s+/: First, line., Second, line, with, two, spaces. = 7
+    // Literal spaces (U+0020 only): "First line." has 1, "Second line with two  spaces." has 5
+    // total spaces = 6
+    expect(estimateTokenCount(text)).toBe(13);
+  });
+});
+
+describe("formatTokenCount", () => {
+  it("formats small counts with the leading `~`", () => {
+    expect(formatTokenCount(0)).toBe("~0 tokens");
+    expect(formatTokenCount(7)).toBe("~7 tokens");
+    expect(formatTokenCount(999)).toBe("~999 tokens");
+  });
+
+  it("formats thousands with k suffix and decimal", () => {
+    expect(formatTokenCount(1000)).toBe("~1k tokens");
+    expect(formatTokenCount(1500)).toBe("~1.5k tokens");
+    expect(formatTokenCount(2750)).toBe("~2.8k tokens");
+  });
+
+  it("formats large counts with rounded k", () => {
+    expect(formatTokenCount(12_345)).toBe("~12k tokens");
+    expect(formatTokenCount(150_000)).toBe("~150k tokens");
+  });
+
+  it("treats negative or non-finite values as zero", () => {
+    expect(formatTokenCount(-1)).toBe("~0 tokens");
+    expect(formatTokenCount(NaN)).toBe("~0 tokens");
+    expect(formatTokenCount(Infinity)).toBe("~0 tokens");
+  });
+});

--- a/src/utils/token-count.ts
+++ b/src/utils/token-count.ts
@@ -1,0 +1,58 @@
+/**
+ * Estimated token count for skill content.
+ *
+ * Uses the heuristic from issue #188: number of words + number of spaces.
+ * This is a deliberately simple approximation — it does NOT match any specific
+ * model tokenizer (BPE, tiktoken, etc.). It is a fast, dependency-free signal
+ * meant to give users a rough sense of the context cost before installing a
+ * skill.
+ *
+ * Always render the result as `~N tokens` (with the leading `~`) so users
+ * understand it is an approximation.
+ */
+
+/**
+ * Compute the estimated token count for a string of skill content.
+ *
+ * Formula: number of words (sequences of non-whitespace characters) +
+ *          number of space characters (literal U+0020 only).
+ *
+ * Notes:
+ *   - Empty / whitespace-only input → 0.
+ *   - Newlines and tabs are whitespace separators but do NOT count toward
+ *     the "spaces" portion (only literal space characters do).
+ *   - Multiple consecutive spaces each count individually.
+ */
+export function estimateTokenCount(content: string): number {
+  if (!content) return 0;
+  const words = content
+    .split(/\s+/)
+    .map((w) => w.trim())
+    .filter(Boolean).length;
+  let spaces = 0;
+  for (let i = 0; i < content.length; i++) {
+    if (content.charCodeAt(i) === 32) spaces++;
+  }
+  return words + spaces;
+}
+
+/**
+ * Format a token count for display.
+ *
+ * Always prefixed with `~` to signal an approximation (per issue #188
+ * acceptance criteria).
+ *
+ * Examples:
+ *   - estimateTokenCount("hello world") = 3   → "~3 tokens"
+ *   - 1234                              → "~1.2k tokens"
+ *   - 12_345                            → "~12k tokens"
+ */
+export function formatTokenCount(count: number): string {
+  if (!Number.isFinite(count) || count < 0) return "~0 tokens";
+  if (count < 1000) return `~${count} tokens`;
+  if (count < 10_000) {
+    const k = (count / 1000).toFixed(1).replace(/\.0$/, "");
+    return `~${k}k tokens`;
+  }
+  return `~${Math.round(count / 1000)}k tokens`;
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,6 +26,17 @@ export interface SkillInfo {
   fileCount?: number;
   effort?: string;
   warnings?: SkillWarning[];
+  /**
+   * Estimated token cost for the skill's SKILL.md content.
+   * Computed as `words + spaces` (issue #188 heuristic).
+   * Always render as `~N tokens` to signal it is an approximation.
+   */
+  tokenCount?: number;
+  /**
+   * Lazily-populated summary of the most recent `asm eval` run for this skill.
+   * Filled in by callers that opt to enrich (e.g., the TUI detail view).
+   */
+  evalSummary?: SkillEvalSummary;
   /** Marketplace name when skill was installed via Claude plugin marketplace */
   marketplace?: string;
   /** Codex plugin metadata when skill was discovered via Codex plugin cache */
@@ -36,6 +47,33 @@ export interface SkillInfo {
     pluginVersion?: string;
     enabled?: boolean;
   };
+}
+
+/**
+ * Slim, JSON-friendly snapshot of an `asm eval` report for the
+ * "before-install" decision surfaces (website cards/modal, TUI detail,
+ * CLI inspect).
+ *
+ * Findings/suggestions are intentionally omitted — they are an authoring
+ * aid, not a consumer-facing signal, and including them in catalog.json
+ * would bloat the payload by ~1MB+ for a few hundred skills.
+ */
+export interface SkillEvalSummary {
+  /** 0..100 normalized score across all categories. */
+  overallScore: number;
+  /** Letter grade for quick scanning. */
+  grade: "A" | "B" | "C" | "D" | "F";
+  /** Per-category breakdown (id, name, score, max). */
+  categories: Array<{
+    id: string;
+    name: string;
+    score: number;
+    max: number;
+  }>;
+  /** ISO-8601 timestamp of when the eval was produced. */
+  evaluatedAt: string;
+  /** Skill version that was evaluated (e.g. `0.2.0`). */
+  evaluatedVersion?: string;
 }
 
 /** Codex plugin manifest (`.codex-plugin/plugin.json`) */
@@ -232,6 +270,12 @@ export interface DiscoveredSkill {
   creator: string;
   compatibility: string;
   allowedTools: string[];
+  /**
+   * Estimated token count for the SKILL.md content. Populated by
+   * `discoverSkills` so downstream consumers (ingester) don't have to
+   * re-read the file.
+   */
+  tokenCount?: number;
 }
 
 // ─── Skill Index Types ───────────────────────────────────────────────────────
@@ -262,6 +306,16 @@ export interface IndexedSkill {
   installUrl: string;
   relPath: string;
   verified?: boolean;
+  /**
+   * Estimated token count for the SKILL.md content
+   * (`words + spaces` heuristic — see `src/utils/token-count.ts`).
+   */
+  tokenCount?: number;
+  /**
+   * Slim eval summary captured at index time for "before-install"
+   * surfaces (website + TUI + CLI inspect).
+   */
+  evalSummary?: SkillEvalSummary;
 }
 
 export interface RepoIndex {

--- a/src/views/skill-detail.ts
+++ b/src/views/skill-detail.ts
@@ -4,6 +4,7 @@ import { theme } from "../utils/colors";
 import type { SkillInfo } from "../utils/types";
 import { countFiles } from "../scanner";
 import { wordWrap, HIGH_RISK_TOOLS, MEDIUM_RISK_TOOLS } from "../formatter";
+import { formatTokenCount } from "../utils/token-count";
 
 const EFFORT_COLORS: Record<string, string> = {
   low: theme.green,
@@ -51,9 +52,10 @@ export function createDetailView(
   const desc = skill.description || "(no description)";
   const wrappedDescLines = wordWrap(desc, descMaxWidth);
   // base detail rows (name, version, creator, license, tool, location, path, symlink, files, scope) = 10
-  // + optional rows: effort, compatibility, allowed-tools (label + tools + optional warning)
+  // + optional rows: effort, compatibility, tokens, allowed-tools (label + tools + optional warning)
   const effortRows = skill.effort ? 1 : 0;
   const compatRows = skill.compatibility ? 1 : 0;
+  const tokenRows = typeof skill.tokenCount === "number" ? 1 : 0;
   const hasHighRiskTools = skill.allowedTools?.some((t) =>
     HIGH_RISK_TOOLS.has(t),
   );
@@ -63,12 +65,19 @@ export function createDetailView(
         ? 3
         : 2
       : 0;
+  // Eval section: 2 lines for label + body in empty state, or
+  // 3 + categories (up to 7) in populated state.
+  const evalRows = skill.evalSummary
+    ? 3 + skill.evalSummary.categories.length
+    : 2;
   const boxHeight = Math.min(
     ctx.height - 2,
     10 +
       effortRows +
       compatRows +
+      tokenRows +
       toolsRows +
+      evalRows +
       2 +
       wrappedDescLines.length +
       2 +
@@ -186,6 +195,17 @@ export function createDetailView(
       })
       .catch(() => {});
   }
+  if (typeof skill.tokenCount === "number") {
+    container.add(
+      detailRow(
+        ctx,
+        "tokens",
+        "Est. Tokens",
+        formatTokenCount(skill.tokenCount),
+        theme.cyan,
+      ),
+    );
+  }
   container.add(detailRow(ctx, "scope", "Scope", skill.scope, theme.accentAlt));
 
   const descLabel = new TextRenderable(ctx, {
@@ -212,6 +232,61 @@ export function createDetailView(
     height: visibleLines.length,
   });
   container.add(descText);
+
+  // ── Eval Score ──────────────────────────────────────────────────────────
+  // Issue #187: surface `asm eval` overall + per-category scores so users
+  // can decide whether to install. Always render an explicit empty state
+  // for skills without an eval so the section never reads as "broken".
+  const evalLabel = new TextRenderable(ctx, {
+    content: "\nEval Score:",
+    fg: theme.fgDim,
+    height: 2,
+  });
+  container.add(evalLabel);
+
+  if (skill.evalSummary) {
+    const ev = skill.evalSummary;
+    const overallColor =
+      ev.overallScore >= 90
+        ? theme.green
+        : ev.overallScore >= 80
+          ? theme.cyan
+          : ev.overallScore >= 65
+            ? theme.yellow
+            : theme.red;
+    container.add(
+      new TextRenderable(ctx, {
+        content: `  Overall: ${ev.overallScore}/100  (${ev.grade})`,
+        fg: overallColor,
+        height: 1,
+      }),
+    );
+    const evVer = ev.evaluatedVersion ? ` — v${ev.evaluatedVersion}` : "";
+    container.add(
+      new TextRenderable(ctx, {
+        content: `  Evaluated: ${ev.evaluatedAt}${evVer}`,
+        fg: theme.fgDim,
+        height: 1,
+      }),
+    );
+    for (const c of ev.categories) {
+      container.add(
+        new TextRenderable(ctx, {
+          content: `    ${c.name.padEnd(28)} ${c.score}/${c.max}`,
+          fg: theme.fg,
+          height: 1,
+        }),
+      );
+    }
+  } else {
+    container.add(
+      new TextRenderable(ctx, {
+        content: "  Not available — run `asm eval` to generate one.",
+        fg: theme.fgDim,
+        height: 1,
+      }),
+    );
+  }
 
   if (skill.allowedTools && skill.allowedTools.length > 0) {
     const toolsLabel = new TextRenderable(ctx, {

--- a/src/views/skill-list.ts
+++ b/src/views/skill-list.ts
@@ -7,6 +7,13 @@ import {
 import type { RenderContext } from "@opentui/core";
 import { theme } from "../utils/colors";
 import type { SkillInfo } from "../utils/types";
+import { formatTokenCount } from "../utils/token-count";
+
+function compactTokens(tokenCount: number | undefined): string {
+  if (typeof tokenCount !== "number") return "\u2014";
+  // Compact form (no "tokens" suffix): "~3", "~1.2k", "~12k" — fits a 7-char column.
+  return formatTokenCount(tokenCount).replace(/ tokens$/, "");
+}
 
 function formatSkillRow(
   index: number,
@@ -27,6 +34,8 @@ function formatSkillRow(
   const creator = creatorRaw.length > 12 ? creatorRaw.slice(0, 12) : creatorRaw;
   const effortRaw = skill.effort || "\u2014";
   const effort = effortRaw.length > 6 ? effortRaw.slice(0, 6) : effortRaw;
+  const tokensRaw = compactTokens(skill.tokenCount);
+  const tokens = tokensRaw.length > 7 ? tokensRaw.slice(0, 7) : tokensRaw;
   const prov =
     skill.providerLabel.length > 11
       ? skill.providerLabel.slice(0, 11)
@@ -35,7 +44,7 @@ function formatSkillRow(
   const type = skill.isSymlink ? "\u2192link" : " dir ";
   const desc =
     descWidth > 0 ? " " + (skill.description || "").slice(0, descWidth) : "";
-  return `${idx} ${name.padEnd(24)} ${ver.padEnd(8)} ${creator.padEnd(13)} ${effort.padEnd(7)} ${prov.padEnd(12)} ${scope.padEnd(8)} ${type.padEnd(6)}${desc}`;
+  return `${idx} ${name.padEnd(24)} ${ver.padEnd(8)} ${creator.padEnd(13)} ${effort.padEnd(7)} ${tokens.padEnd(8)} ${prov.padEnd(12)} ${scope.padEnd(8)} ${type.padEnd(6)}${desc}`;
 }
 
 function buildOptions(skills: SkillInfo[], descWidth: number) {
@@ -52,8 +61,9 @@ function buildOptions(skills: SkillInfo[], descWidth: number) {
 }
 
 function calcDescWidth(termWidth: number): number {
-  // 2(border) + 2(padding) + 4(#) + 24(name) + 8(ver) + 13(creator) + 7(effort) + 12(provider) + 8(scope) + 6(type) + 8(spaces) = 94
-  const fixed = 94;
+  // 2(border) + 2(padding) + 4(#) + 24(name) + 8(ver) + 13(creator) + 7(effort)
+  // + 8(tokens) + 12(provider) + 8(scope) + 6(type) + 9(spaces) = 103
+  const fixed = 103;
   return Math.max(0, termWidth - fixed);
 }
 
@@ -86,7 +96,7 @@ export function createSkillList(
   const descHeader = descWidth > 0 ? " Description" : "";
   const headerRow = new TextRenderable(ctx, {
     id: "skill-list-header",
-    content: `${"#".padStart(3)} ${"Name".padEnd(26)} ${"Ver".padEnd(8)} ${"Creator".padEnd(13)} ${"Effort".padEnd(7)} ${"Tool".padEnd(12)} ${"Scope".padEnd(8)} ${"Type".padEnd(6)}${descHeader}`,
+    content: `${"#".padStart(3)} ${"Name".padEnd(26)} ${"Ver".padEnd(8)} ${"Creator".padEnd(13)} ${"Effort".padEnd(7)} ${"Tokens".padEnd(8)} ${"Tool".padEnd(12)} ${"Scope".padEnd(8)} ${"Type".padEnd(6)}${descHeader}`,
     fg: theme.fgDim,
     height: 1,
   });

--- a/tests/e2e/build-verification.test.ts
+++ b/tests/e2e/build-verification.test.ts
@@ -94,3 +94,96 @@ describe("build: chunk files present", () => {
     expect(chunks.length).toBeGreaterThanOrEqual(1);
   });
 });
+
+// ─── token count + eval enrichment (issues #188 + #187) ────────────────────
+
+describe("data/skill-index: token count + eval enrichment", () => {
+  test("at least one indexed skill has tokenCount", () => {
+    const files = readdirSync(DATA_DIR).filter((f) => f.endsWith(".json"));
+    let foundTokenCount = false;
+    for (const file of files) {
+      const data = JSON.parse(readFileSync(join(DATA_DIR, file), "utf-8"));
+      for (const skill of data.skills || []) {
+        if (typeof skill.tokenCount === "number" && skill.tokenCount > 0) {
+          foundTokenCount = true;
+          break;
+        }
+      }
+      if (foundTokenCount) break;
+    }
+    expect(foundTokenCount).toBe(true);
+  });
+
+  test("at least one indexed skill has evalSummary with required fields", () => {
+    const files = readdirSync(DATA_DIR).filter((f) => f.endsWith(".json"));
+    let foundEvalSummary = false;
+    let exampleSummary: any = null;
+    for (const file of files) {
+      const data = JSON.parse(readFileSync(join(DATA_DIR, file), "utf-8"));
+      for (const skill of data.skills || []) {
+        if (skill.evalSummary) {
+          foundEvalSummary = true;
+          exampleSummary = skill.evalSummary;
+          break;
+        }
+      }
+      if (foundEvalSummary) break;
+    }
+    expect(foundEvalSummary).toBe(true);
+    expect(typeof exampleSummary.overallScore).toBe("number");
+    expect(["A", "B", "C", "D", "F"].includes(exampleSummary.grade)).toBe(true);
+    expect(Array.isArray(exampleSummary.categories)).toBe(true);
+    expect(exampleSummary.categories.length).toBeGreaterThan(0);
+    expect(typeof exampleSummary.evaluatedAt).toBe("string");
+  });
+
+  test("evalSummary categories are slim — no findings/suggestions in payload", () => {
+    const files = readdirSync(DATA_DIR).filter((f) => f.endsWith(".json"));
+    for (const file of files) {
+      const data = JSON.parse(readFileSync(join(DATA_DIR, file), "utf-8"));
+      for (const skill of data.skills || []) {
+        if (!skill.evalSummary) continue;
+        for (const c of skill.evalSummary.categories) {
+          // The slim shape only includes id/name/score/max — keep it that way
+          // so the catalog payload doesn't bloat to ~MBs.
+          expect(c.findings).toBeUndefined();
+          expect(c.suggestions).toBeUndefined();
+        }
+      }
+    }
+  });
+});
+
+// ─── website surfaces token count + eval (issues #188 + #187) ──────────────
+
+describe("website: token count + eval surfaces", () => {
+  const html = readFileSync(join(WEBSITE_DIR, "index.html"), "utf-8");
+
+  test("renderCard reads tokenCount and renders the badge", () => {
+    expect(html).toContain("formatTokens");
+    expect(html).toContain("badge-tokens");
+    expect(html).toContain("s.tokenCount");
+  });
+
+  test("renderCard reads evalSummary and renders the eval badge", () => {
+    expect(html).toContain("badge-eval");
+    expect(html).toContain("s.evalSummary");
+    expect(html).toContain("evalScoreClass");
+  });
+
+  test("modal renders an eval section with empty-state fallback", () => {
+    expect(html).toContain("modal-eval");
+    expect(html).toContain("modal-eval-header");
+    expect(html).toContain("eval-empty");
+    // Always rendered even when there is no data — see issue #187 acceptance criteria
+    expect(html).toContain("No <code>asm eval</code> data is available");
+  });
+
+  test("modal exposes Est. Tokens row when tokenCount is present", () => {
+    expect(html).toContain("Est. Tokens");
+  });
+
+  test("formatTokens always prefixes its output with `~` (approximation)", () => {
+    expect(html).toMatch(/return\s+'~'\s*\+\s*count\s*\+\s*' tokens'/);
+  });
+});

--- a/website/index.html
+++ b/website/index.html
@@ -482,6 +482,22 @@ a:hover { text-decoration: underline; }
   white-space: nowrap;
 }
 .badge-cat { color: var(--brand-dim); background: var(--badge-cat-bg); }
+.badge-tokens {
+  color: var(--text-dim);
+  background: var(--bg-surface);
+  cursor: help;
+  font-weight: 500;
+}
+.badge-eval {
+  font-weight: 600;
+  cursor: help;
+  letter-spacing: 0.02em;
+}
+.badge-eval.eval-a { color: #4ade80; background: rgba(74, 222, 128, 0.12); }
+.badge-eval.eval-b { color: #38bdf8; background: rgba(56, 189, 248, 0.12); }
+.badge-eval.eval-c { color: #fbbf24; background: rgba(251, 191, 36, 0.14); }
+.badge-eval.eval-d { color: #fb923c; background: rgba(251, 146, 60, 0.14); }
+.badge-eval.eval-f { color: #f87171; background: rgba(248, 113, 113, 0.14); }
 .badge-warn {
   color: var(--yellow);
   background: var(--warn-bg);
@@ -614,6 +630,103 @@ a:hover { text-decoration: underline; }
   font-size: 12px;
 }
 .meta-value { color: var(--text-dim); }
+/* ─── Modal eval block ────────────────────────────────────────────────── */
+.modal-eval {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  margin-bottom: 20px;
+  background: var(--bg-surface);
+}
+.modal-eval-header {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+}
+.eval-overall {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+.eval-score {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1;
+}
+.eval-overall.eval-a .eval-score { color: #4ade80; }
+.eval-overall.eval-b .eval-score { color: #38bdf8; }
+.eval-overall.eval-c .eval-score { color: #fbbf24; }
+.eval-overall.eval-d .eval-score { color: #fb923c; }
+.eval-overall.eval-f .eval-score { color: #f87171; }
+.eval-max {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+.eval-grade {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.eval-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+.eval-categories {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.eval-categories td { padding: 4px 0; vertical-align: middle; }
+.eval-cat-name {
+  color: var(--text-dim);
+  white-space: nowrap;
+  padding-right: 12px;
+}
+.eval-cat-bar { width: 100%; padding-right: 12px; }
+.eval-bar {
+  height: 6px;
+  background: var(--bg-card);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.eval-bar-fill { height: 100%; transition: width 0.2s; }
+.eval-bar-fill.eval-a { background: #4ade80; }
+.eval-bar-fill.eval-b { background: #38bdf8; }
+.eval-bar-fill.eval-c { background: #fbbf24; }
+.eval-bar-fill.eval-d { background: #fb923c; }
+.eval-bar-fill.eval-f { background: #f87171; }
+.eval-cat-score {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  text-align: right;
+  white-space: nowrap;
+}
+.eval-empty {
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+.eval-empty code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-card);
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: var(--brand-dim);
+}
 .modal-install {
   background: var(--bg-surface);
   border: 1px solid var(--border);
@@ -1548,6 +1661,28 @@ function getFiltered() {
 }
 
 // ─── Render Grid ───────────────────────────────────────────────────────────
+// Format an estimated token count as "~N tokens" / "~1.2k tokens" / "~12k tokens".
+// Mirrors src/utils/token-count.ts:formatTokenCount so the website + CLI agree.
+function formatTokens(count) {
+  if (typeof count !== 'number' || !isFinite(count) || count < 0) return '~0 tokens';
+  if (count < 1000) return '~' + count + ' tokens';
+  if (count < 10000) {
+    var k = (count / 1000).toFixed(1).replace(/\.0$/, '');
+    return '~' + k + 'k tokens';
+  }
+  return '~' + Math.round(count / 1000) + 'k tokens';
+}
+
+// Pick a CSS class for a 0..100 eval score so the badge color reflects quality.
+function evalScoreClass(score) {
+  if (typeof score !== 'number') return '';
+  if (score >= 90) return 'eval-a';
+  if (score >= 80) return 'eval-b';
+  if (score >= 65) return 'eval-c';
+  if (score >= 50) return 'eval-d';
+  return 'eval-f';
+}
+
 function renderCard(s) {
   const cmd = 'asm install ' + s.installUrl;
   const cats = s.categories.map(c => '<span class="badge badge-cat">' + esc(c) + '</span>').join('');
@@ -1559,6 +1694,15 @@ function renderCard(s) {
   const isVerified = s.verified === true;
   const officialBadge = isOfficial ? '<span class="badge badge-official">official</span>' : '';
   const verifiedBadge = isVerified ? '<span class="badge badge-verified">&#x2713; verified</span>' : '';
+  // Token count badge — labelled with `~` so users know it's an approximation.
+  const tokenBadge = typeof s.tokenCount === 'number'
+    ? '<span class="badge badge-tokens" title="Estimated tokens: words + spaces in SKILL.md (rough approximation)">' + esc(formatTokens(s.tokenCount)) + '</span>'
+    : '';
+  // Eval score badge — overall + grade. Empty state is omitted from the card
+  // to keep things tight; the modal always shows an explicit empty state.
+  const evalBadge = s.evalSummary
+    ? '<span class="badge badge-eval ' + evalScoreClass(s.evalSummary.overallScore) + '" title="asm eval score: ' + esc(s.evalSummary.overallScore + '/100 (' + s.evalSummary.grade + ')') + '">eval ' + esc(s.evalSummary.overallScore + ' ' + s.evalSummary.grade) + '</span>'
+    : '';
   let cardClass = 'skill-card';
   if (isOfficial) cardClass += ' official';
   if (isVerified) cardClass += ' verified';
@@ -1570,7 +1714,7 @@ function renderCard(s) {
     + '</div>'
     + '<p class="skill-desc">' + esc(s.description) + '</p>'
     + '<div class="card-footer">'
-    + '<div class="badge-row">' + officialBadge + verifiedBadge + cats + warn + '</div>'
+    + '<div class="badge-row">' + officialBadge + verifiedBadge + evalBadge + tokenBadge + cats + warn + '</div>'
     + ver
     + '</div>'
     + '<div class="install-bar">'
@@ -1658,15 +1802,48 @@ function openModal(skillId) {
   if (skill.license) meta += '<span class="meta-label">License</span><span class="meta-value">' + esc(skill.license) + '</span>';
   if (skill.creator) meta += '<span class="meta-label">Creator</span><span class="meta-value">' + esc(skill.creator) + '</span>';
   if (skill.compatibility) meta += '<span class="meta-label">Compat</span><span class="meta-value">' + esc(skill.compatibility) + '</span>';
+  if (typeof skill.tokenCount === 'number') meta += '<span class="meta-label" title="Estimated context cost: words + spaces in SKILL.md">Est. Tokens</span><span class="meta-value">' + esc(formatTokens(skill.tokenCount)) + '</span>';
   if (skill.allowedTools && skill.allowedTools.length > 0) meta += '<span class="meta-label">Tools</span><span class="meta-value badge-warn">' + esc(skill.allowedTools.join(', ')) + '</span>';
   meta += '<span class="meta-label">Repo</span><span class="meta-value"><a href="https://github.com/' + esc(skill.owner) + '/' + esc(skill.repo) + '" target="_blank" rel="noopener">' + esc(skill.owner) + '/' + esc(skill.repo) + '</a></span>';
   meta += '<span class="meta-label">Categories</span><span class="meta-value">' + cats + '</span>';
+
+  // Eval section — issue #187. Always rendered with an explicit empty state
+  // so it never reads as "broken or missing".
+  let evalSection = '<div class="modal-eval">';
+  evalSection += '<div class="modal-eval-header">asm eval score</div>';
+  if (skill.evalSummary) {
+    const ev = skill.evalSummary;
+    const scoreClass = evalScoreClass(ev.overallScore);
+    evalSection += '<div class="eval-overall ' + scoreClass + '">'
+      + '<span class="eval-score">' + esc(String(ev.overallScore)) + '<span class="eval-max">/100</span></span>'
+      + '<span class="eval-grade">grade ' + esc(ev.grade) + '</span>'
+      + '</div>';
+    const evDate = ev.evaluatedAt ? new Date(ev.evaluatedAt).toLocaleDateString() : '';
+    const evVer = ev.evaluatedVersion ? ' &middot; v' + esc(ev.evaluatedVersion) : '';
+    evalSection += '<div class="eval-meta">Evaluated ' + esc(evDate) + evVer + '</div>';
+    if (ev.categories && ev.categories.length > 0) {
+      evalSection += '<table class="eval-categories">';
+      for (const c of ev.categories) {
+        const pct = c.max > 0 ? Math.round((c.score / c.max) * 100) : 0;
+        evalSection += '<tr>'
+          + '<td class="eval-cat-name">' + esc(c.name) + '</td>'
+          + '<td class="eval-cat-bar"><div class="eval-bar"><div class="eval-bar-fill ' + evalScoreClass(pct) + '" style="width:' + pct + '%"></div></div></td>'
+          + '<td class="eval-cat-score">' + esc(String(c.score)) + '/' + esc(String(c.max)) + '</td>'
+          + '</tr>';
+      }
+      evalSection += '</table>';
+    }
+  } else {
+    evalSection += '<div class="eval-empty">No <code>asm eval</code> data is available for this skill yet. Run <code>asm eval &lt;skill-path&gt;</code> after installing to generate one.</div>';
+  }
+  evalSection += '</div>';
 
   document.getElementById('modal-content').innerHTML =
     '<div class="modal-name" id="modal-title">' + esc(skill.name) + '</div>'
     + '<div class="modal-repo">' + esc(skill.owner) + '/' + esc(skill.repo) + '</div>'
     + '<div class="modal-desc">' + esc(skill.description) + '</div>'
     + (meta ? '<div class="modal-meta">' + meta + '</div>' : '')
+    + evalSection
     + '<div class="modal-install">'
     + '<code>' + esc(cmd) + '</code>'
     + '<button class="copy-btn" data-cmd="' + esc(cmd) + '" onclick="copyCmd(this)">copy</button>'


### PR DESCRIPTION
Closes #188
Closes #187

## Summary

Surfaces two new "before-install" decision signals on every consumer
surface (website cards/modal, TUI list/detail, CLI inspect):

- **Estimated token count** — `~N tokens` heuristic using
  `words + spaces` (per #188), labelled with `~` so users read it as
  an approximation.
- **`asm eval` scores** — overall score, letter grade, and
  per-category breakdown captured at index time and shown
  prominently. When a skill has no eval data we render an explicit
  empty state pointing the user at `asm eval <skill>` (per #187
  acceptance criteria).

The catalog payload is the single source of truth — the website
reads it directly, so all 3,140 indexed skills have both signals
available without any client-side work.

## Approach

| Layer | Where | What |
|-------|-------|------|
| Util | `src/utils/token-count.ts` | Shared helpers `estimateTokenCount` + `formatTokenCount` so the CLI and website agree on the formula and rendering |
| Types | `src/utils/types.ts` | New optional `tokenCount` + `evalSummary` fields on `SkillInfo`, `IndexedSkill`, `DiscoveredSkill`. New slim `SkillEvalSummary` shape that intentionally omits findings/suggestions to keep `catalog.json` small |
| Scan | `src/installer.ts`, `src/scanner.ts` | Compute `tokenCount` during discovery + scan (no extra disk I/O — SKILL.md is already being read) |
| Index | `src/ingester.ts` | Run `evaluateSkillContent` inline on the SKILL.md the verifier already loaded; write the slim summary to each `IndexedSkill` |
| Catalog | `scripts/build-catalog.ts` | Pass-through; `catalog.json` consumers read the new fields verbatim |
| CLI | `src/formatter.ts` | New `Est. Tokens` row in detail; new `Tokens` column in grouped table; new color-graded `Eval Score` block with empty state |
| TUI | `src/views/skill-list.ts`, `src/views/skill-detail.ts` | New `Tokens` column in list; new `Est. Tokens` row + `Eval Score` block (with empty state) in detail |
| Website | `website/index.html` | New `~N tokens` and `eval N grade` badges on each card; new `asm eval score` block in the modal with score, grade, evaluated date + version, per-category bars, and an explicit empty state |

The slim eval shape keeps `catalog.json` lean — ~2 MB → ~4 MB across
3,140 skills, without findings/suggestions arrays which would have
pushed the payload past 10 MB.

## Notable

- `scripts/enrich-index.ts` (new) is a one-shot helper that
  back-fills the new fields on existing `data/skill-index/*.json`
  files. Useful for future schema bumps; the `preindex` script
  already produces the same fields end-to-end for fresh runs.
- All 25 indexed repos were re-enriched (6,782 skills) — the data/
  diff is large but additive only (no metadata churn).

## Test Results

- `bun test src/` — **1,446 pass / 0 fail** (33,656 expect calls)
- `bun test tests/e2e/` — **191 pass / 0 fail** (96,500 expect calls)
- `bun run typecheck` — clean
- `bun run build` — clean

New tests:
- `src/utils/token-count.test.ts` — 12 tests for the heuristic + formatter
- `src/scanner.test.ts` — assertion that scanner populates `tokenCount`
- `src/ingester.test.ts` — assertions for `tokenCount` on
  `DiscoveredSkill` + slim `evalSummary` shape contract
- `src/formatter.test.ts` — populated + empty-state assertions for both
  `formatSkillDetail` and `formatGroupedTable`
- `tests/e2e/build-verification.test.ts` — data + website assertions

## Acceptance Criteria

#188:
- [x] Each skill exposes an estimated token count (`words + spaces`)
- [x] Website shows the estimate on the list (card badge) and detail (modal `Est. Tokens` row)
- [x] TUI shows the estimate on the skill list (new `Tokens` column) and detail (new `Est. Tokens` row)
- [x] Estimate is labelled as approximation (`~N tokens` everywhere)

#187:
- [x] Detail view displays the overall `asm eval` score prominently
- [x] All per-dimension detail scores are shown with labels and values
- [x] Eval metadata is visible (`Evaluated:` date + skill version)
- [x] Skills without eval data show a clear empty state ("Not available — run `asm eval`...") rather than a missing section