### PR TITLE
feat(cli): scannable asm list output for large inventories (#192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,15 @@ List all global skills sorted by provider location:
 asm list --scope global --sort location
 ```
 
+When you have many skills installed, `asm list` offers condensed views:
+
+```bash
+asm list --summary            # counts by tool/scope/effort only
+asm list --compact            # one line per skill
+asm list --group-by tool      # group rows under tool headers
+asm list --limit 20           # show only the first 20 rows
+```
+
 Search for skills and output JSON:
 
 ```bash

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1381,6 +1381,67 @@ describe("parseArgs: additional flags", () => {
   });
 });
 
+// ─── parseArgs: large-list flags (issue #192) ───────────────────────────────
+
+describe("parseArgs: large-list flags (#192)", () => {
+  const parse = (...args: string[]) => parseArgs(["bun", "script.ts", ...args]);
+
+  test("parses --compact flag", () => {
+    const result = parse("list", "--compact");
+    expect(result.flags.compact).toBe(true);
+  });
+
+  test("defaults compact to false", () => {
+    const result = parse("list");
+    expect(result.flags.compact).toBe(false);
+  });
+
+  test("parses --summary flag", () => {
+    const result = parse("list", "--summary");
+    expect(result.flags.summary).toBe(true);
+  });
+
+  test("defaults summary to false", () => {
+    const result = parse("list");
+    expect(result.flags.summary).toBe(false);
+  });
+
+  test("parses --group-by tool", () => {
+    const result = parse("list", "--group-by", "tool");
+    expect(result.flags.groupBy).toBe("tool");
+  });
+
+  test("parses --group-by scope", () => {
+    const result = parse("list", "--group-by", "scope");
+    expect(result.flags.groupBy).toBe("scope");
+  });
+
+  test("parses --group-by effort", () => {
+    const result = parse("list", "--group-by", "effort");
+    expect(result.flags.groupBy).toBe("effort");
+  });
+
+  test("defaults groupBy to null", () => {
+    const result = parse("list");
+    expect(result.flags.groupBy).toBeNull();
+  });
+
+  test("parses --limit as non-negative integer", () => {
+    const result = parse("list", "--limit", "25");
+    expect(result.flags.limit).toBe(25);
+  });
+
+  test("defaults limit to 0", () => {
+    const result = parse("list");
+    expect(result.flags.limit).toBe(0);
+  });
+
+  test("parses --limit 0 as 'no limit'", () => {
+    const result = parse("list", "--limit", "0");
+    expect(result.flags.limit).toBe(0);
+  });
+});
+
 // ─── isCLIMode: newer commands ──────────────────────────────────────────────
 
 describe("isCLIMode: newer commands", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,11 @@ import {
   formatSearchResults,
   formatAvailableSearchResults,
   formatJSON,
+  formatListSummary,
+  formatCompactTable,
+  formatGroupByTable,
+  applyListLimit,
+  LARGE_LIST_THRESHOLD,
   ansi,
   colorEffort,
   shortenPath,
@@ -213,6 +218,21 @@ interface ParsedArgs {
     machine: boolean;
     noCache: boolean;
     fix: boolean;
+    /** `asm list --compact` — one-line-per-skill dense view (issue #192). */
+    compact: boolean;
+    /**
+     * `asm list --summary` — print only the compact summary (counts by
+     * tool/scope/effort), no full table (issue #192).
+     */
+    summary: boolean;
+    /** `asm list --group-by <tool|scope|effort>` axis (issue #192). */
+    groupBy: "tool" | "scope" | "effort" | null;
+    /**
+     * `asm list --limit <N>` — cap rendered rows; 0 or negative means no
+     * limit. When truncated, the formatter prints a "… N more not shown"
+     * hint (issue #192).
+     */
+    limit: number;
   };
 }
 
@@ -248,6 +268,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
       machine: false,
       noCache: false,
       fix: false,
+      compact: false,
+      summary: false,
+      groupBy: null,
+      limit: 0,
     },
   };
 
@@ -301,6 +325,30 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.flags.verbose = true;
     } else if (arg === "--flat") {
       result.flags.flat = true;
+    } else if (arg === "--compact") {
+      result.flags.compact = true;
+    } else if (arg === "--summary") {
+      result.flags.summary = true;
+    } else if (arg === "--group-by") {
+      i++;
+      const val = args[i];
+      if (val === "tool" || val === "scope" || val === "effort") {
+        result.flags.groupBy = val;
+      } else {
+        error(`Invalid --group-by: "${val}". Must be tool, scope, or effort.`);
+        process.exit(2);
+      }
+    } else if (arg === "--limit") {
+      i++;
+      const val = args[i];
+      const n = Number(val);
+      if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+        error(
+          `Invalid --limit: "${val}". Must be a non-negative integer (0 means no limit).`,
+        );
+        process.exit(2);
+      }
+      result.flags.limit = n;
     } else if (arg === "--installed") {
       result.flags.installed = true;
     } else if (arg === "--available") {
@@ -423,13 +471,19 @@ function printListHelp() {
   console.log(`${ansi.bold("Usage:")} asm list [options]
 
 List all discovered skills. By default, skills installed across multiple
-tools are grouped into a single row with tool badges.
+tools are grouped into a single row with tool badges. When more than
+${LARGE_LIST_THRESHOLD} skills are present, a compact summary is
+automatically prepended above the table.
 
 ${ansi.bold("Options:")}
   --sort <field>       Sort by: name, version, or location (default: name)
   -s, --scope <s>      Filter: global, project, or both (default: both)
   -p, --tool <p>       Filter by tool (claude, codex, openclaw, agents)
   --flat               Show one row per tool instance (ungrouped)
+  --compact            One-line-per-skill dense view
+  --summary            Print only the summary (counts by tool/scope/effort)
+  --group-by <axis>    Group rows under headers (axis: tool | scope | effort)
+  --limit <N>          Limit rendered rows (0 = no limit)
   --json               Output as JSON array
   --machine            Output in stable machine-readable v1 envelope format
   --no-color           Disable ANSI colors
@@ -438,6 +492,12 @@ ${ansi.bold("Options:")}
 ${ansi.bold("Examples:")}
   asm list                          ${ansi.dim("List all skills (grouped)")}
   asm list --flat                   ${ansi.dim("One row per tool instance")}
+  asm list --compact                ${ansi.dim("One line per skill (dense)")}
+  asm list --summary                ${ansi.dim("Counts by tool/scope/effort only")}
+  asm list --group-by tool          ${ansi.dim("Group rows under tool headers")}
+  asm list --group-by scope         ${ansi.dim("Group rows under scope headers")}
+  asm list --group-by effort        ${ansi.dim("Group rows under effort headers")}
+  asm list --limit 20               ${ansi.dim("Show first 20 rows only")}
   asm list -p claude                ${ansi.dim("Only Claude Code skills")}
   asm list -s project               ${ansi.dim("Only project-scoped skills")}
   asm list --sort version           ${ansi.dim("Sort by version")}
@@ -674,8 +734,31 @@ async function cmdList(args: ParsedArgs) {
       output += `\n${ansi.yellow(`${withWarnings.length} skill${withWarnings.length === 1 ? "" : "s"} with warnings -- use --json for details`)}`;
     }
     console.log(output);
+  } else if (args.flags.summary) {
+    // `asm list --summary` — print just the compact summary, no table.
+    console.log(formatListSummary(sorted));
+  } else if (args.flags.groupBy) {
+    // `asm list --group-by <axis>` — rows grouped under category headers.
+    const { skills: limited, hint } = applyListLimit(sorted, args.flags.limit);
+    console.log(formatGroupByTable(limited, args.flags.groupBy));
+    if (hint) console.log(hint);
+  } else if (args.flags.compact) {
+    // `asm list --compact` — one-line-per-skill dense view.
+    const { skills: limited, hint } = applyListLimit(sorted, args.flags.limit);
+    console.log(formatCompactTable(limited));
+    if (hint) console.log(hint);
   } else {
-    console.log(formatGroupedTable(sorted));
+    // Default grouped table. When the inventory is large, prepend a compact
+    // summary section so users see inventory shape before the full table.
+    const lines: string[] = [];
+    if (sorted.length > LARGE_LIST_THRESHOLD) {
+      lines.push(formatListSummary(sorted, { showHint: false }));
+      lines.push("");
+    }
+    const { skills: limited, hint } = applyListLimit(sorted, args.flags.limit);
+    lines.push(formatGroupedTable(limited));
+    if (hint) lines.push(hint);
+    console.log(lines.join("\n"));
   }
 }
 

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -15,6 +15,11 @@ import {
   formatAllowedTools,
   HIGH_RISK_TOOLS,
   MEDIUM_RISK_TOOLS,
+  formatListSummary,
+  formatCompactTable,
+  formatGroupByTable,
+  applyListLimit,
+  LARGE_LIST_THRESHOLD,
 } from "./formatter";
 import type { AvailableSkillResult } from "./formatter";
 import type { SkillInfo } from "./utils/types";
@@ -1138,5 +1143,408 @@ describe("formatGroupedTable token column", () => {
     const output = formatGroupedTable(skills);
     // "~42 tokens" should appear somewhere for the tiny skill row
     expect(output).toContain("~42 tokens");
+  });
+});
+
+// ─── Large-inventory UX (issue #192) ────────────────────────────────────────
+
+/** Build N distinct skills quickly for threshold/volume tests. */
+function makeManySkills(
+  n: number,
+  overrides: (i: number) => Partial<SkillInfo> = () => ({}),
+): SkillInfo[] {
+  return Array.from({ length: n }, (_, i) =>
+    makeSkill({
+      name: `skill-${i}`,
+      dirName: `skill-${i}`,
+      path: `/home/user/.claude/skills/skill-${i}`,
+      ...overrides(i),
+    }),
+  );
+}
+
+describe("LARGE_LIST_THRESHOLD", () => {
+  test("exports the documented threshold constant", () => {
+    expect(typeof LARGE_LIST_THRESHOLD).toBe("number");
+    expect(LARGE_LIST_THRESHOLD).toBeGreaterThan(0);
+    // Anchor the value so tuning requires an explicit test change.
+    expect(LARGE_LIST_THRESHOLD).toBe(50);
+  });
+});
+
+describe("formatListSummary", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("returns 'No skills found.' for empty array", () => {
+    expect(formatListSummary([])).toBe("No skills found.");
+  });
+
+  test("shows total counts, tools, and scopes in header", () => {
+    const skills = [
+      makeSkill({ name: "a", dirName: "a", scope: "global" }),
+      makeSkill({
+        name: "b",
+        dirName: "b",
+        scope: "project",
+        path: "/other",
+      }),
+    ];
+    const output = formatListSummary(skills);
+    expect(output).toContain("2 skills");
+    expect(output).toContain("(2 unique)");
+    expect(output).toContain("1 global, 1 project");
+  });
+
+  test("lists top tools with install counts", () => {
+    const skills = [
+      ...makeManySkills(3, () => ({
+        provider: "claude",
+        providerLabel: "Claude Code",
+      })),
+      ...makeManySkills(2, (i) => ({
+        name: `codex-${i}`,
+        dirName: `codex-${i}`,
+        provider: "codex",
+        providerLabel: "Codex",
+        path: `/codex-${i}`,
+      })),
+    ];
+    const output = formatListSummary(skills);
+    expect(output).toContain("Top tools:");
+    // Claude has 3, Codex has 2 — both should appear with counts
+    expect(output).toContain("[Claude Code]");
+    expect(output).toContain("3 skills");
+    expect(output).toContain("[Codex]");
+    expect(output).toContain("2 skills");
+  });
+
+  test("shows scope breakdown with singular/plural", () => {
+    const skills = [
+      makeSkill({ name: "a", dirName: "a", scope: "global" }),
+      makeSkill({
+        name: "b",
+        dirName: "b",
+        scope: "project",
+        path: "/other",
+      }),
+    ];
+    const output = formatListSummary(skills);
+    expect(output).toContain("global   1 skill");
+    expect(output).toContain("project  1 skill");
+  });
+
+  test("shows top efforts when at least one skill has an effort", () => {
+    const skills = [
+      makeSkill({ name: "a", dirName: "a", effort: "low" }),
+      makeSkill({
+        name: "b",
+        dirName: "b",
+        effort: "low",
+        path: "/b",
+      }),
+      makeSkill({
+        name: "c",
+        dirName: "c",
+        effort: "high",
+        path: "/c",
+      }),
+    ];
+    const output = formatListSummary(skills);
+    expect(output).toContain("Top efforts:");
+    expect(output).toContain("low");
+    expect(output).toContain("high");
+    // "low" count should be 2 (highest)
+    expect(output).toMatch(/low\s+2 skills/);
+  });
+
+  test("omits Top efforts section when no skill has an effort", () => {
+    const skills = [makeSkill({ effort: undefined })];
+    const output = formatListSummary(skills);
+    expect(output).not.toContain("Top efforts:");
+  });
+
+  test("showHint:true appends refinement tip by default", () => {
+    const output = formatListSummary([makeSkill()]);
+    expect(output).toContain("Tip:");
+    expect(output).toContain("asm list -p");
+  });
+
+  test("showHint:false hides refinement tip", () => {
+    const output = formatListSummary([makeSkill()], { showHint: false });
+    expect(output).not.toContain("Tip:");
+  });
+
+  test("respects topN to cap the tools list", () => {
+    // Create 7 different providers to verify topN limits them
+    const skills = [
+      ...makeManySkills(5, () => ({
+        provider: "claude",
+        providerLabel: "Claude Code",
+      })),
+      ...makeManySkills(4, (i) => ({
+        name: `codex-${i}`,
+        dirName: `codex-${i}`,
+        provider: "codex",
+        providerLabel: "Codex",
+        path: `/codex-${i}`,
+      })),
+      ...makeManySkills(3, (i) => ({
+        name: `oc-${i}`,
+        dirName: `oc-${i}`,
+        provider: "openclaw",
+        providerLabel: "OpenClaw",
+        path: `/oc-${i}`,
+      })),
+      ...makeManySkills(2, (i) => ({
+        name: `ag-${i}`,
+        dirName: `ag-${i}`,
+        provider: "agents",
+        providerLabel: "Agents",
+        path: `/ag-${i}`,
+      })),
+      ...makeManySkills(1, (i) => ({
+        name: `cus-${i}`,
+        dirName: `cus-${i}`,
+        provider: "custom",
+        providerLabel: "Custom",
+        path: `/cus-${i}`,
+      })),
+    ];
+    const output = formatListSummary(skills, { topN: 2 });
+    const top = output.split("Top tools:")[1]?.split("Scopes:")[0] ?? "";
+    // With topN=2, only the two highest-count tools are listed
+    expect(top).toContain("[Claude Code]");
+    expect(top).toContain("[Codex]");
+    // Lower-count providers should NOT be listed in topN=2
+    expect(top).not.toContain("[Custom]");
+  });
+});
+
+describe("formatCompactTable", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("returns 'No skills found.' for empty array", () => {
+    expect(formatCompactTable([])).toBe("No skills found.");
+  });
+
+  test("produces exactly one line per unique skill plus footer", () => {
+    const skills = makeManySkills(3);
+    const output = formatCompactTable(skills);
+    const lines = output.split("\n");
+    // 3 data rows + blank line + footer = 5
+    expect(lines.length).toBe(5);
+  });
+
+  test("shows skill name, version, tool, and scope", () => {
+    const output = formatCompactTable([
+      makeSkill({ name: "ship", version: "2.5.0" }),
+    ]);
+    expect(output).toContain("ship");
+    expect(output).toContain("2.5.0");
+    expect(output).toContain("[Claude Code]");
+    expect(output).toContain("global");
+  });
+
+  test("footer shows total and unique counts", () => {
+    const output = formatCompactTable(makeManySkills(3));
+    expect(output).toContain("3 skills (3 unique)");
+  });
+
+  test("groups skills that share dirName+scope like the full table", () => {
+    const skills = [
+      makeSkill({
+        dirName: "dup",
+        name: "dup",
+        provider: "claude",
+        providerLabel: "Claude Code",
+      }),
+      makeSkill({
+        dirName: "dup",
+        name: "dup",
+        provider: "codex",
+        providerLabel: "Codex",
+        path: "/other",
+      }),
+    ];
+    const output = formatCompactTable(skills);
+    expect(output).toContain("2 skills (1 unique)");
+    expect(output).toContain("[Claude Code]");
+    expect(output).toContain("[Codex]");
+  });
+});
+
+describe("formatGroupByTable", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("returns 'No skills found.' for empty array", () => {
+    expect(formatGroupByTable([], "tool")).toBe("No skills found.");
+  });
+
+  test("groups by tool with count in header", () => {
+    const skills = [
+      ...makeManySkills(2, (i) => ({
+        name: `claude-${i}`,
+        dirName: `claude-${i}`,
+        provider: "claude",
+        providerLabel: "Claude Code",
+      })),
+      ...makeManySkills(3, (i) => ({
+        name: `codex-${i}`,
+        dirName: `codex-${i}`,
+        provider: "codex",
+        providerLabel: "Codex",
+        path: `/codex-${i}`,
+      })),
+    ];
+    const output = formatGroupByTable(skills, "tool");
+    // Headers
+    expect(output).toContain("Codex (3)");
+    expect(output).toContain("Claude Code (2)");
+    // Codex should come first (higher count)
+    const codexIdx = output.indexOf("Codex (3)");
+    const claudeIdx = output.indexOf("Claude Code (2)");
+    expect(codexIdx).toBeGreaterThanOrEqual(0);
+    expect(claudeIdx).toBeGreaterThan(codexIdx);
+  });
+
+  test("groups by scope", () => {
+    const skills = [
+      makeSkill({ name: "a", dirName: "a", scope: "global" }),
+      makeSkill({
+        name: "b",
+        dirName: "b",
+        scope: "project",
+        path: "/b",
+      }),
+      makeSkill({
+        name: "c",
+        dirName: "c",
+        scope: "project",
+        path: "/c",
+      }),
+    ];
+    const output = formatGroupByTable(skills, "scope");
+    expect(output).toContain("project (2)");
+    expect(output).toContain("global (1)");
+  });
+
+  test("groups by effort with (unset) bucket for missing values", () => {
+    const skills = [
+      makeSkill({ name: "a", dirName: "a", effort: "low" }),
+      makeSkill({
+        name: "b",
+        dirName: "b",
+        effort: undefined,
+        path: "/b",
+      }),
+    ];
+    const output = formatGroupByTable(skills, "effort");
+    expect(output).toContain("low (1)");
+    expect(output).toContain("(unset) (1)");
+  });
+
+  test("footer mentions the axis", () => {
+    const output = formatGroupByTable(makeManySkills(2), "tool");
+    expect(output).toContain("grouped by tool");
+  });
+
+  test("same skill counted under each of its installed tools", () => {
+    // A shared dirName installed in two tools — should appear under both
+    // when grouping by tool.
+    const skills = [
+      makeSkill({
+        dirName: "dup",
+        name: "dup",
+        provider: "claude",
+        providerLabel: "Claude Code",
+      }),
+      makeSkill({
+        dirName: "dup",
+        name: "dup",
+        provider: "codex",
+        providerLabel: "Codex",
+        path: "/other",
+      }),
+    ];
+    const output = formatGroupByTable(skills, "tool");
+    expect(output).toContain("Claude Code (1)");
+    expect(output).toContain("Codex (1)");
+  });
+});
+
+describe("applyListLimit", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("returns list unchanged when limit is 0", () => {
+    const skills = makeManySkills(5);
+    const { skills: out, hint } = applyListLimit(skills, 0);
+    expect(out.length).toBe(5);
+    expect(hint).toBe("");
+  });
+
+  test("returns list unchanged when limit is negative", () => {
+    const skills = makeManySkills(5);
+    const { skills: out, hint } = applyListLimit(skills, -1);
+    expect(out.length).toBe(5);
+    expect(hint).toBe("");
+  });
+
+  test("returns list unchanged when length <= limit", () => {
+    const skills = makeManySkills(5);
+    const { skills: out, hint } = applyListLimit(skills, 10);
+    expect(out.length).toBe(5);
+    expect(hint).toBe("");
+  });
+
+  test("truncates when length > limit and returns hint", () => {
+    const skills = makeManySkills(10);
+    const { skills: out, hint } = applyListLimit(skills, 3);
+    expect(out.length).toBe(3);
+    expect(hint).toContain("7 more not shown");
+    expect(hint).toContain("--limit");
+  });
+});
+
+describe("formatGroupedTable large-list hints", () => {
+  beforeEach(() => {
+    (globalThis as any).__CLI_NO_COLOR = true;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__CLI_NO_COLOR;
+  });
+
+  test("output unchanged for inventories <= threshold (no Top tools/Tip)", () => {
+    // Build exactly threshold skills — should NOT add the new hint lines.
+    const skills = makeManySkills(LARGE_LIST_THRESHOLD);
+    const output = formatGroupedTable(skills);
+    expect(output).not.toContain("Top tools:");
+    expect(output).not.toContain("Tip:");
+  });
+
+  test("adds Top tools + Tip below footer when > threshold", () => {
+    const skills = makeManySkills(LARGE_LIST_THRESHOLD + 1);
+    const output = formatGroupedTable(skills);
+    expect(output).toContain("Top tools:");
+    expect(output).toContain("Tip:");
   });
 });

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -1525,7 +1525,7 @@ describe("applyListLimit", () => {
   });
 });
 
-describe("formatGroupedTable large-list hints", () => {
+describe("formatGroupedTable large-list output", () => {
   beforeEach(() => {
     (globalThis as any).__CLI_NO_COLOR = true;
   });
@@ -1533,18 +1533,21 @@ describe("formatGroupedTable large-list hints", () => {
     delete (globalThis as any).__CLI_NO_COLOR;
   });
 
-  test("output unchanged for inventories <= threshold (no Top tools/Tip)", () => {
-    // Build exactly threshold skills — should NOT add the new hint lines.
-    const skills = makeManySkills(LARGE_LIST_THRESHOLD);
-    const output = formatGroupedTable(skills);
-    expect(output).not.toContain("Top tools:");
-    expect(output).not.toContain("Tip:");
+  test("output shape is the same for small and large inventories", () => {
+    // formatGroupedTable stays pure — "Top tools" and the refinement Tip are
+    // now provided by formatListSummary (prepended by cmdList when the set
+    // is large). This keeps the renderer easy to reason about and avoids
+    // duplicating the same info in both summary and footer.
+    const small = formatGroupedTable(makeManySkills(3));
+    const large = formatGroupedTable(makeManySkills(LARGE_LIST_THRESHOLD + 1));
+    expect(small).not.toContain("Top tools:");
+    expect(small).not.toContain("Tip:");
+    expect(large).not.toContain("Top tools:");
+    expect(large).not.toContain("Tip:");
   });
 
-  test("adds Top tools + Tip below footer when > threshold", () => {
-    const skills = makeManySkills(LARGE_LIST_THRESHOLD + 1);
-    const output = formatGroupedTable(skills);
-    expect(output).toContain("Top tools:");
-    expect(output).toContain("Tip:");
+  test("footer summary still renders for any size", () => {
+    const output = formatGroupedTable(makeManySkills(3));
+    expect(output).toMatch(/3 skills \(3 unique\)/);
   });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -203,6 +203,250 @@ function groupSkills(skills: SkillInfo[]): GroupedSkill[] {
   return result;
 }
 
+/**
+ * Threshold above which `asm list` automatically prepends a compact summary
+ * section before the full table. Chosen so that installations with "many"
+ * skills (issue #192) surface a scannable overview, while small inventories
+ * keep the existing output verbatim (regression safety for formatter tests).
+ */
+export const LARGE_LIST_THRESHOLD = 50;
+
+/**
+ * Build a compact, human-scannable summary of a skill list.
+ *
+ * Used in two places:
+ *   1. `asm list --summary` — prints the summary alone, no table.
+ *   2. `asm list` when the result set exceeds LARGE_LIST_THRESHOLD — the
+ *      summary is prepended above the full grouped table so users can see
+ *      the shape of their inventory at a glance.
+ *
+ * The summary includes total counts, top tools, top scopes, and top efforts
+ * (up to `topN` entries per category). A trailing hint suggests refining
+ * commands like `asm list -p <tool>` or `asm search <query>`.
+ */
+export function formatListSummary(
+  skills: SkillInfo[],
+  options: { topN?: number; showHint?: boolean } = {},
+): string {
+  const topN = options.topN ?? 5;
+  const showHint = options.showHint ?? true;
+
+  if (skills.length === 0) {
+    return "No skills found.";
+  }
+
+  const lines: string[] = [];
+  const grouped = groupSkills(skills);
+  const uniqueCount = grouped.length;
+  const totalCount = skills.length;
+  const providerSet = new Set(skills.map((s) => s.provider));
+  const globalCount = skills.filter((s) => s.scope === "global").length;
+  const projectCount = skills.filter((s) => s.scope === "project").length;
+
+  const header = `${totalCount} skills (${uniqueCount} unique) across ${providerSet.size} tools | ${globalCount} global, ${projectCount} project`;
+  lines.push(useColor() ? ansi.bold(header) : header);
+  lines.push("");
+
+  // Top tools (by skill install count)
+  const toolCounts = new Map<string, { label: string; count: number }>();
+  for (const s of skills) {
+    const entry = toolCounts.get(s.provider) ?? {
+      label: s.providerLabel,
+      count: 0,
+    };
+    entry.count += 1;
+    toolCounts.set(s.provider, entry);
+  }
+  const topTools = [...toolCounts.entries()]
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, topN);
+
+  lines.push(useColor() ? ansi.bold("Top tools:") : "Top tools:");
+  for (const [provider, { label, count }] of topTools) {
+    const badge = useColor()
+      ? colorProvider(provider, `[${label}]`)
+      : `[${label}]`;
+    lines.push(`  ${badge}  ${count} skill${count === 1 ? "" : "s"}`);
+  }
+
+  // Scope breakdown (always full — only 2 scopes)
+  lines.push("");
+  lines.push(useColor() ? ansi.bold("Scopes:") : "Scopes:");
+  lines.push(`  global   ${globalCount} skill${globalCount === 1 ? "" : "s"}`);
+  lines.push(
+    `  project  ${projectCount} skill${projectCount === 1 ? "" : "s"}`,
+  );
+
+  // Top efforts (only if at least one skill has an effort)
+  const effortCounts = new Map<string, number>();
+  for (const s of skills) {
+    if (s.effort) {
+      effortCounts.set(s.effort, (effortCounts.get(s.effort) ?? 0) + 1);
+    }
+  }
+  if (effortCounts.size > 0) {
+    const topEfforts = [...effortCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, topN);
+    lines.push("");
+    lines.push(useColor() ? ansi.bold("Top efforts:") : "Top efforts:");
+    for (const [effort, count] of topEfforts) {
+      const coloredEffort = colorEffort(effort);
+      lines.push(
+        `  ${coloredEffort.padEnd(6)}  ${count} skill${count === 1 ? "" : "s"}`,
+      );
+    }
+  }
+
+  if (showHint) {
+    lines.push("");
+    const hint =
+      "Tip: refine with `asm list -p <tool>`, `asm search <query>`, or `asm list --compact`";
+    lines.push(useColor() ? ansi.dim(hint) : hint);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * One-line-per-skill compact table format.
+ *
+ * Designed for users with 100+ skills who want to scan their whole inventory
+ * without sacrificing readability. Each row is `name  version  [tools]  scope`
+ * with aligned columns and colorized provider badges.
+ */
+export function formatCompactTable(skills: SkillInfo[]): string {
+  if (skills.length === 0) {
+    return "No skills found.";
+  }
+
+  const grouped = groupSkills(skills);
+  const lines: string[] = [];
+
+  const nameW = Math.max(4, ...grouped.map((g) => g.name.length));
+  const versionW = Math.max(7, ...grouped.map((g) => g.version.length));
+
+  const providerStrs = grouped.map((g) =>
+    g.providers.map((p) => providerBadge(p.provider, p.label)).join(" "),
+  );
+  const providerPlain = grouped.map((g) =>
+    g.providers.map((p) => `[${p.label}]`).join(" "),
+  );
+  const providerW = Math.max(5, ...providerPlain.map((s) => s.length));
+  const scopeW = 7;
+
+  const pad = (s: string, w: number) => s.padEnd(w);
+
+  for (let i = 0; i < grouped.length; i++) {
+    const g = grouped[i];
+    const name = pad(g.name, nameW);
+    const version = ansi.dim(pad(g.version, versionW));
+    const provPadding = providerW - providerPlain[i].length;
+    const prov = providerStrs[i] + " ".repeat(Math.max(0, provPadding));
+    const scope = ansi.dim(pad(g.scope, scopeW));
+    lines.push(`${name}  ${version}  ${prov}  ${scope}`);
+  }
+
+  // Footer — short, just total/unique count
+  lines.push("");
+  const totalCount = skills.length;
+  const uniqueCount = grouped.length;
+  const footer = `${totalCount} skills (${uniqueCount} unique)`;
+  lines.push(ansi.dim(footer));
+
+  return lines.join("\n");
+}
+
+/** Supported group-by axes for `asm list --group-by <axis>`. */
+export type GroupByAxis = "tool" | "scope" | "effort";
+
+/**
+ * Group-by formatter: rows are collapsed under category headers. Each
+ * skill appears once per axis value (e.g., skills installed in multiple
+ * tools appear under each tool when grouping by `tool`). Uses the compact
+ * one-line-per-skill renderer under each header to keep output dense.
+ */
+export function formatGroupByTable(
+  skills: SkillInfo[],
+  axis: GroupByAxis,
+): string {
+  if (skills.length === 0) {
+    return "No skills found.";
+  }
+
+  const buckets = new Map<string, SkillInfo[]>();
+
+  const labelFor = (s: SkillInfo): string[] => {
+    switch (axis) {
+      case "tool":
+        return [s.providerLabel];
+      case "scope":
+        return [s.scope];
+      case "effort":
+        return [s.effort && s.effort.length > 0 ? s.effort : "(unset)"];
+    }
+  };
+
+  for (const s of skills) {
+    for (const label of labelFor(s)) {
+      const list = buckets.get(label) ?? [];
+      list.push(s);
+      buckets.set(label, list);
+    }
+  }
+
+  // Deterministic ordering: by count desc, then alpha
+  const ordered = [...buckets.entries()].sort((a, b) => {
+    if (b[1].length !== a[1].length) return b[1].length - a[1].length;
+    return a[0].localeCompare(b[0]);
+  });
+
+  const lines: string[] = [];
+  for (const [label, members] of ordered) {
+    const header = `${label} (${members.length})`;
+    lines.push(useColor() ? ansi.bold(header) : header);
+    // Reuse compact formatter for dense rows
+    const body = formatCompactTable(members);
+    // Drop the trailing footer from compact (we'll add one at the bottom)
+    const bodyLines = body.split("\n");
+    // Indent every non-empty body line and drop final footer (last two lines)
+    const indented = bodyLines
+      .slice(0, -2)
+      .filter((l) => l.length > 0)
+      .map((l) => `  ${l}`);
+    lines.push(...indented);
+    lines.push("");
+  }
+
+  // Footer
+  const totalCount = skills.length;
+  const uniqueCount = groupSkills(skills).length;
+  const footer = `${totalCount} skills (${uniqueCount} unique), grouped by ${axis}`;
+  lines.push(ansi.dim(footer));
+
+  return lines.join("\n");
+}
+
+/**
+ * Truncate a skill list to `limit` entries when `limit > 0`, returning the
+ * slice plus a hint line for the caller to append. When no truncation is
+ * needed, returns the original list and an empty hint.
+ */
+export function applyListLimit(
+  skills: SkillInfo[],
+  limit: number,
+): { skills: SkillInfo[]; hint: string } {
+  if (!Number.isFinite(limit) || limit <= 0 || skills.length <= limit) {
+    return { skills, hint: "" };
+  }
+  const truncated = skills.slice(0, limit);
+  const remaining = skills.length - limit;
+  const hint = ansi.dim(
+    `... ${remaining} more not shown. Re-run with --limit ${skills.length} (or 0) to see all, or refine with -p <tool>.`,
+  );
+  return { skills: truncated, hint };
+}
+
 export function formatGroupedTable(skills: SkillInfo[]): string {
   if (skills.length === 0) {
     return "No skills found.";
@@ -290,6 +534,32 @@ export function formatGroupedTable(skills: SkillInfo[]): string {
   lines.push("");
   const footer = `${totalCount} skills (${uniqueCount} unique) across ${providerSet.size} tools | ${globalCount} global, ${projectCount} project`;
   lines.push(ansi.dim(footer));
+
+  // Richer footer hints for large inventories (issue #192):
+  // surface top tools and a refinement hint so users can narrow the list
+  // without having to re-read the whole table.
+  if (totalCount > LARGE_LIST_THRESHOLD) {
+    const toolCounts = new Map<string, { label: string; count: number }>();
+    for (const s of skills) {
+      const entry = toolCounts.get(s.provider) ?? {
+        label: s.providerLabel,
+        count: 0,
+      };
+      entry.count += 1;
+      toolCounts.set(s.provider, entry);
+    }
+    const topTools = [...toolCounts.entries()]
+      .sort((a, b) => b[1].count - a[1].count)
+      .slice(0, 3)
+      .map(([, v]) => `${v.label} ${v.count}`)
+      .join(", ");
+    lines.push(ansi.dim(`Top tools: ${topTools}`));
+    lines.push(
+      ansi.dim(
+        "Tip: refine with `asm list -p <tool>`, `asm search <query>`, `asm list --compact`, or `asm list --summary`.",
+      ),
+    );
+  }
 
   return lines.join("\n");
 }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -292,8 +292,12 @@ export function formatListSummary(
     lines.push(useColor() ? ansi.bold("Top efforts:") : "Top efforts:");
     for (const [effort, count] of topEfforts) {
       const coloredEffort = colorEffort(effort);
+      // Pad by visual width, not string length — `colorEffort` wraps the
+      // value in ANSI escape codes when colors are enabled, which inflates
+      // `.padEnd()` char count and breaks alignment in real terminals.
+      const effortPad = Math.max(0, 6 - effort.length);
       lines.push(
-        `  ${coloredEffort.padEnd(6)}  ${count} skill${count === 1 ? "" : "s"}`,
+        `  ${coloredEffort}${" ".repeat(effortPad)}  ${count} skill${count === 1 ? "" : "s"}`,
       );
     }
   }
@@ -534,32 +538,6 @@ export function formatGroupedTable(skills: SkillInfo[]): string {
   lines.push("");
   const footer = `${totalCount} skills (${uniqueCount} unique) across ${providerSet.size} tools | ${globalCount} global, ${projectCount} project`;
   lines.push(ansi.dim(footer));
-
-  // Richer footer hints for large inventories (issue #192):
-  // surface top tools and a refinement hint so users can narrow the list
-  // without having to re-read the whole table.
-  if (totalCount > LARGE_LIST_THRESHOLD) {
-    const toolCounts = new Map<string, { label: string; count: number }>();
-    for (const s of skills) {
-      const entry = toolCounts.get(s.provider) ?? {
-        label: s.providerLabel,
-        count: 0,
-      };
-      entry.count += 1;
-      toolCounts.set(s.provider, entry);
-    }
-    const topTools = [...toolCounts.entries()]
-      .sort((a, b) => b[1].count - a[1].count)
-      .slice(0, 3)
-      .map(([, v]) => `${v.label} ${v.count}`)
-      .join(", ");
-    lines.push(ansi.dim(`Top tools: ${topTools}`));
-    lines.push(
-      ansi.dim(
-        "Tip: refine with `asm list -p <tool>`, `asm search <query>`, `asm list --compact`, or `asm list --summary`.",
-      ),
-    );
-  }
 
   return lines.join("\n");
 }

--- a/tests/e2e/bun-e2e.test.ts
+++ b/tests/e2e/bun-e2e.test.ts
@@ -56,6 +56,96 @@ describe("Bun dist E2E: list", () => {
     const data = JSON.parse(stdout);
     expect(Array.isArray(data)).toBe(true);
   });
+
+  // ─── Large-inventory UX flags (issue #192) ────────────────────────────
+
+  test("--compact exits 0 and does not crash", async () => {
+    const { exitCode } = await runBunDist("list", "--compact");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--summary exits 0 and does not crash", async () => {
+    const { exitCode } = await runBunDist("list", "--summary");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--group-by tool exits 0", async () => {
+    const { exitCode } = await runBunDist("list", "--group-by", "tool");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--group-by scope exits 0", async () => {
+    const { exitCode } = await runBunDist("list", "--group-by", "scope");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--group-by effort exits 0", async () => {
+    const { exitCode } = await runBunDist("list", "--group-by", "effort");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--group-by invalid exits 2 with helpful error", async () => {
+    const { exitCode, stderr } = await runBunDist(
+      "list",
+      "--group-by",
+      "bogus",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Invalid --group-by");
+  });
+
+  test("--limit 5 exits 0", async () => {
+    const { exitCode } = await runBunDist("list", "--limit", "5");
+    expect(exitCode).toBe(0);
+  });
+
+  test("--limit negative exits 2 with helpful error", async () => {
+    const { exitCode, stderr } = await runBunDist("list", "--limit", "-1");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Invalid --limit");
+  });
+
+  test("--limit non-integer exits 2 with helpful error", async () => {
+    const { exitCode, stderr } = await runBunDist("list", "--limit", "abc");
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("Invalid --limit");
+  });
+
+  test("--json is unaffected by --compact (scripting compat)", async () => {
+    // --json takes precedence — output must remain a plain JSON array.
+    const { stdout, exitCode } = await runBunDist(
+      "list",
+      "--json",
+      "--compact",
+    );
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout);
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  test("--machine is unaffected by --summary (scripting compat)", async () => {
+    // --machine takes precedence — envelope shape is unchanged.
+    const { stdout, exitCode } = await runBunDist(
+      "list",
+      "--machine",
+      "--summary",
+    );
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.version).toBe(1);
+    expect(envelope.command).toBe("list");
+    expect(envelope.status).toBe("ok");
+    expect(Array.isArray(envelope.data)).toBe(true);
+  });
+
+  test("help mentions the new flags", async () => {
+    const { stdout, exitCode } = await runBunDist("list", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--compact");
+    expect(stdout).toContain("--summary");
+    expect(stdout).toContain("--group-by");
+    expect(stdout).toContain("--limit");
+  });
 });
 
 describe("Bun dist E2E: config", () => {


### PR DESCRIPTION
Closes #192

## Summary

`asm list` now stays readable and scannable for users with many installed skills. Four new flags, a compact auto-summary that's prepended above the default table once the inventory exceeds 50 skills, and zero changes to the existing `--flat`, `--json`, and `--machine` output so scripts keep working.

## Approach

Balanced refactor:
- Add pure formatter helpers (`formatListSummary`, `formatCompactTable`, `formatGroupByTable`, `applyListLimit`) alongside the existing `formatGroupedTable` — no existing output was repainted for small lists.
- Thread four new flags into `parseArgs` / `cmdList` / `printListHelp`.
- Prepend the summary in the default view only when `skills.length > LARGE_LIST_THRESHOLD` (50). Below that, output is byte-for-byte identical to before.

The new `--group-by` axis is `tool | scope | effort` — all real `SkillInfo` fields. `category` from the issue text was deliberately dropped because there is no underlying data model for it.

## Changes

| File | Change |
|------|--------|
| `src/formatter.ts` | Add `LARGE_LIST_THRESHOLD`, `formatListSummary`, `formatCompactTable`, `formatGroupByTable`, `applyListLimit`. |
| `src/cli.ts` | New flags `--compact`, `--summary`, `--group-by`, `--limit`; updated `cmdList` dispatch; updated help text. |
| `src/formatter.test.ts` | 27 new tests covering every helper + threshold regression guard. |
| `src/cli.test.ts` | 11 new parseArgs tests for the new flags. |
| `tests/e2e/bun-e2e.test.ts` | 11 new e2e tests: each flag runs, invalid values exit 2, scripting paths unaffected. |
| `README.md` | New examples section for the condensed-view flags. |

## Test Results

- Unit tests: 1484 passed (of which 49 new for this PR)
- E2E tests: 78 passed (of which 11 new for this PR)
- Typecheck: passed
- Build: passed
- QA cycles: 1 (advisor caught an ANSI-width padding bug and a duplicated footer — both fixed in a follow-up commit on the branch)

## Acceptance Criteria

- [x] (high) When >50 skills are listed, output includes a compact/grouped summary section at the top of the full table (`LARGE_LIST_THRESHOLD = 50`).
- [x] (medium) New `--compact` (one-line-per-skill) and `--group-by <tool|scope|effort>` flags provide condensed modes.
- [x] (medium) `--limit N` option paginates long output with an actionable "N more not shown" hint.
- [x] (medium) Footer summary is richer via the prepended `formatListSummary` — top tools, scopes, top efforts, and a refinement hint.
- [x] (low) `--flat`, `--json`, `--machine` outputs remain unchanged (verified by e2e tests and by running the existing formatter test suite unmodified).

## Manual verification (602-skill inventory)

```
$ asm list --summary
602 skills (210 unique) across 11 tools | 580 global, 22 project

Top tools:
  [Claude Code]  178 skills
  [Agents]  94 skills
  [Codex]  86 skills
  [OpenCode]  73 skills
  [OpenClaw]  69 skills
...
```

```
$ asm list --compact --limit 5
access             0.0.0  [Plugin (claude-plugins-official)]  global
Agent Development  0.1.0  [Plugin (claude-code-plugins)]      global
...
5 skills (3 unique)
... 597 more not shown. Re-run with --limit 602 (or 0) to see all, or refine with -p <tool>.
```