### PR TITLE
feat(cli): asm eval accepts GitHub refs and batch-evaluates collections (#193, #194)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1733,6 +1733,151 @@ describe("CLI integration: eval", () => {
     expect(stderr).toMatch(/^Error: /m);
     expect(stderr).toMatch(/does not exist/i);
   });
+
+  // ─── #194: batch eval for collection locations ────────────────────────
+
+  test("eval on a collection directory evaluates every child with SKILL.md", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eval-batch-"));
+    try {
+      await mkdir(join(root, "alpha"), { recursive: true });
+      await mkdir(join(root, "beta"), { recursive: true });
+      await writeFile(
+        join(root, "alpha", "SKILL.md"),
+        "---\nname: alpha\ndescription: Do alpha when asked.\n---\n\n## When to Use\n- thing\n\n## Instructions\n1. act\n",
+        "utf-8",
+      );
+      await writeFile(
+        join(root, "beta", "SKILL.md"),
+        "---\nname: beta\ndescription: Do beta when asked.\n---\n\n## When to Use\n- thing\n\n## Instructions\n1. act\n",
+        "utf-8",
+      );
+      // A non-skill folder must be skipped gracefully.
+      await mkdir(join(root, "not-a-skill"), { recursive: true });
+
+      const { stdout, exitCode } = await runCLI("eval", root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Batch summary");
+      expect(stdout).toContain("alpha");
+      expect(stdout).toContain("beta");
+      expect(stdout).not.toContain("not-a-skill"); // skipped silently
+      expect(stdout).toMatch(/Skills evaluated:\s+2\/2/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("eval --json on a collection returns aggregate + results array", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eval-batch-json-"));
+    try {
+      await mkdir(join(root, "a"), { recursive: true });
+      await mkdir(join(root, "b"), { recursive: true });
+      await writeFile(
+        join(root, "a", "SKILL.md"),
+        "---\nname: a\ndescription: Do a when asked.\n---\n\n## When to Use\n- thing\n",
+        "utf-8",
+      );
+      await writeFile(
+        join(root, "b", "SKILL.md"),
+        "---\nname: b\ndescription: Do b when asked.\n---\n\n## When to Use\n- thing\n",
+        "utf-8",
+      );
+      const { stdout, exitCode } = await runCLI("eval", root, "--json");
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toHaveProperty("provenance");
+      expect(parsed).toHaveProperty("aggregate");
+      expect(parsed).toHaveProperty("results");
+      expect(Array.isArray(parsed.results)).toBe(true);
+      expect(parsed.results).toHaveLength(2);
+      expect(parsed.aggregate.total).toBe(2);
+      expect(parsed.aggregate.succeeded).toBe(2);
+      expect(parsed.provenance.remote).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("eval --machine on a collection emits v1 envelope with aggregate", async () => {
+    const root = await mkdtemp(join(tmpdir(), "eval-batch-machine-"));
+    try {
+      await mkdir(join(root, "m1"), { recursive: true });
+      await writeFile(
+        join(root, "m1", "SKILL.md"),
+        "---\nname: m1\ndescription: Do m1 when asked.\n---\nbody\n",
+        "utf-8",
+      );
+      await mkdir(join(root, "m2"), { recursive: true });
+      await writeFile(
+        join(root, "m2", "SKILL.md"),
+        "---\nname: m2\ndescription: Do m2 when asked.\n---\nbody\n",
+        "utf-8",
+      );
+      const { stdout, exitCode } = await runCLI("eval", root, "--machine");
+      expect(exitCode).toBe(0);
+      const parsed = JSON.parse(stdout);
+      expect(parsed.version).toBe(1);
+      expect(parsed.command).toBe("eval");
+      expect(parsed.status).toBe("ok");
+      expect(parsed.data).toHaveProperty("aggregate");
+      expect(parsed.data).toHaveProperty("results");
+      expect(parsed.data.aggregate.total).toBe(2);
+      expect(parsed.data.results).toHaveLength(2);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("eval --concurrency rejects invalid values", async () => {
+    const { exitCode, stderr } = await runCLI(
+      "eval",
+      "./whatever",
+      "--concurrency",
+      "0",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toMatch(/Invalid --concurrency/);
+  });
+
+  // ─── #193: GitHub shorthand routing (without hitting the network) ────
+
+  test("eval with github: shorthand requires git — error is informative", async () => {
+    // We can't actually clone in unit tests; route through a bogus repo and
+    // assert the error path is followed. This locks in that parseSource is
+    // invoked and that --machine still produces a stable error envelope.
+    const { stdout, exitCode } = await runCLI(
+      "eval",
+      "github:bogus_user/repo-that-does-not-exist-for-asm-tests",
+      "--machine",
+    );
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.status).toBe("error");
+    expect(parsed.error.code).toBe("SKILL_NOT_FOUND");
+  });
+
+  test("eval --fix on github: shorthand is rejected with a clear error", async () => {
+    const { stderr, exitCode } = await runCLI(
+      "eval",
+      "github:owner/repo",
+      "--fix",
+    );
+    expect(exitCode).toBe(2);
+    expect(stderr).toMatch(/--fix is only supported for local skill paths/);
+  });
+
+  test("parseArgs accepts --concurrency and --keep flags", () => {
+    const r = parseArgs([
+      "bun",
+      "script.ts",
+      "eval",
+      "./x",
+      "--concurrency",
+      "8",
+      "--keep",
+    ]);
+    expect(r.flags.concurrency).toBe(8);
+    expect(r.flags.keep).toBe(true);
+  });
 });
 
 // ─── CLI integration: eval-providers ────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -110,7 +110,17 @@ import {
   formatReportJSON,
   formatFixPreview,
   buildEvalMachineData,
+  resolveEvalInput,
+  looksLikeGithubInput,
+  runWithConcurrency,
+  summariseBatch,
+  formatBatchSummary,
+  buildBatchMachineData,
   type EvaluationReport,
+  type EvalBatchItem,
+  type EvalBatchResult,
+  type EvalTarget,
+  type EvalProvenance,
 } from "./evaluator";
 import { runProvider } from "./eval/runner";
 import {
@@ -233,6 +243,16 @@ interface ParsedArgs {
      * hint (issue #192).
      */
     limit: number;
+    /**
+     * `asm eval --concurrency <N>` — cap parallel per-skill evaluations in
+     * batch mode (issue #194). 0 = use the default (4).
+     */
+    concurrency: number;
+    /**
+     * `asm eval --keep` — preserve the temp dir used for remote clones so
+     * users can inspect what was fetched (issue #193).
+     */
+    keep: boolean;
   };
 }
 
@@ -272,6 +292,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       summary: false,
       groupBy: null,
       limit: 0,
+      concurrency: 0,
+      keep: false,
     },
   };
 
@@ -353,6 +375,17 @@ export function parseArgs(argv: string[]): ParsedArgs {
       result.flags.installed = true;
     } else if (arg === "--available") {
       result.flags.available = true;
+    } else if (arg === "--concurrency") {
+      i++;
+      const val = args[i];
+      const n = Number(val);
+      if (!Number.isFinite(n) || n < 1 || !Number.isInteger(n)) {
+        error(`Invalid --concurrency: "${val}". Must be a positive integer.`);
+        process.exit(2);
+      }
+      result.flags.concurrency = n;
+    } else if (arg === "--keep") {
+      result.flags.keep = true;
     } else if (arg === "--transport" || arg === "-t") {
       i++;
       const val = args[i];
@@ -2709,31 +2742,43 @@ async function cmdDoctor(args: ParsedArgs) {
 // ─── Eval ───────────────────────────────────────────────────────────────────
 
 function printEvalHelp() {
-  console.log(`${ansi.bold("Usage:")} asm eval <skill-path> [options]
+  console.log(`${ansi.bold("Usage:")} asm eval <target> [options]
 
 Evaluate a skill's SKILL.md against best practices and produce a scored quality
 report with recommendations. Zero configuration — just point it at a skill
 directory. Categories: structure, description quality, prompt engineering,
 context efficiency, safety, testability, and naming conventions.
 
+Accepts a local path, a GitHub shorthand, or a GitHub URL. When the target is a
+collection (no SKILL.md at the root but each immediate child has one), every
+child skill is evaluated and an aggregate summary is printed.
+
 ${ansi.bold("Arguments:")}
-  skill-path           Path to a skill directory (must contain SKILL.md)
+  target               Local path, github:owner/repo[#ref][:subpath], or
+                       https://github.com/owner/repo[/tree/<ref>/<sub>]
 
 ${ansi.bold("Options:")}
   --fix                Apply deterministic auto-fixes to SKILL.md (creates .bak)
   --dry-run            With --fix, preview the diff without writing
   --json               Output report as JSON
   --machine            Output in stable machine-readable v1 envelope format
+  --concurrency N      Cap parallel per-skill evals in batch mode (default: 4)
+  --keep               Preserve the temp dir used for remote clones
+  -t, --transport M    Git transport (auto|https|ssh) for remote targets
   --no-color           Disable ANSI colors
   -V, --verbose        Show debug output
 
 ${ansi.bold("Examples:")}
-  asm eval ./my-skill                     ${ansi.dim("Score and recommend improvements")}
-  asm eval ./my-skill --json              ${ansi.dim("Output report as JSON")}
-  asm eval ./my-skill --fix               ${ansi.dim("Auto-fix deterministic frontmatter issues")}
-  asm eval ./my-skill --fix --dry-run     ${ansi.dim("Preview fixes as diff")}
-  asm eval ./my-skill --machine           ${ansi.dim("Machine-readable v1 envelope output")}
-  asm eval-providers list                 ${ansi.dim("List registered eval providers")}`);
+  asm eval ./my-skill                                ${ansi.dim("Score a single skill")}
+  asm eval ./skills/                                 ${ansi.dim("Batch-score every skill in the dir")}
+  asm eval github:mattpocock/skills:grill-me         ${ansi.dim("Fetch a remote skill and score it")}
+  asm eval github:mattpocock/skills                  ${ansi.dim("Batch-score a remote collection")}
+  asm eval https://github.com/mattpocock/skills/tree/main/grill-me
+  asm eval ./my-skill --json                         ${ansi.dim("Output report as JSON")}
+  asm eval ./my-skill --fix                          ${ansi.dim("Auto-fix deterministic issues")}
+  asm eval ./my-skill --fix --dry-run                ${ansi.dim("Preview fixes as diff")}
+  asm eval ./my-skill --machine                      ${ansi.dim("Machine-readable v1 envelope")}
+  asm eval-providers list                            ${ansi.dim("List registered eval providers")}`);
 }
 
 // Idempotency guard: `register()` throws on duplicate (id, version) so we only
@@ -2769,6 +2814,84 @@ function unwrapRunnerErrorOrThrow(result: {
   if (err) throw new Error(err.message);
 }
 
+/**
+ * Default fetchRemote adapter used by `cmdEval` — clones a GitHub shorthand or
+ * URL into a temp dir via the installer pipeline, resolves any subpath, then
+ * hands the root back with a cleanup hook.
+ */
+async function fetchRemoteForEval(
+  input: string,
+  transport: TransportMode,
+  keep: boolean,
+): Promise<{
+  rootDir: string;
+  cleanup: () => Promise<void>;
+  sourceRef: string;
+  commitSha: string | null;
+}> {
+  await checkGitAvailable();
+  let source = parseSource(input);
+  if (source.isLocal) {
+    // Defensive: looksLikeGithubInput should have filtered this, but guard
+    // against future regressions so the local-path branch is the only entry.
+    throw new Error(
+      `fetchRemoteForEval received a local path: "${input}". This is a bug — local paths should use the non-remote branch.`,
+    );
+  }
+  source = await resolveSubpath(source);
+
+  const tempDir = await cloneToTemp(source, transport);
+
+  // `source.subpath` may point at a subdirectory inside the repo. Use that as
+  // the root when present so the eval pipeline treats the subdir as the skill.
+  const rootDir = source.subpath ? joinPath(tempDir, source.subpath) : tempDir;
+
+  // Commit SHA — best-effort; we do not fail the whole eval if git can't resolve it.
+  let commitSha: string | null = null;
+  try {
+    const { execFile } = await import("child_process");
+    const { promisify } = await import("util");
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", tempDir, "rev-parse", "HEAD"],
+      { timeout: 5_000 },
+    );
+    const sha = stdout.trim();
+    if (/^[0-9a-f]{40}$/i.test(sha)) commitSha = sha;
+  } catch {
+    // ignore — provenance is optional
+  }
+
+  const sourceRef = `github:${source.owner}/${source.repo}${
+    source.ref ? `#${source.ref}` : ""
+  }${source.subpath ? `:${source.subpath}` : ""}`;
+
+  const cleanup = async () => {
+    if (keep) return;
+    await cleanupTemp(tempDir);
+  };
+
+  return { rootDir, cleanup, sourceRef, commitSha };
+}
+
+async function runSingleEval(
+  target: EvalTarget,
+): Promise<{ report: EvaluationReport | null; error: string | null }> {
+  ensureEvalBuiltins();
+  const provider = resolveEvalProvider("quality", "^1.0.0");
+  try {
+    const result = await runProvider(provider, {
+      skillPath: target.skillPath,
+      skillMdPath: target.skillMdPath,
+    });
+    unwrapRunnerErrorOrThrow(result);
+    return { report: result.raw as EvaluationReport, error: null };
+  } catch (err: any) {
+    return { report: null, error: err?.message ?? String(err) };
+  }
+}
+
 async function cmdEval(args: ParsedArgs) {
   if (args.flags.help) {
     printEvalHelp();
@@ -2781,8 +2904,8 @@ async function cmdEval(args: ParsedArgs) {
   const startTime = performance.now();
 
   // Path is the first positional (carried as `subcommand` by parseArgs).
-  const skillPath = args.subcommand;
-  if (!skillPath) {
+  const rawInput = args.subcommand;
+  if (!rawInput) {
     if (args.flags.machine) {
       restoreConsole?.();
       console.log(
@@ -2800,13 +2923,35 @@ async function cmdEval(args: ParsedArgs) {
     process.exit(2);
   }
 
-  try {
-    if (args.flags.fix) {
-      // --fix stays on applyFix() directly. Auto-fix is quality-provider
-      // specific — we do not expose it via provider capability yet; wait
-      // until a second provider needs the same surface.
+  // ─── --fix path: single-skill only (scope limit) ────────────────────────
+  //
+  // Auto-fix is intentionally restricted to a single skill for now. A batch
+  // --fix rollout would need per-skill diff aggregation, independent backup
+  // handling, and a --continue-on-error surface — none of which either issue
+  // #193 or #194 asks for. Keep the diff minimal; surface a clear error when
+  // the user points --fix at a collection or a remote input.
+  if (args.flags.fix) {
+    if (looksLikeGithubInput(rawInput)) {
+      const msg =
+        "--fix is only supported for local skill paths. Clone the repo first or run `asm install` to materialise it locally.";
+      if (args.flags.machine) {
+        restoreConsole?.();
+        console.log(
+          formatMachineError(
+            "eval",
+            ErrorCodes.INVALID_ARGUMENT,
+            msg,
+            startTime,
+          ),
+        );
+        process.exit(2);
+      }
+      error(msg);
+      process.exit(2);
+    }
+    try {
       const gitAuthor = await detectGitAuthor();
-      const fix = await applyFix(skillPath, {
+      const fix = await applyFix(rawInput, {
         dryRun: args.flags.dryRun,
         gitAuthor,
       });
@@ -2847,46 +2992,33 @@ async function cmdEval(args: ParsedArgs) {
       console.log("");
       console.log(formatFixPreview(fix));
       return;
+    } catch (err: any) {
+      if (args.flags.machine) {
+        restoreConsole?.();
+        console.log(
+          formatMachineError(
+            "eval",
+            ErrorCodes.SKILL_NOT_FOUND,
+            err?.message ?? String(err),
+            startTime,
+          ),
+        );
+        process.exit(1);
+      }
+      error(err?.message ?? String(err));
+      process.exit(1);
     }
+    return;
+  }
 
-    // Non-fix path: run through the eval framework.
-    ensureEvalBuiltins();
-    const provider = resolveEvalProvider("quality", "^1.0.0");
-    const { resolve: resolvePath } = await import("path");
-    const absSkillPath = resolvePath(skillPath);
-    const result = await runProvider(provider, {
-      skillPath: absSkillPath,
-      skillMdPath: resolvePath(absSkillPath, "SKILL.md"),
+  // ─── Non-fix path: unified resolver + single-or-batch eval ──────────────
+  let resolved: Awaited<ReturnType<typeof resolveEvalInput>> | null = null;
+
+  try {
+    resolved = await resolveEvalInput(rawInput, {
+      fetchRemote: (input: string) =>
+        fetchRemoteForEval(input, args.flags.transport, args.flags.keep),
     });
-
-    // Preserve pre-existing behavior on failure paths: runner wraps thrown
-    // errors into an error-shaped EvalResult; re-throw so the catch block
-    // below emits the same SKILL_NOT_FOUND envelope + exit 1 as before.
-    unwrapRunnerErrorOrThrow(result);
-
-    // `raw` holds the original EvaluationReport — the adapter stores it
-    // verbatim (src/eval/providers/quality/v1/index.ts). Byte-identical
-    // rendering requires passing this through to the existing formatters.
-    const report = result.raw as EvaluationReport;
-
-    if (args.flags.machine) {
-      restoreConsole?.();
-      console.log(
-        formatMachineOutput(
-          "eval",
-          buildEvalMachineData(report, null),
-          startTime,
-        ),
-      );
-      return;
-    }
-
-    if (args.flags.json) {
-      console.log(formatReportJSON(report));
-      return;
-    }
-
-    console.log(formatReport(report));
   } catch (err: any) {
     if (args.flags.machine) {
       restoreConsole?.();
@@ -2903,6 +3035,181 @@ async function cmdEval(args: ParsedArgs) {
     error(err?.message ?? String(err));
     process.exit(1);
   }
+
+  try {
+    // Single-skill path — preserve byte-identical output locked in by existing tests.
+    if (!resolved.isCollection && resolved.targets.length === 1) {
+      const target = resolved.targets[0];
+      const { report, error: runErr } = await runSingleEval(target);
+      if (!report) {
+        throw new Error(runErr ?? "eval failed");
+      }
+
+      if (args.flags.machine) {
+        restoreConsole?.();
+        // Attach provenance for remote inputs via the machine data surface —
+        // the machine envelope is versioned so adding fields is safe.
+        const data = buildEvalMachineData(report, null);
+        const augmented = resolved.provenance.remote
+          ? {
+              ...data,
+              provenance: {
+                input: resolved.provenance.input,
+                remote: true,
+                source_ref: resolved.provenance.sourceRef ?? null,
+                commit_sha: resolved.provenance.commitSha ?? null,
+                temp_path: resolved.provenance.tempPath ?? null,
+              },
+            }
+          : data;
+        console.log(formatMachineOutput("eval", augmented, startTime));
+        return;
+      }
+
+      if (args.flags.json) {
+        // Local path: preserve byte-identical EvaluationReport shape locked in
+        // by cli.test.ts (eval --json shape test). Remote path: extend with a
+        // provenance block so #193's AC ("source URL + resolved SHA + temp
+        // path in output") is met for the JSON surface too.
+        if (resolved.provenance.remote) {
+          console.log(
+            JSON.stringify(
+              {
+                ...report,
+                provenance: {
+                  input: resolved.provenance.input,
+                  remote: true,
+                  sourceRef: resolved.provenance.sourceRef ?? null,
+                  commitSha: resolved.provenance.commitSha ?? null,
+                  tempPath: resolved.provenance.tempPath ?? null,
+                },
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          console.log(formatReportJSON(report));
+        }
+        return;
+      }
+
+      console.log(formatReport(report));
+      if (resolved.provenance.remote) {
+        printRemoteProvenance(resolved.provenance);
+      }
+      return;
+    }
+
+    // Collection path — concurrency-bounded iteration + aggregate summary.
+    const concurrency = args.flags.concurrency || 4;
+    if (resolved.targets.length === 0) {
+      throw new Error(
+        `No skills to evaluate at "${rawInput}" — the resolved location has no SKILL.md in itself or its immediate children.`,
+      );
+    }
+    const items: EvalBatchItem[] = await runWithConcurrency(
+      resolved.targets,
+      concurrency,
+      async (target) => {
+        const { report, error: runErr } = await runSingleEval(target);
+        return {
+          label: target.label,
+          skillPath: target.skillPath,
+          report,
+          error: runErr,
+        };
+      },
+    );
+    const aggregate = summariseBatch(items);
+    const batch: EvalBatchResult = {
+      provenance: resolved.provenance,
+      aggregate,
+      results: items,
+    };
+
+    if (args.flags.machine) {
+      restoreConsole?.();
+      console.log(
+        formatMachineOutput("eval", buildBatchMachineData(batch), startTime),
+      );
+      return;
+    }
+
+    if (args.flags.json) {
+      console.log(
+        JSON.stringify(
+          {
+            provenance: batch.provenance,
+            aggregate: batch.aggregate,
+            results: batch.results.map((r) => ({
+              label: r.label,
+              skillPath: r.skillPath,
+              error: r.error,
+              report: r.report,
+            })),
+          },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    // Human-readable text: print each report then the summary footer.
+    for (const item of batch.results) {
+      if (item.report) {
+        console.log(formatReport(item.report));
+      } else {
+        console.log(`Skill evaluation: ${item.skillPath}`);
+        console.log(
+          `  ${ansi.red("error:")} ${item.error ?? "unknown failure"}`,
+        );
+      }
+      console.log("");
+    }
+    console.log(formatBatchSummary(batch));
+    if (resolved.provenance.remote && !args.flags.verbose) {
+      // formatBatchSummary already prints provenance for remote inputs, so
+      // we deliberately skip the extra print here to avoid duplication.
+    }
+  } catch (err: any) {
+    if (args.flags.machine) {
+      restoreConsole?.();
+      console.log(
+        formatMachineError(
+          "eval",
+          ErrorCodes.SKILL_NOT_FOUND,
+          err?.message ?? String(err),
+          startTime,
+        ),
+      );
+      process.exit(1);
+    }
+    error(err?.message ?? String(err));
+    process.exit(1);
+  } finally {
+    if (resolved) {
+      try {
+        await resolved.cleanup();
+      } catch {
+        // best-effort cleanup — do not swallow the outer error.
+      }
+    }
+  }
+}
+
+function printRemoteProvenance(provenance: EvalProvenance): void {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(ansi.dim("Fetched remote skill:"));
+  if (provenance.sourceRef)
+    lines.push(ansi.dim(`  Source:  ${provenance.sourceRef}`));
+  if (provenance.commitSha)
+    lines.push(ansi.dim(`  Commit:  ${provenance.commitSha}`));
+  if (provenance.tempPath)
+    lines.push(ansi.dim(`  Temp:    ${provenance.tempPath}`));
+  console.log(lines.join("\n"));
 }
 
 // ─── Eval providers ─────────────────────────────────────────────────────────

--- a/src/evaluator.test.ts
+++ b/src/evaluator.test.ts
@@ -10,6 +10,16 @@ import {
   formatReportJSON,
   formatFixPreview,
   buildEvalMachineData,
+  resolveEvalInput,
+  classifyEvalDirectory,
+  findChildSkillDirs,
+  looksLikeGithubInput,
+  runWithConcurrency,
+  summariseBatch,
+  formatBatchSummary,
+  buildBatchMachineData,
+  type EvalBatchItem,
+  type EvalProvenance,
 } from "./evaluator";
 import { mkdtemp, rm, readFile, writeFile, access } from "fs/promises";
 import { join } from "path";
@@ -491,5 +501,413 @@ describe("formatters", () => {
     });
     expect(preview).toContain("did the thing");
     expect(preview).toContain("skipped the other thing");
+  });
+});
+
+// ─── Input resolution / collection detection (issues #193 + #194) ──────────
+
+const MINI_SKILL = `---
+name: mini
+description: Do something specific when asked.
+---
+# mini
+
+## When to Use
+- something
+
+## Instructions
+1. do the thing
+`;
+
+describe("looksLikeGithubInput", () => {
+  it("recognises github: shorthand", () => {
+    expect(looksLikeGithubInput("github:owner/repo")).toBe(true);
+    expect(looksLikeGithubInput("github:owner/repo#main")).toBe(true);
+    expect(looksLikeGithubInput("github:owner/repo:subdir")).toBe(true);
+  });
+
+  it("recognises https github URLs", () => {
+    expect(looksLikeGithubInput("https://github.com/a/b")).toBe(true);
+    expect(looksLikeGithubInput("http://github.com/a/b")).toBe(true);
+    expect(looksLikeGithubInput("https://github.com/a/b/tree/main/sub")).toBe(
+      true,
+    );
+  });
+
+  it("rejects local paths", () => {
+    expect(looksLikeGithubInput("./skills")).toBe(false);
+    expect(looksLikeGithubInput("/tmp/x")).toBe(false);
+    expect(looksLikeGithubInput("my-skill")).toBe(false);
+  });
+
+  it("rejects empty input", () => {
+    expect(looksLikeGithubInput("")).toBe(false);
+  });
+});
+
+describe("classifyEvalDirectory", () => {
+  it("detects a single skill (SKILL.md at root)", async () => {
+    const dir = skillDir("single-skill");
+    await writeSkillMd(dir, MINI_SKILL);
+    const r = await classifyEvalDirectory(dir);
+    expect(r.kind).toBe("single");
+    expect(r.skillDirs).toEqual([dir]);
+  });
+
+  it("detects a collection (no root SKILL.md, children have one)", async () => {
+    const root = join(tempDir, "collection");
+    const { mkdir } = await import("fs/promises");
+    await mkdir(root, { recursive: true });
+    await writeSkillMd(join(root, "alpha"), MINI_SKILL);
+    await writeSkillMd(join(root, "beta"), MINI_SKILL);
+    const r = await classifyEvalDirectory(root);
+    expect(r.kind).toBe("collection");
+    expect(r.skillDirs.length).toBe(2);
+    expect(r.skillDirs.map((d) => d.split("/").pop()).sort()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("returns 'none' for an empty directory", async () => {
+    const { mkdir } = await import("fs/promises");
+    await mkdir(join(tempDir, "empty"), { recursive: true });
+    const r = await classifyEvalDirectory(join(tempDir, "empty"));
+    expect(r.kind).toBe("none");
+    expect(r.skillDirs).toEqual([]);
+  });
+
+  it("skips hidden and node_modules child directories", async () => {
+    const root = join(tempDir, "noisy");
+    const { mkdir } = await import("fs/promises");
+    await mkdir(root, { recursive: true });
+    await writeSkillMd(join(root, "real"), MINI_SKILL);
+    await writeSkillMd(join(root, ".hidden"), MINI_SKILL);
+    await writeSkillMd(join(root, "node_modules"), MINI_SKILL);
+    const r = await classifyEvalDirectory(root);
+    expect(r.kind).toBe("collection");
+    expect(r.skillDirs.length).toBe(1);
+    expect(r.skillDirs[0].endsWith("/real")).toBe(true);
+  });
+});
+
+describe("findChildSkillDirs", () => {
+  it("returns empty array for a non-existent directory", async () => {
+    const r = await findChildSkillDirs(join(tempDir, "does-not-exist"));
+    expect(r).toEqual([]);
+  });
+
+  it("is sorted by basename", async () => {
+    const root = join(tempDir, "sorted");
+    const { mkdir } = await import("fs/promises");
+    await mkdir(root, { recursive: true });
+    await writeSkillMd(join(root, "c"), MINI_SKILL);
+    await writeSkillMd(join(root, "a"), MINI_SKILL);
+    await writeSkillMd(join(root, "b"), MINI_SKILL);
+    const r = await findChildSkillDirs(root);
+    expect(r.map((d) => d.split("/").pop())).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("resolveEvalInput (local)", () => {
+  it("resolves a single skill directory", async () => {
+    const dir = skillDir("single");
+    await writeSkillMd(dir, MINI_SKILL);
+    const r = await resolveEvalInput(dir);
+    expect(r.isCollection).toBe(false);
+    expect(r.targets).toHaveLength(1);
+    expect(r.targets[0].skillPath).toBe(dir);
+    expect(r.provenance.remote).toBe(false);
+  });
+
+  it("resolves a collection and sets isCollection=true", async () => {
+    const root = join(tempDir, "coll");
+    const { mkdir } = await import("fs/promises");
+    await mkdir(root, { recursive: true });
+    await writeSkillMd(join(root, "a"), MINI_SKILL);
+    await writeSkillMd(join(root, "b"), MINI_SKILL);
+    const r = await resolveEvalInput(root);
+    expect(r.isCollection).toBe(true);
+    expect(r.targets).toHaveLength(2);
+    expect(r.provenance.remote).toBe(false);
+  });
+
+  it("throws on missing path", async () => {
+    await expect(resolveEvalInput(join(tempDir, "missing"))).rejects.toThrow(
+      /does not exist/,
+    );
+  });
+
+  it("throws on an empty directory", async () => {
+    const { mkdir } = await import("fs/promises");
+    await mkdir(join(tempDir, "empty"), { recursive: true });
+    await expect(resolveEvalInput(join(tempDir, "empty"))).rejects.toThrow(
+      /No SKILL\.md/,
+    );
+  });
+
+  it("accepts a SKILL.md file directly as input", async () => {
+    const dir = skillDir("directfile");
+    const p = await writeSkillMd(dir, MINI_SKILL);
+    const r = await resolveEvalInput(p);
+    expect(r.isCollection).toBe(false);
+    expect(r.targets).toHaveLength(1);
+    expect(r.targets[0].skillMdPath).toBe(p);
+  });
+});
+
+describe("resolveEvalInput (github fetchRemote adapter)", () => {
+  it("routes github: input through the fetchRemote adapter", async () => {
+    // Stage a fake "remote" checkout locally so the test stays off the network.
+    const fakeRepo = join(tempDir, "fake-repo");
+    const { mkdir } = await import("fs/promises");
+    await mkdir(fakeRepo, { recursive: true });
+    await writeSkillMd(join(fakeRepo, "alpha"), MINI_SKILL);
+    await writeSkillMd(join(fakeRepo, "beta"), MINI_SKILL);
+
+    let cleanupCalled = 0;
+    const r = await resolveEvalInput("github:test/fake", {
+      fetchRemote: async (input: string) => {
+        expect(input).toBe("github:test/fake");
+        return {
+          rootDir: fakeRepo,
+          cleanup: async () => {
+            cleanupCalled++;
+          },
+          sourceRef: "github:test/fake",
+          commitSha: "0".repeat(40),
+        };
+      },
+    });
+
+    expect(r.isCollection).toBe(true);
+    expect(r.targets).toHaveLength(2);
+    expect(r.provenance.remote).toBe(true);
+    expect(r.provenance.sourceRef).toBe("github:test/fake");
+    expect(r.provenance.commitSha).toBe("0".repeat(40));
+    expect(cleanupCalled).toBe(0);
+    await r.cleanup();
+    expect(cleanupCalled).toBe(1);
+  });
+
+  it("routes an https URL through the fetchRemote adapter and resolves single skill", async () => {
+    const fakeRepo = join(tempDir, "fake-single");
+    await writeSkillMd(fakeRepo, MINI_SKILL);
+    const r = await resolveEvalInput(
+      "https://github.com/owner/repo/tree/main/sub",
+      {
+        fetchRemote: async () => ({
+          rootDir: fakeRepo,
+          cleanup: async () => {},
+          sourceRef: "github:owner/repo#main:sub",
+          commitSha: null,
+        }),
+      },
+    );
+    expect(r.isCollection).toBe(false);
+    expect(r.targets).toHaveLength(1);
+    expect(r.provenance.remote).toBe(true);
+  });
+
+  it("calls cleanup when the remote root has no skills", async () => {
+    const fakeRepo = join(tempDir, "empty-remote");
+    const { mkdir } = await import("fs/promises");
+    await mkdir(fakeRepo, { recursive: true });
+    let cleanedUp = 0;
+    await expect(
+      resolveEvalInput("github:test/nothing", {
+        fetchRemote: async () => ({
+          rootDir: fakeRepo,
+          cleanup: async () => {
+            cleanedUp++;
+          },
+          sourceRef: "github:test/nothing",
+          commitSha: null,
+        }),
+      }),
+    ).rejects.toThrow(/No SKILL\.md/);
+    expect(cleanedUp).toBe(1);
+  });
+
+  it("throws if a github input is supplied with no fetchRemote adapter", async () => {
+    await expect(resolveEvalInput("github:owner/repo")).rejects.toThrow(
+      /Remote evaluation is not available/,
+    );
+  });
+});
+
+describe("runWithConcurrency", () => {
+  it("processes all inputs and preserves order", async () => {
+    const inputs = [1, 2, 3, 4, 5, 6, 7];
+    const results = await runWithConcurrency(inputs, 3, async (n) => {
+      await new Promise((r) => setTimeout(r, 5 * ((n * 13) % 4)));
+      return n * 2;
+    });
+    expect(results).toEqual([2, 4, 6, 8, 10, 12, 14]);
+  });
+
+  it("never exceeds the concurrency cap", async () => {
+    const limit = 2;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const inputs = [1, 2, 3, 4, 5, 6];
+    await runWithConcurrency(inputs, limit, async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight--;
+      return null;
+    });
+    expect(maxInFlight).toBeLessThanOrEqual(limit);
+  });
+
+  it("handles empty input", async () => {
+    const r = await runWithConcurrency<number, number>([], 4, async (x) => x);
+    expect(r).toEqual([]);
+  });
+
+  it("treats limit < 1 as 1", async () => {
+    const r = await runWithConcurrency([1, 2, 3], 0, async (x) => x);
+    expect(r).toEqual([1, 2, 3]);
+  });
+});
+
+describe("summariseBatch", () => {
+  function mkItem(
+    label: string,
+    score: number | null,
+    err: string | null = null,
+  ): EvalBatchItem {
+    return {
+      label,
+      skillPath: `/virtual/${label}`,
+      report:
+        score === null
+          ? null
+          : ({
+              skillPath: `/virtual/${label}`,
+              skillMdPath: `/virtual/${label}/SKILL.md`,
+              overallScore: score,
+              grade: "B",
+              categories: [],
+              topSuggestions: [],
+              evaluatedAt: new Date().toISOString(),
+              frontmatter: {},
+            } as any),
+      error: err,
+    };
+  }
+
+  it("computes counts, mean, top, bottom for mixed results", () => {
+    const agg = summariseBatch([
+      mkItem("a", 90),
+      mkItem("b", 70),
+      mkItem("c", 50),
+      mkItem("d", null, "boom"),
+    ]);
+    expect(agg.total).toBe(4);
+    expect(agg.succeeded).toBe(3);
+    expect(agg.failed).toBe(1);
+    expect(agg.meanScore).toBe(70);
+    expect(agg.top?.label).toBe("a");
+    expect(agg.bottom?.label).toBe("c");
+  });
+
+  it("returns null mean/top/bottom when nothing succeeded", () => {
+    const agg = summariseBatch([mkItem("a", null, "err")]);
+    expect(agg.meanScore).toBeNull();
+    expect(agg.top).toBeNull();
+    expect(agg.bottom).toBeNull();
+  });
+});
+
+describe("formatBatchSummary", () => {
+  it("prints provenance lines when remote", () => {
+    const provenance: EvalProvenance = {
+      input: "github:a/b",
+      remote: true,
+      sourceRef: "github:a/b#main",
+      commitSha: "abc123",
+      tempPath: "/tmp/fake",
+    };
+    const out = formatBatchSummary({
+      provenance,
+      aggregate: {
+        total: 1,
+        succeeded: 1,
+        failed: 0,
+        meanScore: 88,
+        top: { label: "a", score: 88 },
+        bottom: { label: "a", score: 88 },
+      },
+      results: [],
+    });
+    expect(out).toContain("Batch summary");
+    expect(out).toContain("Mean score:");
+    expect(out).toContain("Source:");
+    expect(out).toContain("github:a/b#main");
+    expect(out).toContain("abc123");
+  });
+
+  it("skips provenance for local inputs", () => {
+    const out = formatBatchSummary({
+      provenance: { input: "./skills", remote: false, sourceRef: null },
+      aggregate: {
+        total: 2,
+        succeeded: 2,
+        failed: 0,
+        meanScore: 80,
+        top: { label: "a", score: 90 },
+        bottom: { label: "b", score: 70 },
+      },
+      results: [],
+    });
+    expect(out).toContain("Skills evaluated:");
+    expect(out).not.toContain("Source:");
+    expect(out).not.toContain("Commit:");
+  });
+});
+
+describe("buildBatchMachineData", () => {
+  it("wraps provenance, aggregate, and per-skill reports in a machine shape", () => {
+    const data = buildBatchMachineData({
+      provenance: {
+        input: "./skills",
+        remote: false,
+        sourceRef: null,
+      },
+      aggregate: {
+        total: 1,
+        succeeded: 1,
+        failed: 0,
+        meanScore: 70,
+        top: { label: "x", score: 70 },
+        bottom: { label: "x", score: 70 },
+      },
+      results: [
+        {
+          label: "x",
+          skillPath: "/virtual/x",
+          error: null,
+          report: {
+            skillPath: "/virtual/x",
+            skillMdPath: "/virtual/x/SKILL.md",
+            evaluatedAt: new Date().toISOString(),
+            categories: [],
+            overallScore: 70,
+            grade: "C",
+            topSuggestions: [],
+            frontmatter: {},
+          } as any,
+        },
+      ],
+    });
+    expect(data.provenance.input).toBe("./skills");
+    expect(data.aggregate.total).toBe(1);
+    expect(data.aggregate.mean_score).toBe(70);
+    expect(Array.isArray(data.results)).toBe(true);
+    expect(data.results[0].label).toBe("x");
+    expect(data.results[0].report).not.toBeNull();
+    expect(data.results[0].report?.overall_score).toBe(70);
   });
 });

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -28,7 +28,14 @@
  *                          schema. Downstream issues can add it later.
  */
 
-import { readFile, writeFile, stat, copyFile, access } from "fs/promises";
+import {
+  readFile,
+  writeFile,
+  stat,
+  copyFile,
+  access,
+  readdir,
+} from "fs/promises";
 import { join, resolve, basename, isAbsolute } from "path";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
 
@@ -1471,6 +1478,435 @@ export function formatFixPreview(result: FixResult): string {
     lines.push(`Backup: ${result.backupPath}`);
   }
   return lines.join("\n");
+}
+
+// ─── Input resolution (local path / GitHub shorthand / URL) ───────────────
+//
+// Issues #193 + #194 extend `asm eval` to accept GitHub URLs/shorthand and to
+// evaluate a collection of skills in one go. The input-resolution pipeline is
+// shared between the single-skill path and the batch path so both features
+// stay consistent.
+//
+//   • `asm eval ./skill`                → single skill (SKILL.md at root)
+//   • `asm eval ./skills/`              → collection (enumerated children)
+//   • `asm eval github:owner/repo`      → whole repo (single-or-collection)
+//   • `asm eval github:owner/repo:sub`  → subpath resolved from cloned repo
+//
+// The resolver returns a list of `EvalTarget` entries plus a `cleanup` hook
+// that the caller MUST invoke in a `finally` block — local inputs get a no-op
+// cleanup, remote inputs get an `rm -rf` of the temp clone directory.
+
+export interface EvalTarget {
+  /** Absolute path to the skill directory. */
+  skillPath: string;
+  /** Absolute path to the skill's SKILL.md. */
+  skillMdPath: string;
+  /** Short display label (the skill's directory basename). */
+  label: string;
+}
+
+export interface EvalProvenance {
+  /** Original input as typed by the user (e.g. `github:owner/repo`). */
+  input: string;
+  /** True when the input was a GitHub URL / shorthand. */
+  remote: boolean;
+  /** Canonical `github:owner/repo[#ref][:subpath]` form, or null for local. */
+  sourceRef?: string | null;
+  /** Commit SHA resolved from the temp clone, when available. */
+  commitSha?: string | null;
+  /** Temp dir created to stage the clone, when applicable. */
+  tempPath?: string | null;
+}
+
+export interface ResolvedEvalInput {
+  /** One entry per SKILL.md to evaluate. */
+  targets: EvalTarget[];
+  /** True when >1 skill was discovered (or the caller forced batch mode). */
+  isCollection: boolean;
+  /** Cleanup fn for the temp clone. Safe to call twice; no-op for local paths. */
+  cleanup: () => Promise<void>;
+  /** Source provenance. */
+  provenance: EvalProvenance;
+}
+
+/**
+ * Detect immediate child directories that contain a `SKILL.md` file. Used to
+ * decide whether a given root looks like a single skill or a collection.
+ *
+ * The search is non-recursive — only the direct children of `rootDir` are
+ * considered candidates (matching the expected layouts described in #194:
+ * `./skills/<skill>/SKILL.md`).
+ */
+export async function findChildSkillDirs(rootDir: string): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(rootDir);
+  } catch {
+    return [];
+  }
+
+  const results: string[] = [];
+  for (const entry of entries) {
+    // Skip common non-skill directories early.
+    if (
+      entry.startsWith(".") ||
+      entry === "node_modules" ||
+      entry === "dist" ||
+      entry === "build"
+    ) {
+      continue;
+    }
+
+    const full = join(rootDir, entry);
+    let s;
+    try {
+      s = await stat(full);
+    } catch {
+      continue;
+    }
+    if (!s.isDirectory()) continue;
+
+    const skillMd = join(full, "SKILL.md");
+    try {
+      const mdStat = await stat(skillMd);
+      if (mdStat.isFile()) results.push(full);
+    } catch {
+      // no SKILL.md at this child — skip (do not recurse).
+    }
+  }
+
+  results.sort((a, b) => basename(a).localeCompare(basename(b)));
+  return results;
+}
+
+/**
+ * Result of classifying a local directory path.
+ *  - `single`     : the directory itself is a skill (SKILL.md at root)
+ *  - `collection` : no root SKILL.md, at least one child has SKILL.md
+ *  - `none`       : neither — caller should error out
+ */
+export interface DirectoryClassification {
+  kind: "single" | "collection" | "none";
+  /** For `single`: the skill dir. For `collection`: the list of child skill dirs. */
+  skillDirs: string[];
+}
+
+/**
+ * Classify a directory as a single skill, a collection of skills, or neither.
+ */
+export async function classifyEvalDirectory(
+  rootDir: string,
+): Promise<DirectoryClassification> {
+  const rootSkillMd = join(rootDir, "SKILL.md");
+  try {
+    const s = await stat(rootSkillMd);
+    if (s.isFile()) {
+      return { kind: "single", skillDirs: [rootDir] };
+    }
+  } catch {
+    // fall through and look at children
+  }
+
+  const children = await findChildSkillDirs(rootDir);
+  if (children.length > 0) {
+    return { kind: "collection", skillDirs: children };
+  }
+  return { kind: "none", skillDirs: [] };
+}
+
+/**
+ * Heuristic: does the input look like a GitHub URL / shorthand rather than a
+ * filesystem path? We mirror the rules used by `installer.isLocalPath` / the
+ * GitHub URL regex, but keep them local to the evaluator to avoid a cyclic
+ * import into `installer.ts`.
+ */
+export function looksLikeGithubInput(input: string): boolean {
+  if (!input) return false;
+  if (input.startsWith("github:")) return true;
+  if (/^https?:\/\/github\.com\//i.test(input)) return true;
+  return false;
+}
+
+function buildTargetFromSkillDir(skillDir: string): EvalTarget {
+  return {
+    skillPath: skillDir,
+    skillMdPath: join(skillDir, "SKILL.md"),
+    label: basename(skillDir),
+  };
+}
+
+/**
+ * Resolve the input argument for `asm eval` into one or more evaluation
+ * targets. Delegates network fetching to the supplied `fetchRemote` adapter
+ * so the pure path-classification logic stays unit-testable without hitting
+ * git / the network.
+ *
+ * Expected contract for `fetchRemote`:
+ *   • parse the GitHub input (shorthand or URL)
+ *   • clone into a temp directory honouring the `transport` preference
+ *   • resolve any subpath segment, returning the final on-disk root
+ *   • return `{ rootDir, cleanup, sourceRef, commitSha }`
+ *
+ * When `fetchRemote` is omitted, this function only handles local paths.
+ */
+export interface ResolveEvalInputOptions {
+  fetchRemote?: (input: string) => Promise<{
+    rootDir: string;
+    cleanup: () => Promise<void>;
+    sourceRef: string;
+    commitSha: string | null;
+  }>;
+}
+
+export async function resolveEvalInput(
+  input: string,
+  options: ResolveEvalInputOptions = {},
+): Promise<ResolvedEvalInput> {
+  if (!input) {
+    throw new Error("resolveEvalInput: input must be a non-empty string");
+  }
+
+  if (looksLikeGithubInput(input)) {
+    if (!options.fetchRemote) {
+      throw new Error(
+        `Remote evaluation is not available in this context: "${input}"`,
+      );
+    }
+    const remote = await options.fetchRemote(input);
+    let classification: DirectoryClassification;
+    try {
+      classification = await classifyEvalDirectory(remote.rootDir);
+    } catch (err) {
+      await remote.cleanup().catch(() => {});
+      throw err;
+    }
+    if (classification.kind === "none") {
+      await remote.cleanup().catch(() => {});
+      throw new Error(
+        `No SKILL.md found at ${remote.rootDir} (source: ${input}). The location is neither a single skill nor a skill collection.`,
+      );
+    }
+    return {
+      targets: classification.skillDirs.map(buildTargetFromSkillDir),
+      isCollection: classification.kind === "collection",
+      cleanup: remote.cleanup,
+      provenance: {
+        input,
+        remote: true,
+        sourceRef: remote.sourceRef,
+        commitSha: remote.commitSha,
+        tempPath: remote.rootDir,
+      },
+    };
+  }
+
+  // Local path: accept either a SKILL.md file or a directory.
+  const abs = isAbsolute(input) ? input : resolve(input);
+  let s;
+  try {
+    s = await stat(abs);
+  } catch {
+    throw new Error(`Skill path does not exist: ${abs}`);
+  }
+
+  if (s.isFile()) {
+    // Treat a direct SKILL.md as a single-skill input whose skillPath is the
+    // filename (matches legacy evaluateSkill behaviour).
+    return {
+      targets: [
+        {
+          skillPath: basename(abs) === "SKILL.md" ? basename(abs) : abs,
+          skillMdPath: abs,
+          label: basename(abs),
+        },
+      ],
+      isCollection: false,
+      cleanup: async () => {},
+      provenance: { input, remote: false, sourceRef: null },
+    };
+  }
+
+  if (!s.isDirectory()) {
+    throw new Error(`Skill path is not a directory or file: ${abs}`);
+  }
+
+  const classification = await classifyEvalDirectory(abs);
+  if (classification.kind === "none") {
+    throw new Error(
+      `No SKILL.md found in ${abs}. Pass a skill directory, a SKILL.md file, or a collection root with SKILL.md in its children.`,
+    );
+  }
+
+  return {
+    targets: classification.skillDirs.map(buildTargetFromSkillDir),
+    isCollection: classification.kind === "collection",
+    cleanup: async () => {},
+    provenance: { input, remote: false, sourceRef: null },
+  };
+}
+
+// ─── Aggregate / batch report ─────────────────────────────────────────────
+
+export interface EvalBatchItem {
+  /** Short directory label (basename). */
+  label: string;
+  /** Absolute skill path evaluated. */
+  skillPath: string;
+  /** The evaluation report, when the eval succeeded. */
+  report: EvaluationReport | null;
+  /** Error message when eval failed for this skill (non-fatal — kept in results). */
+  error: string | null;
+}
+
+export interface EvalBatchAggregate {
+  total: number;
+  succeeded: number;
+  failed: number;
+  meanScore: number | null;
+  top: { label: string; score: number } | null;
+  bottom: { label: string; score: number } | null;
+}
+
+export interface EvalBatchResult {
+  provenance: EvalProvenance;
+  aggregate: EvalBatchAggregate;
+  results: EvalBatchItem[];
+}
+
+export function summariseBatch(items: EvalBatchItem[]): EvalBatchAggregate {
+  const succeeded = items.filter((i) => i.report !== null);
+  const total = items.length;
+  const failed = total - succeeded.length;
+  if (succeeded.length === 0) {
+    return {
+      total,
+      succeeded: 0,
+      failed,
+      meanScore: null,
+      top: null,
+      bottom: null,
+    };
+  }
+  const scores = succeeded.map((i) => i.report!.overallScore);
+  const mean = scores.reduce((a, b) => a + b, 0) / scores.length;
+  const meanScore = Math.round(mean);
+  const sorted = [...succeeded].sort(
+    (a, b) => b.report!.overallScore - a.report!.overallScore,
+  );
+  const top = sorted[0];
+  const bottom = sorted[sorted.length - 1];
+  return {
+    total,
+    succeeded: succeeded.length,
+    failed,
+    meanScore,
+    top: { label: top.label, score: top.report!.overallScore },
+    bottom: { label: bottom.label, score: bottom.report!.overallScore },
+  };
+}
+
+/**
+ * Run an async task for each input with a bounded concurrency window.
+ * Preserves output order (index-indexed results array).
+ */
+export async function runWithConcurrency<T, R>(
+  inputs: T[],
+  limit: number,
+  fn: (input: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(inputs.length);
+  let next = 0;
+  const boundedLimit = Math.max(1, Math.floor(limit));
+  const workers: Promise<void>[] = [];
+  const size = Math.min(boundedLimit, inputs.length);
+  for (let w = 0; w < size; w++) {
+    workers.push(
+      (async () => {
+        while (true) {
+          const idx = next++;
+          if (idx >= inputs.length) break;
+          results[idx] = await fn(inputs[idx], idx);
+        }
+      })(),
+    );
+  }
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Render a concise human-readable summary of a batch run. Not the full per-skill
+ * detail — caller can still print individual reports before the summary.
+ */
+export function formatBatchSummary(
+  batch: EvalBatchResult,
+  widthHint: number = 28,
+): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("Batch summary:");
+  lines.push(
+    `  Skills evaluated:      ${batch.aggregate.succeeded}/${batch.aggregate.total}` +
+      (batch.aggregate.failed > 0
+        ? `  (${batch.aggregate.failed} failed)`
+        : ""),
+  );
+  if (batch.aggregate.meanScore !== null) {
+    lines.push(`  Mean score:            ${batch.aggregate.meanScore}/100`);
+  }
+  if (batch.aggregate.top) {
+    lines.push(
+      `  Top:                   ${batch.aggregate.top.label} (${batch.aggregate.top.score}/100)`,
+    );
+  }
+  if (
+    batch.aggregate.bottom &&
+    batch.aggregate.bottom.label !== batch.aggregate.top?.label
+  ) {
+    lines.push(
+      `  Bottom:                ${batch.aggregate.bottom.label} (${batch.aggregate.bottom.score}/100)`,
+    );
+  }
+  if (batch.provenance.remote) {
+    if (batch.provenance.sourceRef) {
+      lines.push(`  Source:                ${batch.provenance.sourceRef}`);
+    }
+    if (batch.provenance.commitSha) {
+      lines.push(`  Commit:                ${batch.provenance.commitSha}`);
+    }
+    if (batch.provenance.tempPath) {
+      lines.push(`  Fetched to:            ${batch.provenance.tempPath}`);
+    }
+  }
+  // widthHint is intentionally unused for now — reserved for future padding.
+  void widthHint;
+  return lines.join("\n");
+}
+
+export function buildBatchMachineData(batch: EvalBatchResult) {
+  return {
+    provenance: {
+      input: batch.provenance.input,
+      remote: batch.provenance.remote,
+      source_ref: batch.provenance.sourceRef ?? null,
+      commit_sha: batch.provenance.commitSha ?? null,
+      temp_path: batch.provenance.tempPath ?? null,
+    },
+    aggregate: {
+      total: batch.aggregate.total,
+      succeeded: batch.aggregate.succeeded,
+      failed: batch.aggregate.failed,
+      mean_score: batch.aggregate.meanScore,
+      top: batch.aggregate.top,
+      bottom: batch.aggregate.bottom,
+    },
+    results: batch.results.map((r) => ({
+      label: r.label,
+      skill_path: r.skillPath,
+      error: r.error,
+      report: r.report ? buildEvalMachineData(r.report, null) : null,
+    })),
+  };
 }
 
 /**

--- a/tests/e2e/bun-e2e.test.ts
+++ b/tests/e2e/bun-e2e.test.ts
@@ -646,3 +646,71 @@ describe("Bun dist E2E: init edge cases", () => {
     expect(exitCode).toBe(2);
   });
 });
+
+// ─── eval remote + batch (issues #193 + #194) ───────────────────────────
+
+describe("Bun dist E2E: eval remote + batch", () => {
+  test("eval on a collection local directory evaluates every child", async () => {
+    const root = await mkdtemp(join(tmpdir(), "e2e-eval-batch-"));
+    try {
+      const { mkdir } = await import("fs/promises");
+      await mkdir(join(root, "alpha"), { recursive: true });
+      await mkdir(join(root, "beta"), { recursive: true });
+      await writeFile(
+        join(root, "alpha", "SKILL.md"),
+        "---\nname: alpha\ndescription: Do alpha when asked.\n---\n\n## When to Use\n- thing\n",
+        "utf-8",
+      );
+      await writeFile(
+        join(root, "beta", "SKILL.md"),
+        "---\nname: beta\ndescription: Do beta when asked.\n---\n\n## When to Use\n- thing\n",
+        "utf-8",
+      );
+
+      const { stdout, exitCode } = await runBunDist("eval", root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Batch summary");
+      expect(stdout).toMatch(/Skills evaluated:\s+2\/2/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("eval on a single skill directory preserves legacy output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "e2e-eval-single-"));
+    try {
+      await writeFile(
+        join(root, "SKILL.md"),
+        "---\nname: only\ndescription: Do only when asked.\n---\n\n## When to Use\n- thing\n",
+        "utf-8",
+      );
+      const { stdout, exitCode } = await runBunDist("eval", root);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Skill evaluation:");
+      expect(stdout).toContain("Overall score:");
+      expect(stdout).not.toContain("Batch summary");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("eval --help documents remote + batch usage", async () => {
+    const { stdout, exitCode } = await runBunDist("eval", "--help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("github:");
+    expect(stdout).toContain("collection");
+    expect(stdout).toContain("--concurrency");
+  });
+
+  test("eval github: shorthand fails gracefully on bogus repo (machine envelope)", async () => {
+    const { stdout, exitCode } = await runBunDist(
+      "eval",
+      "github:this-owner-does-not-exist/this-repo-does-not-exist-asm-e2e",
+      "--machine",
+    );
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.status).toBe("error");
+    expect(parsed.command).toBe("eval");
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Extends `asm eval` in two complementary ways — both were filed as `feature` issues and #194 explicitly builds on #193's input-parsing work.

- **#193 — GitHub URL / shorthand input.** `asm eval` now accepts `github:owner/repo[#ref][:subpath]` shorthand and full `https://github.com/...` URLs alongside local paths. Remote inputs go through the existing installer pipeline (`parseSource` → `resolveSubpath` → `cloneToTemp`) into a temp directory that is cleaned up automatically after the run; `--keep` preserves it for inspection. Provenance (source ref, resolved commit SHA, temp path) is threaded into text, `--json`, and `--machine` output.
- **#194 — Batch eval.** `asm eval` detects when the resolved location is a *collection* (no `SKILL.md` at the root but its immediate children each contain one) and evaluates every child. Per-skill reports render first, followed by an aggregate summary with mean / top / bottom. `--concurrency N` caps parallel evals (default 4). Non-skill children are skipped silently. `--json` and `--machine` emit `{ provenance, aggregate, results[] }`; single-skill output stays byte-identical.

The input-resolution stage (`resolveEvalInput` in `src/evaluator.ts`) is factored so both paths share it — `cmdEval` always loops over an `EvalTarget[]` (size 1 for singles, N for collections). No duplicated logic.

### Scope notes

- `--fix` remains single-skill-only. Collection- and remote-`--fix` are out of scope for both issues and would need independent diff aggregation; pointing `--fix` at a collection or a GitHub input now produces a clear `INVALID_ARGUMENT` error rather than silently misbehaving.
- Batch runs where every skill fails still exit 0 because per-item errors are captured in the `results[]` array (useful for CI dashboards that consume the JSON). The error envelope is reserved for truly fatal failures (unresolvable input, clone failure).

### Files changed

- `src/evaluator.ts` — new `resolveEvalInput`, `classifyEvalDirectory`, `findChildSkillDirs`, `runWithConcurrency`, `summariseBatch`, `formatBatchSummary`, `buildBatchMachineData` helpers + provenance types.
- `src/cli.ts` — rewritten `cmdEval` to route through the resolver, new `fetchRemoteForEval` adapter, `--concurrency` and `--keep` flags added to `parseArgs`, extended `printEvalHelp`.
- `src/evaluator.test.ts` — 28 new unit tests for classification, resolution, concurrency, aggregation, machine shape, and remote adapter plumbing.
- `src/cli.test.ts` — 7 new CLI integration tests for batch eval (text / JSON / machine), `--concurrency` validation, `--fix` guardrails, and `parseArgs` flag handling.
- `tests/e2e/bun-e2e.test.ts` — 4 new e2e tests exercising the built dist for single-skill preservation, batch collection eval, `--help` documentation, and graceful github: error handling.

Closes #193
Closes #194

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/` — 1519 pass, 0 fail
- [x] `bun run build` — dist built
- [x] `bun test tests/e2e/` — 207 pass, 0 fail (82 from bun-e2e suite covering the new eval paths)
- [x] Manual smoke: `asm eval ./skills` prints the batch summary; `asm eval ./skills/hello-world` preserves legacy output; `asm eval --machine` on a collection emits the new aggregate envelope
- [x] Manual smoke: `asm eval github:bogus/repo --machine` returns the expected SKILL_NOT_FOUND envelope on clone failure
- [x] Manual smoke: `asm eval github:owner/repo --fix` rejected with a clear message (single-skill-only guardrail)