### PR TITLE
feat(eval): add skill-creator deterministic provider (#197)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1596,8 +1596,16 @@ describe("CLI integration: eval", () => {
       const parsed = JSON.parse(stdout);
       expect(parsed).toHaveProperty("overallScore");
       expect(parsed).toHaveProperty("categories");
+      expect(parsed).toHaveProperty("providers");
       expect(Array.isArray(parsed.categories)).toBe(true);
       expect(parsed.categories.length).toBe(7);
+      expect(Array.isArray(parsed.providers)).toBe(true);
+      expect(
+        parsed.providers.some((p: { id: string }) => p.id === "quality"),
+      ).toBe(true);
+      expect(
+        parsed.providers.some((p: { id: string }) => p.id === "skill-creator"),
+      ).toBe(true);
     } finally {
       await cleanup();
     }
@@ -1615,6 +1623,12 @@ describe("CLI integration: eval", () => {
       expect(parsed.command).toBe("eval");
       expect(parsed.status).toBe("ok");
       expect(parsed.data.overall_score).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(parsed.data.providers)).toBe(true);
+      expect(
+        parsed.data.providers.some(
+          (p: { id: string }) => p.id === "skill-creator",
+        ),
+      ).toBe(true);
     } finally {
       await cleanup();
     }
@@ -1694,6 +1708,7 @@ describe("CLI integration: eval", () => {
       expect(parsed).toHaveProperty("grade");
       expect(parsed).toHaveProperty("topSuggestions");
       expect(parsed).toHaveProperty("frontmatter");
+      expect(Array.isArray(parsed.providers)).toBe(true);
       expect(parsed).not.toHaveProperty("providerId");
       expect(parsed).not.toHaveProperty("schemaVersion");
       // Every category still carries findings + suggestions arrays — the
@@ -1883,7 +1898,7 @@ describe("CLI integration: eval", () => {
 // ─── CLI integration: eval-providers ────────────────────────────────────────
 
 describe("CLI integration: eval-providers", () => {
-  test("eval-providers list prints quality@1.0.0 with schema + description", async () => {
+  test("eval-providers list prints quality and skill-creator with schema + description", async () => {
     const { stdout, exitCode } = await runCLI("eval-providers", "list");
     expect(exitCode).toBe(0);
     // Column header + one quality row. Exact formatting is incidental; we
@@ -1894,8 +1909,10 @@ describe("CLI integration: eval-providers", () => {
     expect(stdout).toContain("description");
     expect(stdout).toContain("requires");
     expect(stdout).toContain("quality");
+    expect(stdout).toContain("skill-creator");
     expect(stdout).toContain("1.0.0");
     expect(stdout).toContain("Static linter for SKILL.md");
+    expect(stdout).toContain("Deterministic SKILL.md validation");
   });
 
   test("eval-providers list --json emits a parseable array", async () => {
@@ -1907,7 +1924,7 @@ describe("CLI integration: eval-providers", () => {
     expect(exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
     expect(Array.isArray(parsed)).toBe(true);
-    expect(parsed.length).toBeGreaterThanOrEqual(1);
+    expect(parsed.length).toBeGreaterThanOrEqual(2);
     const quality = parsed.find((p: { id: string }) => p.id === "quality");
     expect(quality).toBeTruthy();
     expect(quality.version).toBe("1.0.0");
@@ -1915,6 +1932,12 @@ describe("CLI integration: eval-providers", () => {
     expect(typeof quality.description).toBe("string");
     expect(quality.description.length).toBeGreaterThan(0);
     expect(Array.isArray(quality.requires)).toBe(true);
+    const skillCreator = parsed.find(
+      (p: { id: string }) => p.id === "skill-creator",
+    );
+    expect(skillCreator).toBeTruthy();
+    expect(skillCreator.version).toBe("1.0.0");
+    expect(skillCreator.schemaVersion).toBe(1);
   });
 
   test("eval-providers with no subcommand exits with code 2", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -122,12 +122,14 @@ import {
   type EvalTarget,
   type EvalProvenance,
 } from "./evaluator";
+import { ensureEvalBuiltins, getEvalProviders } from "./eval/builtins";
 import { runProvider } from "./eval/runner";
+import { list as listEvalProviders } from "./eval/registry";
 import {
-  resolve as resolveEvalProvider,
-  list as listEvalProviders,
-} from "./eval/registry";
-import { registerBuiltins } from "./eval/providers";
+  sortProviderReports,
+  toProviderEvalReport,
+  type ProviderEvalReport,
+} from "./eval/summary";
 import {
   formatMachineOutput,
   formatMachineError,
@@ -2781,17 +2783,6 @@ ${ansi.bold("Examples:")}
   asm eval-providers list                            ${ansi.dim("List registered eval providers")}`);
 }
 
-// Idempotency guard: `register()` throws on duplicate (id, version) so we only
-// call `registerBuiltins()` once per process lifetime. cmdEval and
-// cmdEvalProviders both call `ensureEvalBuiltins()` at entry; tests that reset
-// the registry directly are responsible for their own registration.
-let _evalBuiltinsRegistered = false;
-function ensureEvalBuiltins(): void {
-  if (_evalBuiltinsRegistered) return;
-  registerBuiltins();
-  _evalBuiltinsRegistered = true;
-}
-
 /**
  * If a `runProvider()` result carries an error-shaped finding (the runner's
  * error-wrap path), re-throw so the existing catch block in `cmdEval` keeps
@@ -2875,18 +2866,39 @@ async function fetchRemoteForEval(
   return { rootDir, cleanup, sourceRef, commitSha };
 }
 
-async function runSingleEval(
-  target: EvalTarget,
-): Promise<{ report: EvaluationReport | null; error: string | null }> {
+async function runSingleEval(target: EvalTarget): Promise<{
+  report: (EvaluationReport & { providers: ProviderEvalReport[] }) | null;
+  error: string | null;
+}> {
   ensureEvalBuiltins();
-  const provider = resolveEvalProvider("quality", "^1.0.0");
   try {
-    const result = await runProvider(provider, {
+    const ctx = {
       skillPath: target.skillPath,
       skillMdPath: target.skillMdPath,
-    });
-    unwrapRunnerErrorOrThrow(result);
-    return { report: result.raw as EvaluationReport, error: null };
+    };
+    const results = (
+      await Promise.all(
+        sortProviderReports(getEvalProviders()).map(async (provider) => {
+          const applicable = await provider.applicable(ctx, {});
+          if (!applicable.ok) return null;
+          return runProvider(provider, ctx);
+        }),
+      )
+    ).filter((result): result is NonNullable<typeof result> => result !== null);
+
+    const quality = results.find((result) => result.providerId === "quality");
+    if (!quality) {
+      throw new Error("quality provider did not produce a result");
+    }
+    unwrapRunnerErrorOrThrow(quality);
+    const report = quality.raw as EvaluationReport;
+    return {
+      report: {
+        ...report,
+        providers: sortProviderReports(results.map(toProviderEvalReport)),
+      },
+      error: null,
+    };
   } catch (err: any) {
     return { report: null, error: err?.message ?? String(err) };
   }

--- a/src/eval/builtins.ts
+++ b/src/eval/builtins.ts
@@ -1,0 +1,23 @@
+import { registerBuiltins } from "./providers";
+import {
+  list as listEvalProviders,
+  resolve as resolveEvalProvider,
+} from "./registry";
+
+let builtinsRegistered = false;
+
+export function ensureEvalBuiltins(): void {
+  if (builtinsRegistered) return;
+  registerBuiltins();
+  builtinsRegistered = true;
+}
+
+export function getEvalProviders() {
+  ensureEvalBuiltins();
+  return listEvalProviders();
+}
+
+export function getEvalProvider(id: string, range: string) {
+  ensureEvalBuiltins();
+  return resolveEvalProvider(id, range);
+}

--- a/src/eval/providers/index.test.ts
+++ b/src/eval/providers/index.test.ts
@@ -11,12 +11,12 @@ describe("registerBuiltins", () => {
     expect(typeof registerBuiltins).toBe("function");
   });
 
-  it("registers the quality provider", () => {
+  it("registers the built-in providers", () => {
     registerBuiltins();
     const providers = list();
-    expect(providers).toHaveLength(1);
+    expect(providers).toHaveLength(2);
     const ids = providers.map((p) => p.id).sort();
-    expect(ids).toEqual(["quality"]);
+    expect(ids).toEqual(["quality", "skill-creator"]);
     for (const p of providers) {
       expect(p.version).toBe("1.0.0");
       expect(p.schemaVersion).toBe(1);
@@ -27,6 +27,13 @@ describe("registerBuiltins", () => {
     registerBuiltins();
     const provider = resolve("quality", "^1.0.0");
     expect(provider.id).toBe("quality");
+    expect(provider.version).toBe("1.0.0");
+  });
+
+  it("makes skill-creator resolvable via semver range", () => {
+    registerBuiltins();
+    const provider = resolve("skill-creator", "^1.0.0");
+    expect(provider.id).toBe("skill-creator");
     expect(provider.version).toBe("1.0.0");
   });
 

--- a/src/eval/providers/index.ts
+++ b/src/eval/providers/index.ts
@@ -13,6 +13,7 @@
 
 import { register } from "../registry";
 import { qualityProviderV1 } from "./quality/v1";
+import { skillCreatorProviderV1 } from "./skill-creator/v1";
 
 /**
  * Register every built-in provider with the shared registry.
@@ -23,4 +24,5 @@ import { qualityProviderV1 } from "./quality/v1";
  */
 export function registerBuiltins(): void {
   register(qualityProviderV1);
+  register(skillCreatorProviderV1);
 }

--- a/src/eval/providers/skill-creator/v1/index.test.ts
+++ b/src/eval/providers/skill-creator/v1/index.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { runProvider } from "../../../runner";
+import { skillCreatorProviderV1 } from "./index";
+
+async function withSkill(
+  content: string,
+  testFn: (skillPath: string) => Promise<void>,
+): Promise<void> {
+  const skillPath = await mkdtemp(join(tmpdir(), "skill-creator-provider-"));
+  try {
+    await writeFile(join(skillPath, "SKILL.md"), content, "utf-8");
+    await testFn(skillPath);
+  } finally {
+    await rm(skillPath, { recursive: true, force: true });
+  }
+}
+
+async function run(content: string) {
+  let result: Awaited<ReturnType<typeof runProvider>> | null = null;
+  await withSkill(content, async (skillPath) => {
+    result = await runProvider(skillCreatorProviderV1, {
+      skillPath,
+      skillMdPath: join(skillPath, "SKILL.md"),
+    });
+  });
+  return result!;
+}
+
+describe("skillCreatorProviderV1", () => {
+  it("accepts a valid skill", async () => {
+    const result = await run(`---
+name: valid-skill
+description: Validate a skill when asked. Don't use for unrelated docs.
+license: MIT
+compatibility: Claude Code
+effort: medium
+metadata:
+  version: 1.0.0
+---
+
+# Valid
+`);
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.findings).toHaveLength(0);
+    expect(result.categories[0]?.score).toBe(result.categories[0]?.max);
+  });
+
+  it("fails when frontmatter is missing", async () => {
+    const result = await run(`# Missing
+
+No frontmatter here.
+`);
+    expect(result.passed).toBe(false);
+    expect(result.findings.some((f) => f.code === "missing-frontmatter")).toBe(
+      true,
+    );
+  });
+
+  it("fails when YAML is invalid", async () => {
+    const result = await run(`---
+name: bad
+description: [unterminated
+---
+`);
+    expect(result.passed).toBe(false);
+    expect(result.findings.some((f) => f.code === "invalid-yaml")).toBe(true);
+  });
+
+  it("fails on disallowed keys", async () => {
+    const result = await run(`---
+name: disallowed-key
+description: Validate a skill when asked. Don't use for unrelated docs.
+creator: Somebody
+---
+`);
+    expect(result.passed).toBe(false);
+    expect(result.findings.some((f) => f.code === "allowed-keys")).toBe(true);
+  });
+
+  it("fails on invalid effort values", async () => {
+    const result = await run(`---
+name: invalid-effort
+description: Validate a skill when asked. Don't use for unrelated docs.
+effort: XL
+---
+`);
+    expect(result.passed).toBe(false);
+    expect(result.findings.some((f) => f.code === "effort-enum")).toBe(true);
+  });
+
+  it("fails when required fields are missing", async () => {
+    const result = await run(`---
+license: MIT
+---
+`);
+    expect(result.passed).toBe(false);
+    expect(result.findings.some((f) => f.code === "name-present")).toBe(true);
+    expect(result.findings.some((f) => f.code === "description-present")).toBe(
+      true,
+    );
+  });
+
+  it("emits a warning when negative-trigger guidance is missing", async () => {
+    const result = await run(`---
+name: warning-skill
+description: Validate a skill when asked.
+---
+`);
+    expect(result.passed).toBe(true);
+    expect(
+      result.findings.some(
+        (f) => f.code === "negative-trigger-clause" && f.severity === "warning",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/eval/providers/skill-creator/v1/index.ts
+++ b/src/eval/providers/skill-creator/v1/index.ts
@@ -1,0 +1,369 @@
+import { readFile, stat } from "fs/promises";
+import { parse as parseYaml } from "yaml";
+import type {
+  ApplicableResult,
+  EvalOpts,
+  EvalProvider,
+  EvalResult,
+  Finding,
+  SkillContext,
+} from "../../../types";
+
+const PROVIDER_ID = "skill-creator";
+const PROVIDER_VERSION = "1.0.0";
+const SCHEMA_VERSION = 1;
+
+const ALLOWED_PROPERTIES = new Set([
+  "name",
+  "description",
+  "license",
+  "allowed-tools",
+  "metadata",
+  "compatibility",
+  "effort",
+]);
+
+const VALID_EFFORT_LEVELS = new Set(["low", "medium", "high", "max"]);
+
+interface ValidationCheck {
+  id: string;
+  label: string;
+  passed: boolean;
+  severity: "error" | "warning";
+  message: string;
+}
+
+interface ValidationPayload {
+  skillPath: string;
+  skillMdPath: string;
+  validatedAt: string;
+  checkCount: number;
+  passedChecks: number;
+  checks: ValidationCheck[];
+  frontmatter: Record<string, unknown> | null;
+}
+
+function extractFrontmatter(content: string): string | null {
+  if (!content.startsWith("---")) return null;
+  const lines = content.split("\n");
+  if (lines.length < 3 || lines[0]?.trim() !== "---") return null;
+  const closingIndex = lines.findIndex(
+    (line, index) => index > 0 && line.trim() === "---",
+  );
+  if (closingIndex === -1) return null;
+  return lines.slice(1, closingIndex).join("\n");
+}
+
+function toFinding(check: ValidationCheck): Finding {
+  return {
+    severity: check.severity,
+    message: check.message,
+    code: check.id,
+    categoryId: "validation",
+  };
+}
+
+function pushCheck(
+  checks: ValidationCheck[],
+  id: string,
+  label: string,
+  passed: boolean,
+  severity: "error" | "warning",
+  message: string,
+): void {
+  checks.push({ id, label, passed, severity, message });
+}
+
+function buildRaw(
+  ctx: SkillContext,
+  checks: ValidationCheck[],
+  frontmatter: Record<string, unknown> | null,
+): ValidationPayload {
+  const errorChecks = checks.filter((check) => check.severity === "error");
+  return {
+    skillPath: ctx.skillPath,
+    skillMdPath: ctx.skillMdPath,
+    validatedAt: new Date().toISOString(),
+    checkCount: errorChecks.length,
+    passedChecks: errorChecks.filter((check) => check.passed).length,
+    checks,
+    frontmatter,
+  };
+}
+
+async function validate(ctx: SkillContext): Promise<{
+  score: number;
+  passed: boolean;
+  findings: Finding[];
+  raw: ValidationPayload;
+}> {
+  const content = await readFile(ctx.skillMdPath, "utf-8");
+  const checks: ValidationCheck[] = [];
+  const frontmatterBlock = extractFrontmatter(content);
+
+  if (frontmatterBlock === null) {
+    pushCheck(
+      checks,
+      "missing-frontmatter",
+      "Frontmatter exists",
+      false,
+      "error",
+      "SKILL.md must start with a YAML frontmatter block.",
+    );
+    const raw = buildRaw(ctx, checks, null);
+    return {
+      score: 0,
+      passed: false,
+      findings: checks.map(toFinding),
+      raw,
+    };
+  }
+
+  pushCheck(
+    checks,
+    "frontmatter-present",
+    "Frontmatter exists",
+    true,
+    "error",
+    "SKILL.md contains a YAML frontmatter block.",
+  );
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(frontmatterBlock);
+  } catch (err: any) {
+    pushCheck(
+      checks,
+      "invalid-yaml",
+      "Frontmatter parses as YAML",
+      false,
+      "error",
+      `Invalid YAML in frontmatter: ${err?.message ?? String(err)}`,
+    );
+    const raw = buildRaw(ctx, checks, null);
+    return {
+      score: 0,
+      passed: false,
+      findings: checks.map(toFinding),
+      raw,
+    };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    pushCheck(
+      checks,
+      "frontmatter-not-object",
+      "Frontmatter is a mapping",
+      false,
+      "error",
+      "Frontmatter must parse to a YAML object.",
+    );
+    const raw = buildRaw(ctx, checks, null);
+    return {
+      score: 0,
+      passed: false,
+      findings: checks.map(toFinding),
+      raw,
+    };
+  }
+
+  const frontmatter = parsed as Record<string, unknown>;
+  pushCheck(
+    checks,
+    "frontmatter-object",
+    "Frontmatter is a mapping",
+    true,
+    "error",
+    "Frontmatter parses to a YAML object.",
+  );
+
+  const unexpectedKeys = Object.keys(frontmatter).filter(
+    (key) => !ALLOWED_PROPERTIES.has(key),
+  );
+  pushCheck(
+    checks,
+    "allowed-keys",
+    "Allowed top-level keys only",
+    unexpectedKeys.length === 0,
+    "error",
+    unexpectedKeys.length === 0
+      ? "Frontmatter uses only the allowed top-level keys."
+      : `Unexpected frontmatter key(s): ${unexpectedKeys.sort().join(", ")}.`,
+  );
+
+  const name = frontmatter.name;
+  const nameString = typeof name === "string" ? name.trim() : "";
+  pushCheck(
+    checks,
+    "name-present",
+    "Name is present and non-empty",
+    nameString.length > 0,
+    "error",
+    nameString.length > 0
+      ? "Frontmatter includes a non-empty `name`."
+      : "Frontmatter must include a non-empty string `name`.",
+  );
+
+  if (nameString.length > 0) {
+    const validName =
+      /^[a-z0-9-]+$/.test(nameString) &&
+      !nameString.startsWith("-") &&
+      !nameString.endsWith("-") &&
+      !nameString.includes("--") &&
+      nameString.length <= 64;
+    pushCheck(
+      checks,
+      "name-kebab-case",
+      "Name follows skill-creator naming rules",
+      validName,
+      "error",
+      validName
+        ? "Name follows the skill-creator kebab-case naming rules."
+        : "Name must be kebab-case, avoid consecutive/edge hyphens, and stay within 64 characters.",
+    );
+  }
+
+  const description = frontmatter.description;
+  const descriptionString =
+    typeof description === "string" ? description.trim() : "";
+  pushCheck(
+    checks,
+    "description-present",
+    "Description is present and non-empty",
+    descriptionString.length > 0,
+    "error",
+    descriptionString.length > 0
+      ? "Frontmatter includes a non-empty `description`."
+      : "Frontmatter must include a non-empty string `description`.",
+  );
+
+  if (descriptionString.length > 0) {
+    const validDescription =
+      !descriptionString.includes("\n") &&
+      !descriptionString.includes("\r") &&
+      !descriptionString.includes("<") &&
+      !descriptionString.includes(">") &&
+      descriptionString.length <= 1024;
+    pushCheck(
+      checks,
+      "description-shape",
+      "Description follows skill-creator formatting rules",
+      validDescription,
+      "error",
+      validDescription
+        ? "Description is single-line, angle-bracket free, and within 1024 characters."
+        : "Description must be a single line, avoid angle brackets, and stay within 1024 characters.",
+    );
+  }
+
+  const effort = frontmatter.effort;
+  pushCheck(
+    checks,
+    "effort-enum",
+    "Effort uses the supported enum",
+    effort === undefined ||
+      (typeof effort === "string" && VALID_EFFORT_LEVELS.has(effort.trim())),
+    "error",
+    effort === undefined ||
+      (typeof effort === "string" && VALID_EFFORT_LEVELS.has(effort.trim()))
+      ? "Effort is omitted or uses a supported value."
+      : "Effort must be one of: low, medium, high, max.",
+  );
+
+  const compatibility = frontmatter.compatibility;
+  if (compatibility !== undefined) {
+    const compatibilityValid =
+      typeof compatibility === "string" && compatibility.length <= 500;
+    pushCheck(
+      checks,
+      "compatibility-shape",
+      "Compatibility is a short string",
+      compatibilityValid,
+      "error",
+      compatibilityValid
+        ? "Compatibility is a valid short string."
+        : "Compatibility must be a string no longer than 500 characters.",
+    );
+  }
+
+  const hasNegativeTriggerClause =
+    /don'?t use (?:for|when|if|on)|not (?:for|intended for|suitable for|meant for)\b|skip (?:for|when|if)|avoid (?:using )?(?:for|when|on)|never (?:use )?for\b|only (?:use )?for\b/i.test(
+      descriptionString,
+    );
+  pushCheck(
+    checks,
+    "negative-trigger-clause",
+    "Description includes a negative-trigger clause",
+    hasNegativeTriggerClause,
+    "warning",
+    hasNegativeTriggerClause
+      ? "Description names adjacent cases that should not trigger the skill."
+      : "Description appears to lack a negative-trigger clause; consider naming adjacent cases that should not trigger the skill.",
+  );
+
+  const raw = buildRaw(ctx, checks, frontmatter);
+  const score =
+    raw.checkCount === 0
+      ? 100
+      : Math.round((raw.passedChecks / raw.checkCount) * 100);
+  const findings = checks.filter((check) => !check.passed).map(toFinding);
+
+  return {
+    score,
+    passed: findings.every((finding) => finding.severity !== "error"),
+    findings,
+    raw,
+  };
+}
+
+export const skillCreatorProviderV1: EvalProvider = {
+  id: PROVIDER_ID,
+  version: PROVIDER_VERSION,
+  schemaVersion: SCHEMA_VERSION,
+  description:
+    "Deterministic SKILL.md validation ported from skill-creator rules.",
+
+  async applicable(ctx: SkillContext): Promise<ApplicableResult> {
+    try {
+      const file = await stat(ctx.skillMdPath);
+      if (!file.isFile()) {
+        return {
+          ok: false,
+          reason: `${ctx.skillMdPath} is not a file`,
+        };
+      }
+      return { ok: true };
+    } catch {
+      return {
+        ok: false,
+        reason: `SKILL.md not found at ${ctx.skillMdPath}`,
+      };
+    }
+  },
+
+  async run(ctx: SkillContext, _opts: EvalOpts): Promise<EvalResult> {
+    const result = await validate(ctx);
+    return {
+      providerId: PROVIDER_ID,
+      providerVersion: PROVIDER_VERSION,
+      schemaVersion: SCHEMA_VERSION,
+      score: result.score,
+      passed: result.passed,
+      categories: [
+        {
+          id: "validation",
+          name: "Deterministic validation",
+          score: result.raw.passedChecks,
+          max: result.raw.checkCount,
+          findings: result.findings.length > 0 ? result.findings : undefined,
+        },
+      ],
+      findings: result.findings,
+      raw: result.raw,
+      startedAt: "",
+      durationMs: 0,
+    };
+  },
+};
+
+export default skillCreatorProviderV1;

--- a/src/eval/summary.ts
+++ b/src/eval/summary.ts
@@ -1,0 +1,66 @@
+import type { SkillEvalSummary } from "../utils/types";
+import type { EvalResult } from "./types";
+
+export interface ProviderEvalReport {
+  id: string;
+  version: string;
+  schemaVersion: number;
+  score: number;
+  passed: boolean;
+  categories: EvalResult["categories"];
+  findings: EvalResult["findings"];
+  raw?: unknown;
+}
+
+export function scoreToGrade(score: number): SkillEvalSummary["grade"] {
+  if (score >= 90) return "A";
+  if (score >= 80) return "B";
+  if (score >= 65) return "C";
+  if (score >= 50) return "D";
+  return "F";
+}
+
+export function toProviderEvalReport(result: EvalResult): ProviderEvalReport {
+  return {
+    id: result.providerId,
+    version: result.providerVersion,
+    schemaVersion: result.schemaVersion,
+    score: result.score,
+    passed: result.passed,
+    categories: result.categories,
+    findings: result.findings,
+    raw: result.raw,
+  };
+}
+
+export function toSkillEvalSummary(
+  result: EvalResult,
+  evaluatedVersion?: string,
+): SkillEvalSummary {
+  return {
+    providerId: result.providerId,
+    providerVersion: result.providerVersion,
+    schemaVersion: result.schemaVersion,
+    passed: result.passed,
+    overallScore: result.score,
+    grade: scoreToGrade(result.score),
+    categories: result.categories.map((c) => ({
+      id: c.id,
+      name: c.name,
+      score: c.score,
+      max: c.max,
+    })),
+    evaluatedAt: result.startedAt,
+    evaluatedVersion,
+  };
+}
+
+export function sortProviderReports<T extends { id: string }>(
+  reports: T[],
+): T[] {
+  return [...reports].sort((a, b) => {
+    if (a.id === "quality" && b.id !== "quality") return -1;
+    if (b.id === "quality" && a.id !== "quality") return 1;
+    return a.id.localeCompare(b.id);
+  });
+}

--- a/src/evaluator.test.ts
+++ b/src/evaluator.test.ts
@@ -461,6 +461,53 @@ describe("formatters", () => {
     expect(text).toContain("Structure & completeness");
   });
 
+  it("formatReport inlines extra providers in headline and renders their findings", () => {
+    const baseReport = evaluateSkillContent({
+      content: HIGH_QUALITY_SKILL,
+      skillPath: "/virtual/code-review",
+      skillMdPath: "/virtual/code-review/SKILL.md",
+    });
+    const withProviders = {
+      ...baseReport,
+      providers: [
+        {
+          id: "quality",
+          version: "1.0.0",
+          schemaVersion: 1,
+          score: baseReport.overallScore,
+          passed: true,
+          categories: [],
+          findings: [],
+        },
+        {
+          id: "skill-creator",
+          version: "1.0.0",
+          schemaVersion: 1,
+          score: 88,
+          passed: true,
+          categories: [],
+          findings: [
+            {
+              severity: "warning" as const,
+              message: "Missing negative-trigger clause.",
+              code: "negative-trigger-clause",
+              categoryId: "validation",
+            },
+          ],
+        },
+      ],
+    };
+    const text = formatReport(withProviders);
+    // Extra provider surfaces next to the headline
+    expect(text).toContain("skill-creator@1.0.0:  88/100  pass");
+    // Quality categories appear exactly once
+    const categoriesMatches = text.match(/Structure & completeness/g) ?? [];
+    expect(categoriesMatches.length).toBe(1);
+    // Extra-provider findings render in their own block
+    expect(text).toContain("skill-creator@1.0.0 findings:");
+    expect(text).toContain("[warning] Missing negative-trigger clause.");
+  });
+
   it("formatReportJSON returns parseable JSON", () => {
     const report = evaluateSkillContent({
       content: HIGH_QUALITY_SKILL,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1415,6 +1415,13 @@ function bar(score: number, max: number, width = 20): string {
 
 /**
  * Render a human-readable evaluation report (no ANSI — the CLI adds colour).
+ *
+ * Quality is the primary provider — its score drives the `Overall score:`
+ * headline and its categories get the familiar bar chart. Any additional
+ * providers (e.g. skill-creator) are surfaced as a one-line score next to
+ * the headline plus a dedicated findings block when they have something to
+ * say. This keeps a single `asm eval` call showing all results without
+ * duplicating quality's categories under a second heading.
  */
 export function formatReport(
   report: EvaluationReport & { providers?: ProviderEvalReport[] },
@@ -1424,6 +1431,16 @@ export function formatReport(
   lines.push(`SKILL.md:         ${report.skillMdPath}`);
   lines.push("");
   lines.push(`Overall score:    ${report.overallScore}/100  (${report.grade})`);
+
+  const extraProviders = (report.providers ?? []).filter(
+    (p) => p.id !== "quality",
+  );
+  for (const provider of extraProviders) {
+    const verdict = provider.passed ? "pass" : "fail";
+    const label = `${provider.id}@${provider.version}`;
+    lines.push(`  ${label}:  ${provider.score}/100  ${verdict}`);
+  }
+
   lines.push("");
   lines.push("Categories:");
   for (const c of report.categories) {
@@ -1443,22 +1460,13 @@ export function formatReport(
   } else {
     lines.push("No suggestions — skill looks great.");
   }
-  if (report.providers && report.providers.length > 0) {
+
+  for (const provider of extraProviders) {
+    if (provider.findings.length === 0) continue;
     lines.push("");
-    lines.push("Providers:");
-    for (const provider of report.providers) {
-      const verdict = provider.passed ? "pass" : "fail";
-      lines.push(
-        `  ${provider.id}@${provider.version}  ${provider.score}/100  ${verdict}`,
-      );
-      for (const category of provider.categories) {
-        lines.push(
-          `    ${category.name.padEnd(26)} ${category.score}/${category.max}`,
-        );
-      }
-      for (const finding of provider.findings) {
-        lines.push(`    [${finding.severity}] ${finding.message}`);
-      }
+    lines.push(`${provider.id}@${provider.version} findings:`);
+    for (const finding of provider.findings) {
+      lines.push(`  [${finding.severity}] ${finding.message}`);
     }
   }
   return lines.join("\n");

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -37,6 +37,7 @@ import {
   readdir,
 } from "fs/promises";
 import { join, resolve, basename, isAbsolute } from "path";
+import type { ProviderEvalReport } from "./eval/summary";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -1415,7 +1416,9 @@ function bar(score: number, max: number, width = 20): string {
 /**
  * Render a human-readable evaluation report (no ANSI — the CLI adds colour).
  */
-export function formatReport(report: EvaluationReport): string {
+export function formatReport(
+  report: EvaluationReport & { providers?: ProviderEvalReport[] },
+): string {
   const lines: string[] = [];
   lines.push(`Skill evaluation: ${report.skillPath}`);
   lines.push(`SKILL.md:         ${report.skillMdPath}`);
@@ -1439,6 +1442,24 @@ export function formatReport(report: EvaluationReport): string {
     }
   } else {
     lines.push("No suggestions — skill looks great.");
+  }
+  if (report.providers && report.providers.length > 0) {
+    lines.push("");
+    lines.push("Providers:");
+    for (const provider of report.providers) {
+      const verdict = provider.passed ? "pass" : "fail";
+      lines.push(
+        `  ${provider.id}@${provider.version}  ${provider.score}/100  ${verdict}`,
+      );
+      for (const category of provider.categories) {
+        lines.push(
+          `    ${category.name.padEnd(26)} ${category.score}/${category.max}`,
+        );
+      }
+      for (const finding of provider.findings) {
+        lines.push(`    [${finding.severity}] ${finding.message}`);
+      }
+    }
   }
   return lines.join("\n");
 }
@@ -1913,7 +1934,7 @@ export function buildBatchMachineData(batch: EvalBatchResult) {
  * Machine-envelope friendly shape for `asm eval`.
  */
 export function buildEvalMachineData(
-  report: EvaluationReport,
+  report: EvaluationReport & { providers?: ProviderEvalReport[] },
   fix: FixResult | null = null,
 ) {
   return {
@@ -1930,6 +1951,22 @@ export function buildEvalMachineData(
       suggestions: c.suggestions,
     })),
     top_suggestions: report.topSuggestions,
+    providers:
+      report.providers?.map((provider) => ({
+        id: provider.id,
+        version: provider.version,
+        schemaVersion: provider.schemaVersion,
+        score: provider.score,
+        passed: provider.passed,
+        categories: provider.categories.map((category) => ({
+          id: category.id,
+          name: category.name,
+          score: category.score,
+          max: category.max,
+          findings: category.findings ?? [],
+        })),
+        findings: provider.findings,
+      })) ?? [],
     fix: fix
       ? {
           dry_run: fix.dryRun,

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -1125,6 +1125,45 @@ describe("formatSkillDetail token count + eval", () => {
     expect(output).toContain("Safety");
     expect(output).toContain("7/10");
   });
+
+  test("renders multiple provider summaries when available", async () => {
+    const output = await formatSkillDetail(
+      makeSkill({
+        evalSummary: undefined,
+        evalSummaries: {
+          quality: {
+            providerId: "quality",
+            providerVersion: "1.0.0",
+            overallScore: 87,
+            grade: "B",
+            categories: [
+              { id: "structure", name: "Structure", score: 9, max: 10 },
+            ],
+            evaluatedAt: "2026-04-20T10:00:00.000Z",
+          },
+          "skill-creator": {
+            providerId: "skill-creator",
+            providerVersion: "1.0.0",
+            overallScore: 100,
+            grade: "A",
+            categories: [
+              {
+                id: "validation",
+                name: "Deterministic validation",
+                score: 7,
+                max: 7,
+              },
+            ],
+            evaluatedAt: "2026-04-20T10:00:01.000Z",
+          },
+        },
+      }),
+    );
+    expect(output).toContain("quality@1.0.0");
+    expect(output).toContain("skill-creator@1.0.0");
+    expect(output).toContain("Deterministic validation");
+    expect(output).toContain("7/7");
+  });
 });
 
 describe("formatGroupedTable token column", () => {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -764,20 +764,40 @@ export async function formatSkillDetail(skill: SkillInfo): Promise<string> {
   // "broken or missing".
   lines.push("");
   lines.push(useColor() ? ansi.bold("Eval Score:") : "Eval Score:");
-  if (skill.evalSummary) {
-    const ev = skill.evalSummary;
-    const overallColored = colorEvalScore(ev.overallScore);
-    lines.push(`  Overall: ${overallColored} / 100  (${ev.grade})`);
-    const evVer = ev.evaluatedVersion
-      ? ` — version ${ev.evaluatedVersion}`
-      : "";
-    lines.push(
-      `  ${useColor() ? ansi.dim("Evaluated:") : "Evaluated:"} ${ev.evaluatedAt}${evVer}`,
-    );
-    if (ev.categories.length > 0) {
-      lines.push(useColor() ? ansi.dim("  Categories:") : "  Categories:");
-      for (const c of ev.categories) {
-        lines.push(`    ${c.name.padEnd(28)} ${c.score}/${c.max}`);
+  const evalSummaries = getEvalSummaries(skill);
+  if (evalSummaries.length > 0) {
+    const multipleProviders = evalSummaries.length > 1;
+    for (const ev of evalSummaries) {
+      const overallColored = colorEvalScore(ev.overallScore);
+      const providerLabel = ev.providerId
+        ? `${ev.providerId}@${ev.providerVersion ?? "?"}`
+        : "quality";
+      if (multipleProviders) {
+        lines.push(
+          `  ${providerLabel}: ${overallColored} / 100  (${ev.grade})`,
+        );
+      } else {
+        lines.push(`  Overall: ${overallColored} / 100  (${ev.grade})`);
+      }
+      const evVer = ev.evaluatedVersion
+        ? ` — version ${ev.evaluatedVersion}`
+        : "";
+      lines.push(
+        `  ${useColor() ? ansi.dim("Evaluated:") : "Evaluated:"} ${ev.evaluatedAt}${evVer}`,
+      );
+      if (ev.categories.length > 0) {
+        if (multipleProviders) {
+          lines.push(
+            useColor()
+              ? ansi.dim(`  Categories (${providerLabel}):`)
+              : `  Categories (${providerLabel}):`,
+          );
+        } else {
+          lines.push(useColor() ? ansi.dim("  Categories:") : "  Categories:");
+        }
+        for (const c of ev.categories) {
+          lines.push(`    ${c.name.padEnd(28)} ${c.score}/${c.max}`);
+        }
       }
     }
   } else {
@@ -818,6 +838,24 @@ export function colorEvalScore(score: number): string {
   if (score >= 80) return ansi.cyan(txt);
   if (score >= 65) return ansi.yellow(txt);
   return ansi.red(txt);
+}
+
+function getEvalSummaries(
+  skill: SkillInfo,
+): NonNullable<SkillInfo["evalSummary"]>[] {
+  if (skill.evalSummaries && Object.keys(skill.evalSummaries).length > 0) {
+    const summaries = Object.values(skill.evalSummaries) as NonNullable<
+      SkillInfo["evalSummary"]
+    >[];
+    return summaries.sort((a, b) => {
+      const aId = a.providerId ?? "quality";
+      const bId = b.providerId ?? "quality";
+      if (aId === "quality" && bId !== "quality") return -1;
+      if (bId === "quality" && aId !== "quality") return 1;
+      return aId.localeCompare(bId);
+    });
+  }
+  return skill.evalSummary ? [skill.evalSummary] : [];
 }
 
 // ─── Multi-instance detail formatter ────────────────────────────────────────
@@ -868,19 +906,31 @@ export async function formatSkillInspect(skills: SkillInfo[]): Promise<string> {
   // Eval summary block
   lines.push("");
   lines.push(useColor() ? ansi.bold("  Eval Score:") : "  Eval Score:");
-  if (ref.evalSummary) {
-    const ev = ref.evalSummary;
-    const overallColored = colorEvalScore(ev.overallScore);
-    lines.push(`    Overall: ${overallColored} / 100  (${ev.grade})`);
-    const evVer = ev.evaluatedVersion
-      ? ` — version ${ev.evaluatedVersion}`
-      : "";
-    lines.push(
-      `    ${useColor() ? ansi.dim("Evaluated:") : "Evaluated:"} ${ev.evaluatedAt}${evVer}`,
-    );
-    if (ev.categories.length > 0) {
-      for (const c of ev.categories) {
-        lines.push(`      ${c.name.padEnd(28)} ${c.score}/${c.max}`);
+  const refEvalSummaries = getEvalSummaries(ref);
+  if (refEvalSummaries.length > 0) {
+    const multipleProviders = refEvalSummaries.length > 1;
+    for (const ev of refEvalSummaries) {
+      const overallColored = colorEvalScore(ev.overallScore);
+      const providerLabel = ev.providerId
+        ? `${ev.providerId}@${ev.providerVersion ?? "?"}`
+        : "quality";
+      if (multipleProviders) {
+        lines.push(
+          `    ${providerLabel}: ${overallColored} / 100  (${ev.grade})`,
+        );
+      } else {
+        lines.push(`    Overall: ${overallColored} / 100  (${ev.grade})`);
+      }
+      const evVer = ev.evaluatedVersion
+        ? ` — version ${ev.evaluatedVersion}`
+        : "";
+      lines.push(
+        `    ${useColor() ? ansi.dim("Evaluated:") : "Evaluated:"} ${ev.evaluatedAt}${evVer}`,
+      );
+      if (ev.categories.length > 0) {
+        for (const c of ev.categories) {
+          lines.push(`      ${c.name.padEnd(28)} ${c.score}/${c.max}`);
+        }
       }
     }
   } else {

--- a/src/ingester.test.ts
+++ b/src/ingester.test.ts
@@ -346,4 +346,37 @@ example
     expect(typeof slim.evaluatedAt).toBe("string");
     expect(slim.evaluatedVersion).toBe("0.2.0");
   });
+
+  it("projects provider summaries with provider metadata", async () => {
+    const { toSkillEvalSummary } = await import("./eval/summary");
+    const summary = toSkillEvalSummary(
+      {
+        providerId: "skill-creator",
+        providerVersion: "1.0.0",
+        schemaVersion: 1,
+        score: 100,
+        passed: true,
+        categories: [
+          {
+            id: "validation",
+            name: "Deterministic validation",
+            score: 7,
+            max: 7,
+          },
+        ],
+        findings: [],
+        startedAt: "2026-04-21T10:00:00.000Z",
+        durationMs: 3,
+      },
+      "0.2.0",
+    );
+
+    expect(summary.providerId).toBe("skill-creator");
+    expect(summary.providerVersion).toBe("1.0.0");
+    expect(summary.schemaVersion).toBe(1);
+    expect(summary.passed).toBe(true);
+    expect(summary.overallScore).toBe(100);
+    expect(summary.grade).toBe("A");
+    expect(summary.categories).toHaveLength(1);
+  });
 });

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -13,6 +13,9 @@ import { debug } from "./logger";
 import { verifySkill } from "./verifier";
 import { estimateTokenCount } from "./utils/token-count";
 import { evaluateSkillContent } from "./evaluator";
+import { getEvalProviders } from "./eval/builtins";
+import { runProvider } from "./eval/runner";
+import { sortProviderReports, toSkillEvalSummary } from "./eval/summary";
 import type {
   RepoIndex,
   IndexedSkill,
@@ -95,6 +98,7 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
       // user runs `asm install`. We intentionally drop findings/suggestions
       // from the catalog payload to keep catalog.json small.
       let evalSummary: SkillEvalSummary | undefined;
+      let evalSummaries: IndexedSkill["evalSummaries"] | undefined;
       if (skillMdContent) {
         try {
           const report = evaluateSkillContent({
@@ -119,6 +123,36 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
           // ingest because one skill produced a malformed evaluator result.
           debug(`ingester: eval failed for ${skill.name}: ${err}`);
         }
+
+        try {
+          const ctx = {
+            skillPath: join(tempDir, skill.relPath),
+            skillMdPath,
+          };
+          const providerResults = await Promise.all(
+            sortProviderReports(getEvalProviders()).map(async (provider) => {
+              const applicable = await provider.applicable(ctx, {});
+              if (!applicable.ok) return null;
+              return runProvider(provider, ctx);
+            }),
+          );
+          const summaries = providerResults
+            .filter(
+              (result): result is NonNullable<typeof result> => result !== null,
+            )
+            .map((result) =>
+              toSkillEvalSummary(result, skill.version || undefined),
+            );
+          if (summaries.length > 0) {
+            evalSummaries = Object.fromEntries(
+              summaries
+                .filter((summary) => summary.providerId)
+                .map((summary) => [summary.providerId!, summary]),
+            );
+          }
+        } catch (err) {
+          debug(`ingester: provider eval failed for ${skill.name}: ${err}`);
+        }
       }
 
       skills.push({
@@ -134,6 +168,7 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
         verified: verification.verified,
         tokenCount,
         evalSummary,
+        evalSummaries,
       });
     }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -37,6 +37,8 @@ export interface SkillInfo {
    * Filled in by callers that opt to enrich (e.g., the TUI detail view).
    */
   evalSummary?: SkillEvalSummary;
+  /** Provider-keyed summaries for all registered eval providers. */
+  evalSummaries?: Record<string, SkillEvalSummary>;
   /** Marketplace name when skill was installed via Claude plugin marketplace */
   marketplace?: string;
   /** Codex plugin metadata when skill was discovered via Codex plugin cache */
@@ -59,6 +61,14 @@ export interface SkillInfo {
  * would bloat the payload by ~1MB+ for a few hundred skills.
  */
 export interface SkillEvalSummary {
+  /** Provider id that produced the summary (e.g. `quality`). */
+  providerId?: string;
+  /** Provider version that produced the summary. */
+  providerVersion?: string;
+  /** Eval result schema version for this provider summary. */
+  schemaVersion?: number;
+  /** Whether the provider considered the skill a pass. */
+  passed?: boolean;
   /** 0..100 normalized score across all categories. */
   overallScore: number;
   /** Letter grade for quick scanning. */
@@ -316,6 +326,8 @@ export interface IndexedSkill {
    * surfaces (website + TUI + CLI inspect).
    */
   evalSummary?: SkillEvalSummary;
+  /** Provider-keyed summaries for all registered eval providers. */
+  evalSummaries?: Record<string, SkillEvalSummary>;
 }
 
 export interface RepoIndex {

--- a/src/views/skill-detail.ts
+++ b/src/views/skill-detail.ts
@@ -13,6 +13,24 @@ const EFFORT_COLORS: Record<string, string> = {
   max: theme.accentAlt, // magenta
 };
 
+function getEvalSummaries(
+  skill: SkillInfo,
+): NonNullable<SkillInfo["evalSummary"]>[] {
+  if (skill.evalSummaries && Object.keys(skill.evalSummaries).length > 0) {
+    const summaries = Object.values(skill.evalSummaries) as NonNullable<
+      SkillInfo["evalSummary"]
+    >[];
+    return summaries.sort((a, b) => {
+      const aId = a.providerId ?? "quality";
+      const bId = b.providerId ?? "quality";
+      if (aId === "quality" && bId !== "quality") return -1;
+      if (bId === "quality" && aId !== "quality") return 1;
+      return aId.localeCompare(bId);
+    });
+  }
+  return skill.evalSummary ? [skill.evalSummary] : [];
+}
+
 function detailRow(
   ctx: RenderContext,
   id: string,
@@ -65,11 +83,17 @@ export function createDetailView(
         ? 3
         : 2
       : 0;
+  const evalSummaries = getEvalSummaries(skill);
   // Eval section: 2 lines for label + body in empty state, or
-  // 3 + categories (up to 7) in populated state.
-  const evalRows = skill.evalSummary
-    ? 3 + skill.evalSummary.categories.length
-    : 2;
+  // 2 lines per summary plus category rows. Multi-provider mode adds the
+  // provider label inline rather than creating separate section headers.
+  const evalRows =
+    evalSummaries.length > 0
+      ? evalSummaries.reduce(
+          (sum: number, summary) => sum + 2 + summary.categories.length,
+          0,
+        )
+      : 2;
   const boxHeight = Math.min(
     ctx.height - 2,
     10 +
@@ -244,39 +268,46 @@ export function createDetailView(
   });
   container.add(evalLabel);
 
-  if (skill.evalSummary) {
-    const ev = skill.evalSummary;
-    const overallColor =
-      ev.overallScore >= 90
-        ? theme.green
-        : ev.overallScore >= 80
-          ? theme.cyan
-          : ev.overallScore >= 65
-            ? theme.yellow
-            : theme.red;
-    container.add(
-      new TextRenderable(ctx, {
-        content: `  Overall: ${ev.overallScore}/100  (${ev.grade})`,
-        fg: overallColor,
-        height: 1,
-      }),
-    );
-    const evVer = ev.evaluatedVersion ? ` — v${ev.evaluatedVersion}` : "";
-    container.add(
-      new TextRenderable(ctx, {
-        content: `  Evaluated: ${ev.evaluatedAt}${evVer}`,
-        fg: theme.fgDim,
-        height: 1,
-      }),
-    );
-    for (const c of ev.categories) {
+  if (evalSummaries.length > 0) {
+    const multipleProviders = evalSummaries.length > 1;
+    for (const ev of evalSummaries) {
+      const overallColor =
+        ev.overallScore >= 90
+          ? theme.green
+          : ev.overallScore >= 80
+            ? theme.cyan
+            : ev.overallScore >= 65
+              ? theme.yellow
+              : theme.red;
+      const providerLabel = ev.providerId
+        ? `${ev.providerId}@${ev.providerVersion ?? "?"}`
+        : "quality";
       container.add(
         new TextRenderable(ctx, {
-          content: `    ${c.name.padEnd(28)} ${c.score}/${c.max}`,
-          fg: theme.fg,
+          content: multipleProviders
+            ? `  ${providerLabel}: ${ev.overallScore}/100  (${ev.grade})`
+            : `  Overall: ${ev.overallScore}/100  (${ev.grade})`,
+          fg: overallColor,
           height: 1,
         }),
       );
+      const evVer = ev.evaluatedVersion ? ` — v${ev.evaluatedVersion}` : "";
+      container.add(
+        new TextRenderable(ctx, {
+          content: `  Evaluated: ${ev.evaluatedAt}${evVer}`,
+          fg: theme.fgDim,
+          height: 1,
+        }),
+      );
+      for (const c of ev.categories) {
+        container.add(
+          new TextRenderable(ctx, {
+            content: `    ${c.name.padEnd(28)} ${c.score}/${c.max}`,
+            fg: theme.fg,
+            height: 1,
+          }),
+        );
+      }
     }
   } else {
     container.add(


### PR DESCRIPTION
## Summary
- add a new built-in skill-creator 1.0.0 eval provider that ports the deterministic SKILL.md validation rules from skill-creator
- thread provider summaries through asm eval, skill indexing, formatter output, and detail views while preserving the legacy quality report shape
- cover provider registration, provider behavior, CLI output, and formatter/index integration with targeted tests

## Details
- validates frontmatter presence and parsing, allowed top-level keys, required name and description fields, and the effort enum
- includes provider metadata in JSON and machine output and surfaces provider summaries alongside the existing quality summary in detail and TUI views
- evaluates built-in providers during ingestion so indexed skills carry deterministic eval summaries for catalog surfaces

## Testing
- bun run typecheck
- bun test src/eval/providers/index.test.ts src/eval/providers/quality/v1/index.test.ts src/eval/providers/skill-creator/v1/index.test.ts src/formatter.test.ts src/cli.test.ts
- push hooks: build
- push hooks: e2e tests (bun)

Closes #197