### PR TITLE
test: isolate publisher + import tests from host state (#167)

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -2124,12 +2124,14 @@ describe("CLI integration: import", () => {
     );
     expect(exitCode).toBe(0);
     const result = JSON.parse(stdout);
-    // Most should be skipped (1 expected failure: codex-plugin provider missing locally)
-    expect(result.failed).toBe(1);
+    // Importing an export of the host's own state: nothing should install,
+    // every result is either skipped (provider present, already installed) or
+    // failed (provider missing on this host). The per-host failed count is not
+    // stable — it depends on which providers are configured — so we assert on
+    // the invariant instead: no results outside {skipped, failed}.
+    expect(result.installed).toBe(0);
     for (const r of result.results) {
-      if (r.status !== "failed") {
-        expect(r.status).toBe("skipped");
-      }
+      expect(["skipped", "failed"]).toContain(r.status);
     }
   });
 

--- a/src/publisher.test.ts
+++ b/src/publisher.test.ts
@@ -535,6 +535,30 @@ describe("publishSkill", () => {
     return async () => ({ ...makeDummySecurityReport(), ...overrides });
   }
 
+  // Tests must be host-independent: they should not take a different branch
+  // through publishSkill depending on whether the developer happens to have `gh`
+  // installed and authenticated. Each test that reaches step 6 passes this stub
+  // so results match across dev machines, CI, and the pre-commit hook.
+  function fakeGhCli(
+    overrides: Partial<{
+      available: boolean;
+      authenticated: boolean;
+      login: string | null;
+    }> = {},
+  ): () => Promise<{
+    available: boolean;
+    authenticated: boolean;
+    login: string | null;
+  }> {
+    const result = {
+      available: true,
+      authenticated: true,
+      login: "testuser",
+      ...overrides,
+    };
+    return async () => result;
+  }
+
   beforeEach(async () => {
     gitDir = await mkdtemp(join(tmpdir(), "publish-integ-"));
     // Init git repo
@@ -619,6 +643,7 @@ describe("publishSkill", () => {
         verdict: "warning",
         verdictReason: "Suspicious patterns detected",
       }),
+      _checkGhCliFn: fakeGhCli(),
     });
 
     // With --force + --dry-run, should succeed past the verdict check
@@ -653,6 +678,7 @@ describe("publishSkill", () => {
         verdict: "safe",
         verdictReason: "No issues found",
       }),
+      _checkGhCliFn: fakeGhCli(),
     });
 
     expect(result.success).toBe(true);
@@ -676,6 +702,7 @@ describe("publishSkill", () => {
         verdict: "safe",
         verdictReason: "Clean",
       }),
+      _checkGhCliFn: fakeGhCli(),
     });
 
     expect(result.success).toBe(true);
@@ -707,8 +734,9 @@ describe("publishSkill", () => {
   });
 
   test("fallback path when gh CLI is unavailable", async () => {
-    // Run with dry-run to avoid needing gh
-    // The test verifies the pipeline up through manifest generation
+    // This test's point is to exercise the `gh not available` branch explicitly.
+    // Stub gh as unavailable so the test runs the same whether or not the host
+    // has gh installed; the fallback path still produces a valid manifest.
     const result = await publishSkill({
       path: gitDir,
       dryRun: true,
@@ -718,9 +746,11 @@ describe("publishSkill", () => {
         verdict: "safe",
         verdictReason: "No issues found",
       }),
+      _checkGhCliFn: fakeGhCli({ available: false, authenticated: false }),
     });
 
-    // Regardless of gh availability, dry-run should succeed with a manifest
+    // Fallback path should still succeed with a manifest — PR creation is
+    // skipped, author falls back to metadata.creator.
     expect(result.success).toBe(true);
     expect(result.manifest).not.toBeNull();
     expect(result.error).toBeNull();
@@ -747,6 +777,7 @@ describe("publishSkill", () => {
       force: false,
       yes: true,
       _auditFn: fakeAudit({ verdict: "safe", verdictReason: "OK" }),
+      _checkGhCliFn: fakeGhCli(),
     });
 
     expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary

Fixes #167 — five tests that failed locally for contributors depending on host state (`gh` CLI auth, installed skill providers) while passing on CI.

## Root causes

**publisher.test.ts — 4 tests reach step 6 of `publishSkill` without injecting `_checkGhCliFn`**

Failing:
- `--force overrides warning verdict`
- `--dry-run exits before side effects with valid manifest`
- `dry-run manifest includes correct metadata fields`
- `fallback path when gh CLI is unavailable`

These tests dry-run the publisher pipeline but reach past the security verdict check into step 6, which invokes the real `gh` CLI unless the `_checkGhCliFn` override is passed. On hosts where \`gh\` is authed as a user other than \`testuser\`, or returns a transient API error, the branch taken diverged from what assertions expected.

The test literally named \`fallback path when gh CLI is unavailable\` was not actually testing the fallback path on any machine with \`gh\` installed.

**cli.test.ts — `import existing skills are skipped` hardcoded a magic number**

\`expect(result.failed).toBe(1)\` only matched one developer's machine. Reporter saw \`38\`, CI saw \`0\`, others pass with \`1\`. The test re-imports an export of the host's own installed skills — `failed` equals the count of missing providers on that specific host.

## Fix

- Add a `fakeGhCli()` helper next to `fakeAudit()` in `publisher.test.ts`, inject it into all 5 tests in the \`publishSkill\` describe block that reach step 6. The "gh unavailable" test now stubs \`{ available: false }\` explicitly.
- Replace the magic number in `import existing skills are skipped` with the real invariant: \`installed === 0\` and every result is \`"skipped"\` or \`"failed"\`.

## Side effect

Publisher test suite runs ~3× faster (8.6s → 2.8s) — no more subprocess spawns for \`gh\`.

## Test plan

- [x] \`bun test src/publisher.test.ts\` — 69/69 pass
- [x] \`bun test src/cli.test.ts\` — 298/298 pass
- [x] \`bun test src/\` — 1530/1530 pass
- [x] \`bun run --bun tsc --noEmit\` — clean
- [x] Pre-commit and pre-push hooks pass (incl. typecheck, unit tests, build, e2e tests)
- [ ] Please verify on the environment that originally hit #167 — I could not reproduce the original failures locally, so the fix is principled (removes host-state dependence) rather than directly witnessed as a failure → pass transition.