### PR TITLE
feat(bundles): ship pre-defined bundles with ASM for popular use cases

### DIFF
--- a/data/bundles/content-writing.json
+++ b/data/bundles/content-writing.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "name": "content-writing",
+  "description": "Content creation and marketing skills: blog drafting, social media posts, Reddit writing, and SEO optimization.",
+  "author": "ASM",
+  "createdAt": "2025-01-01T00:00:00.000Z",
+  "tags": ["content", "marketing", "social-media", "seo"],
+  "skills": [
+    {
+      "name": "blog-draft",
+      "installUrl": "github:luongnv89/skills:skills/blog-draft",
+      "description": "Draft SEO-optimized blog posts from ideas or outlines"
+    },
+    {
+      "name": "x-post-generator",
+      "installUrl": "github:luongnv89/skills:skills/x-post-generator",
+      "description": "Generate copy-paste-ready X (Twitter) posts"
+    },
+    {
+      "name": "reddit-writer",
+      "installUrl": "github:luongnv89/skills:skills/reddit-writer",
+      "description": "Generate authentic Reddit posts and replies"
+    },
+    {
+      "name": "seo-ai-optimizer",
+      "installUrl": "github:luongnv89/skills:skills/seo-ai-optimizer",
+      "description": "Audit and optimize website codebases for search engine visibility"
+    }
+  ]
+}

--- a/data/bundles/devops.json
+++ b/data/bundles/devops.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "name": "devops",
+  "description": "DevOps workflow skills: CI/CD pipeline setup, release management, code review, and security review.",
+  "author": "ASM",
+  "createdAt": "2025-01-01T00:00:00.000Z",
+  "tags": ["devops", "ci-cd", "release", "security"],
+  "skills": [
+    {
+      "name": "devops-pipeline",
+      "installUrl": "github:luongnv89/skills:skills/devops-pipeline",
+      "description": "Implement pre-commit hooks and lean GitHub Actions CI/CD pipelines"
+    },
+    {
+      "name": "release-manager",
+      "installUrl": "github:luongnv89/skills:skills/release-manager",
+      "description": "Automate the full release lifecycle"
+    },
+    {
+      "name": "code-review",
+      "installUrl": "github:luongnv89/skills:skills/code-review",
+      "description": "Review code changes for bugs, security issues, and best practices"
+    },
+    {
+      "name": "security-review",
+      "installUrl": "github:affaan-m/everything-claude-code:skills/security-review",
+      "description": "Complete a security review of the codebase"
+    }
+  ]
+}

--- a/data/bundles/eu-project-ops.json
+++ b/data/bundles/eu-project-ops.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "name": "eu-project-ops",
+  "description": "EU project operations skills: BIEN evaluation, COGNIMAN toolbox descriptions, and Montimage UI design.",
+  "author": "ASM",
+  "createdAt": "2025-01-01T00:00:00.000Z",
+  "tags": ["eu-project", "montimage", "cogniman", "bien"],
+  "skills": [
+    {
+      "name": "bien-evaluator",
+      "installUrl": "github:luongnv89/skills:skills/bien-evaluator",
+      "description": "Evaluate a French real estate listing for the BIEN database"
+    },
+    {
+      "name": "cogniman-toolbox-desc",
+      "installUrl": "github:luongnv89/skills:skills/cogniman-toolbox-desc",
+      "description": "Generate a COGNIMAN Toolbox tool description"
+    },
+    {
+      "name": "mi-designer",
+      "installUrl": "github:luongnv89/skills:skills/mi-designer",
+      "description": "Design frontend components and UI pages following Montimage brand identity"
+    }
+  ]
+}

--- a/data/bundles/frontend-dev.json
+++ b/data/bundles/frontend-dev.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "name": "frontend-dev",
+  "description": "Essential skills for frontend development: UI design, UX review, QA testing, browsing, and code review.",
+  "author": "ASM",
+  "createdAt": "2025-01-01T00:00:00.000Z",
+  "tags": ["frontend", "design", "qa", "web"],
+  "skills": [
+    {
+      "name": "frontend-design",
+      "installUrl": "github:luongnv89/skills:skills/frontend-design",
+      "description": "Design and implement production-grade frontend components and UI pages"
+    },
+    {
+      "name": "dont-make-me-think",
+      "installUrl": "github:luongnv89/skills:skills/dont-make-me-think",
+      "description": "Review UI for usability issues using Don't Make Me Think principles"
+    },
+    {
+      "name": "qa",
+      "installUrl": "github:mattpocock/skills:qa",
+      "description": "Systematically QA test a web application"
+    },
+    {
+      "name": "browse",
+      "installUrl": "github:luongnv89/skills:skills/browse",
+      "description": "Fast headless browser for QA testing and site dogfooding"
+    },
+    {
+      "name": "code-review",
+      "installUrl": "github:luongnv89/skills:skills/code-review",
+      "description": "Review code changes for bugs, security issues, and best practices"
+    }
+  ]
+}

--- a/data/bundles/ios-release.json
+++ b/data/bundles/ios-release.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "name": "ios-release",
+  "description": "iOS app release workflow: release management, App Store review checks, release notes, and VS Code extension publishing.",
+  "author": "ASM",
+  "createdAt": "2025-01-01T00:00:00.000Z",
+  "tags": ["ios", "mobile", "release", "appstore"],
+  "skills": [
+    {
+      "name": "release-manager",
+      "installUrl": "github:luongnv89/skills:skills/release-manager",
+      "description": "Automate the full release lifecycle"
+    },
+    {
+      "name": "appstore-review-checker",
+      "installUrl": "github:luongnv89/skills:skills/appstore-review-checker",
+      "description": "Audit iOS/macOS app projects against App Store Review Guidelines"
+    },
+    {
+      "name": "release-notes",
+      "installUrl": "github:luongnv89/skills:skills/release-notes",
+      "description": "Generate release notes from git commits and GitHub PRs/issues"
+    },
+    {
+      "name": "vscode-extension-publisher",
+      "installUrl": "github:luongnv89/skills:skills/vscode-extension-publisher",
+      "description": "Publish VS Code extensions to the Visual Studio Marketplace"
+    }
+  ]
+}

--- a/src/bundler.test.ts
+++ b/src/bundler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, writeFile, mkdir, readdir, rm, readFile } from "fs/promises";
-import { join } from "path";
+import { join, resolve, dirname } from "path";
+import { fileURLToPath } from "url";
 import { tmpdir } from "os";
 import {
   validateBundle,
@@ -10,11 +11,16 @@ import {
   readBundleFile,
   loadBundle,
   listBundles,
+  listPredefinedBundles,
   removeBundle,
   getBundleDir,
   ensureBundleDir,
 } from "./bundler";
 import type { BundleManifest, BundleSkillRef, SkillInfo } from "./utils/types";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PREDEFINED_BUNDLE_DIR = resolve(__dirname, "..", "data", "bundles");
 
 // ─── Test Helpers ──────────────────────────────────────────────────────────
 
@@ -569,5 +575,116 @@ describe("loadBundle", () => {
     await expect(loadBundle("__nonexistent-bundle-xyz__")).rejects.toThrow(
       "Bundle file not found",
     );
+  });
+
+  it("falls back to predefined bundle when not in user dir", async () => {
+    // 'frontend-dev' should exist as a predefined bundle
+    const bundle = await loadBundle("frontend-dev");
+    expect(bundle.name).toBe("frontend-dev");
+    expect(bundle.skills.length).toBeGreaterThan(0);
+    expect(bundle.version).toBe(1);
+  });
+
+  it("prefers user bundle over predefined bundle with same name", async () => {
+    // Save a user bundle with a predefined name to test priority
+    const userBundle = makeBundle({
+      name: "frontend-dev",
+      description: "User override of frontend-dev",
+    });
+    await saveBundle(userBundle);
+    try {
+      const loaded = await loadBundle("frontend-dev");
+      expect(loaded.description).toBe("User override of frontend-dev");
+    } finally {
+      await removeBundle("frontend-dev");
+    }
+  });
+});
+
+// ─── listPredefinedBundles ─────────────────────────────────────────────────
+
+describe("listPredefinedBundles", () => {
+  it("returns an array of bundles", async () => {
+    const bundles = await listPredefinedBundles();
+    expect(Array.isArray(bundles)).toBe(true);
+  });
+
+  it("returns at least 5 predefined bundles", async () => {
+    const bundles = await listPredefinedBundles();
+    expect(bundles.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("returns bundles sorted by name", async () => {
+    const bundles = await listPredefinedBundles();
+    for (let i = 1; i < bundles.length; i++) {
+      expect(
+        bundles[i].name.localeCompare(bundles[i - 1].name),
+      ).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("all predefined bundles are valid BundleManifest v1", async () => {
+    const bundles = await listPredefinedBundles();
+    for (const bundle of bundles) {
+      expect(bundle.version).toBe(1);
+      expect(typeof bundle.name).toBe("string");
+      expect(bundle.name.length).toBeGreaterThan(0);
+      expect(typeof bundle.description).toBe("string");
+      expect(typeof bundle.author).toBe("string");
+      expect(Array.isArray(bundle.skills)).toBe(true);
+      expect(bundle.skills.length).toBeGreaterThan(0);
+      for (const skill of bundle.skills) {
+        expect(typeof skill.name).toBe("string");
+        expect(typeof skill.installUrl).toBe("string");
+        expect(skill.installUrl.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("includes frontend-dev bundle", async () => {
+    const bundles = await listPredefinedBundles();
+    const frontendDev = bundles.find((b) => b.name === "frontend-dev");
+    expect(frontendDev).toBeDefined();
+    expect(frontendDev!.skills.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("includes devops bundle", async () => {
+    const bundles = await listPredefinedBundles();
+    const devops = bundles.find((b) => b.name === "devops");
+    expect(devops).toBeDefined();
+    expect(devops!.skills.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("includes ios-release bundle", async () => {
+    const bundles = await listPredefinedBundles();
+    const iosRelease = bundles.find((b) => b.name === "ios-release");
+    expect(iosRelease).toBeDefined();
+    expect(iosRelease!.skills.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("includes content-writing bundle", async () => {
+    const bundles = await listPredefinedBundles();
+    const contentWriting = bundles.find((b) => b.name === "content-writing");
+    expect(contentWriting).toBeDefined();
+    expect(contentWriting!.skills.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("includes eu-project-ops bundle", async () => {
+    const bundles = await listPredefinedBundles();
+    const euOps = bundles.find((b) => b.name === "eu-project-ops");
+    expect(euOps).toBeDefined();
+    expect(euOps!.skills.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("all bundles have tags as string arrays when present", async () => {
+    const bundles = await listPredefinedBundles();
+    for (const bundle of bundles) {
+      if (bundle.tags !== undefined) {
+        expect(Array.isArray(bundle.tags)).toBe(true);
+        for (const tag of bundle.tags) {
+          expect(typeof tag).toBe("string");
+        }
+      }
+    }
   });
 });

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, readdir, access, mkdir, rm } from "fs/promises";
-import { join, resolve } from "path";
+import { join, resolve, dirname } from "path";
 import { homedir } from "os";
+import { fileURLToPath } from "url";
 import { debug } from "./logger";
 import { readLock } from "./utils/lock";
 import type {
@@ -12,7 +13,17 @@ import type {
 
 // ─── Constants ─────────────────────────────────────────────────────────────
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 const BUNDLE_DIR = join(homedir(), ".config", "agent-skill-manager", "bundles");
+
+/**
+ * Path to the shipped (predefined) bundles directory bundled with ASM.
+ * In dev (src/): __dirname is src/, data/bundles/ is at ../data/bundles/
+ * In dist/ build: __dirname is dist/, data/bundles/ is at ../data/bundles/
+ */
+const PREDEFINED_BUNDLE_DIR = resolve(__dirname, "..", "data", "bundles");
 
 // ─── Validation ────────────────────────────────────────────────────────────
 
@@ -203,6 +214,8 @@ export async function readBundleFile(
 
 /**
  * Load a bundle by name (looks in the bundles directory) or by file path.
+ * Falls back to the shipped predefined bundles in data/bundles/ when the
+ * name is not found in the user bundles directory.
  */
 export async function loadBundle(nameOrPath: string): Promise<BundleManifest> {
   // If it looks like a file path (has extension or path separator), read directly
@@ -215,10 +228,61 @@ export async function loadBundle(nameOrPath: string): Promise<BundleManifest> {
     return readBundleFile(absPath);
   }
 
-  // Otherwise, look in the bundles directory
+  // Look in the user bundles directory first
   const filename = `${sanitizeBundleName(nameOrPath)}.json`;
   const filePath = join(BUNDLE_DIR, filename);
-  return readBundleFile(filePath);
+
+  try {
+    return await readBundleFile(filePath);
+  } catch (err: any) {
+    // If not found in user dir, fall back to predefined (shipped) bundles
+    if (err?.message?.includes("Bundle file not found")) {
+      const predefinedPath = join(PREDEFINED_BUNDLE_DIR, filename);
+      try {
+        return await readBundleFile(predefinedPath);
+      } catch (predefinedErr: any) {
+        if (predefinedErr?.message?.includes("Bundle file not found")) {
+          throw new Error(`Bundle file not found: ${filePath}`);
+        }
+        throw predefinedErr;
+      }
+    }
+    throw err;
+  }
+}
+
+/**
+ * List all pre-defined (shipped) bundles from the data/bundles/ directory.
+ */
+export async function listPredefinedBundles(): Promise<BundleManifest[]> {
+  const bundles: BundleManifest[] = [];
+
+  try {
+    await access(PREDEFINED_BUNDLE_DIR);
+  } catch {
+    return bundles;
+  }
+
+  let entries: string[];
+  try {
+    entries = await readdir(PREDEFINED_BUNDLE_DIR);
+  } catch {
+    return bundles;
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const filePath = join(PREDEFINED_BUNDLE_DIR, entry);
+    try {
+      const bundle = await readBundleFile(filePath);
+      bundles.push(bundle);
+    } catch {
+      debug(`bundle: skipping invalid predefined file ${filePath}`);
+    }
+  }
+
+  bundles.sort((a, b) => a.name.localeCompare(b.name));
+  return bundles;
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,6 +79,7 @@ import {
   saveBundle,
   loadBundle,
   listBundles,
+  listPredefinedBundles,
   removeBundle,
 } from "./bundler";
 import { publishSkill, formatFallbackInstructions } from "./publisher";
@@ -265,6 +266,8 @@ interface ParsedArgs {
     author: string | null;
     /** `asm bundle modify --tags <tag,...>` — comma-separated tags for bundle (issue #204). */
     tags: string | null;
+    /** `asm bundle list --predefined` — show pre-defined bundles shipped with ASM (issue #206). */
+    predefined: boolean;
   };
 }
 
@@ -311,6 +314,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
       description: null,
       author: null,
       tags: null,
+      predefined: false,
     },
   };
 
@@ -454,6 +458,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
     } else if (arg === "--tags") {
       i++;
       result.flags.tags = args[i] || null;
+    } else if (arg === "--predefined") {
+      result.flags.predefined = true;
     } else if (arg.startsWith("-")) {
       error(`Unknown option: ${arg}`);
       console.error(`Run "asm --help" for usage.`);
@@ -4030,8 +4036,9 @@ recipe of skills for a particular workflow, domain, or project setup.
 
 ${ansi.bold("Subcommands:")}
   create <name>          Create a new bundle from installed skills
-  install <name|file>    Install all skills from a bundle
+  install <name|file>    Install all skills from a bundle (supports pre-defined names)
   list                   List all saved bundles
+  list --predefined      List pre-defined bundles shipped with ASM
   show <name|file>       Show bundle details
   remove <name>          Remove a saved bundle
   modify <name>          Add/remove skills or update bundle metadata
@@ -4041,14 +4048,17 @@ ${ansi.bold("Options:")}
   -s, --scope <s>      Filter: global, project, or both (default: both)
   -y, --yes            Skip confirmation prompts
   --json               Output as JSON
+  --predefined         Show pre-defined bundles shipped with ASM (for list)
   --no-color           Disable ANSI colors
   -V, --verbose        Show debug output
 
 ${ansi.bold("Examples:")}
   asm bundle create my-workflow                ${ansi.dim("Create from installed skills")}
   asm bundle install my-workflow               ${ansi.dim("Install a saved bundle")}
+  asm bundle install frontend-dev              ${ansi.dim("Install a pre-defined bundle")}
   asm bundle install ./bundle.json             ${ansi.dim("Install from file")}
   asm bundle list                              ${ansi.dim("Show all saved bundles")}
+  asm bundle list --predefined                 ${ansi.dim("List pre-defined bundles")}
   asm bundle list --json                       ${ansi.dim("List bundles as JSON")}
   asm bundle show my-workflow                  ${ansi.dim("Show bundle details")}
   asm bundle remove my-workflow                ${ansi.dim("Remove a saved bundle")}
@@ -4360,6 +4370,43 @@ async function cmdBundle(args: ParsedArgs) {
     }
 
     case "list": {
+      const showPredefined = Boolean(args.flags.predefined);
+
+      if (showPredefined) {
+        const predefinedBundles = await listPredefinedBundles();
+
+        if (predefinedBundles.length === 0) {
+          if (args.flags.json) {
+            console.log("[]");
+          } else {
+            console.log("No predefined bundles found.");
+          }
+          return;
+        }
+
+        if (args.flags.json) {
+          console.log(JSON.stringify(predefinedBundles, null, 2));
+        } else {
+          console.error(ansi.bold(`Pre-defined Bundles (${predefinedBundles.length}):\n`));
+          for (const bundle of predefinedBundles) {
+            const tagsStr =
+              bundle.tags && bundle.tags.length > 0
+                ? ` ${ansi.dim(`[${bundle.tags.join(", ")}]`)}`
+                : "";
+            console.error(
+              `  ${ansi.cyan(bundle.name)} ${ansi.dim(`(${bundle.skills.length} skills)`)}${tagsStr}`,
+            );
+            if (bundle.description) {
+              console.error(`    ${ansi.dim(bundle.description)}`);
+            }
+          }
+          console.error(
+            `\n${ansi.dim("Install a bundle with: asm bundle install <name>")}`,
+          );
+        }
+        return;
+      }
+
       const bundles = await listBundles();
 
       if (bundles.length === 0) {
@@ -4368,6 +4415,9 @@ async function cmdBundle(args: ParsedArgs) {
         } else {
           console.log("No bundles found.");
           console.error(ansi.dim("Create one with: asm bundle create <name>"));
+          console.error(
+            ansi.dim("List pre-defined bundles with: asm bundle list --predefined"),
+          );
         }
         return;
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4077,7 +4077,9 @@ async function cmdBundle(args: ParsedArgs) {
   const subcommand = args.subcommand;
 
   if (!subcommand) {
-    error("Missing subcommand. Use: create, install, list, show, remove, modify, or export");
+    error(
+      "Missing subcommand. Use: create, install, list, show, remove, modify, or export",
+    );
     console.error(`Run "asm bundle --help" for usage.`);
     process.exit(2);
   }
@@ -4387,7 +4389,9 @@ async function cmdBundle(args: ParsedArgs) {
         if (args.flags.json) {
           console.log(JSON.stringify(predefinedBundles, null, 2));
         } else {
-          console.error(ansi.bold(`Pre-defined Bundles (${predefinedBundles.length}):\n`));
+          console.error(
+            ansi.bold(`Pre-defined Bundles (${predefinedBundles.length}):\n`),
+          );
           for (const bundle of predefinedBundles) {
             const tagsStr =
               bundle.tags && bundle.tags.length > 0
@@ -4416,7 +4420,9 @@ async function cmdBundle(args: ParsedArgs) {
           console.log("No bundles found.");
           console.error(ansi.dim("Create one with: asm bundle create <name>"));
           console.error(
-            ansi.dim("List pre-defined bundles with: asm bundle list --predefined"),
+            ansi.dim(
+              "List pre-defined bundles with: asm bundle list --predefined",
+            ),
           );
         }
         return;
@@ -4530,7 +4536,9 @@ async function cmdBundle(args: ParsedArgs) {
       const bundleName = args.positional[0];
       if (!bundleName) {
         error("Missing required argument: <name>");
-        console.error(`Usage: asm bundle modify <name> [--add <installUrl>] [--remove <skillName>] [--description <desc>] [--author <author>] [--tags <tag,...>]`);
+        console.error(
+          `Usage: asm bundle modify <name> [--add <installUrl>] [--remove <skillName>] [--description <desc>] [--author <author>] [--tags <tag,...>]`,
+        );
         process.exit(2);
       }
 
@@ -4548,7 +4556,11 @@ async function cmdBundle(args: ParsedArgs) {
       const addUrl = args.flags.add;
       if (addUrl) {
         const newSkillRef: BundleSkillRef = {
-          name: addUrl.split("/").pop()?.replace(/\.json$/, "") ?? addUrl,
+          name:
+            addUrl
+              .split("/")
+              .pop()
+              ?.replace(/\.json$/, "") ?? addUrl,
           installUrl: addUrl,
         };
         bundle.skills.push(newSkillRef);
@@ -4567,7 +4579,9 @@ async function cmdBundle(args: ParsedArgs) {
           modified = true;
           console.error(ansi.green(`Removed skill "${removeSkill}"`));
         } else {
-          console.error(ansi.dim(`Skill "${removeSkill}" not found in bundle (no change)`));
+          console.error(
+            ansi.dim(`Skill "${removeSkill}" not found in bundle (no change)`),
+          );
         }
       }
 
@@ -4607,27 +4621,35 @@ async function cmdBundle(args: ParsedArgs) {
         newTags === null
       ) {
         console.error(ansi.bold(`Modifying bundle "${bundle.name}"`));
-        console.error(`  Current skills: ${bundle.skills.map((s) => s.name).join(", ")}`);
+        console.error(
+          `  Current skills: ${bundle.skills.map((s) => s.name).join(", ")}`,
+        );
         console.error(`  Description: ${bundle.description}`);
         console.error(`  Author: ${bundle.author}`);
         console.error(`  Tags: ${bundle.tags?.join(", ") ?? "(none)"}`);
         console.error(``);
 
-        process.stderr.write(`${ansi.bold("New description")} (Enter to keep current): `);
+        process.stderr.write(
+          `${ansi.bold("New description")} (Enter to keep current): `,
+        );
         const descInput = await readLine();
         if (descInput.trim()) {
           bundle.description = descInput.trim();
           modified = true;
         }
 
-        process.stderr.write(`${ansi.bold("New author")} (Enter to keep current): `);
+        process.stderr.write(
+          `${ansi.bold("New author")} (Enter to keep current): `,
+        );
         const authorInput = await readLine();
         if (authorInput.trim()) {
           bundle.author = authorInput.trim();
           modified = true;
         }
 
-        process.stderr.write(`${ansi.bold("New tags (comma-separated)")} (Enter to keep current): `);
+        process.stderr.write(
+          `${ansi.bold("New tags (comma-separated)")} (Enter to keep current): `,
+        );
         const tagsInput = await readLine();
         if (tagsInput.trim()) {
           bundle.tags = tagsInput
@@ -4681,8 +4703,7 @@ async function cmdBundle(args: ParsedArgs) {
       }
 
       const outputFile =
-        (args.positional[1] as string | undefined) ??
-        `./${bundleName}.json`;
+        (args.positional[1] as string | undefined) ?? `./${bundleName}.json`;
 
       const { resolve: resolvePath } = await import("path");
       const absOutputPath = resolvePath(outputFile);
@@ -4717,10 +4738,20 @@ async function cmdBundle(args: ParsedArgs) {
       }
 
       const { writeFile: fsWriteFile } = await import("fs/promises");
-      await fsWriteFile(absOutputPath, JSON.stringify(bundle, null, 2) + "\n", "utf-8");
+      await fsWriteFile(
+        absOutputPath,
+        JSON.stringify(bundle, null, 2) + "\n",
+        "utf-8",
+      );
 
       if (args.flags.json) {
-        console.log(JSON.stringify({ exported: true, path: absOutputPath, bundle }, null, 2));
+        console.log(
+          JSON.stringify(
+            { exported: true, path: absOutputPath, bundle },
+            null,
+            2,
+          ),
+        );
       } else {
         console.error(ansi.green(`Exported to ${absOutputPath}`));
       }


### PR DESCRIPTION
Closes #206

## Summary

- Adds 5 curated pre-defined bundle JSON files in `data/bundles/` (new directory) following the existing `BundleManifest` v1 schema:
  - `frontend-dev.json` — frontend-design, dont-make-me-think, qa, browse, code-review
  - `devops.json` — devops-pipeline, release-manager, code-review, security-review
  - `ios-release.json` — release-manager, appstore-review-checker, release-notes, vscode-extension-publisher
  - `content-writing.json` — blog-draft, x-post-generator, reddit-writer, seo-ai-optimizer
  - `eu-project-ops.json` — bien-evaluator, cogniman-toolbox-desc, mi-designer
- Adds `listPredefinedBundles()` exported from `src/bundler.ts` to list all shipped bundle files
- Updates `loadBundle()` in `src/bundler.ts` to fall back to `data/bundles/` when the bundle name is not found in the user bundles directory (user bundles take priority)
- Adds `--predefined` flag to `asm bundle list` subcommand to show shipped bundles
- Adds `predefined` flag to `ParsedArgs` interface and `parseArgs()` in `src/cli.ts`
- Uses real `installUrl` values from `data/skill-index/` for all skills
- Adds 12 new unit tests for `listPredefinedBundles()` and the predefined fallback in `loadBundle()`

## Test plan

- [x] `bun run test` — 1563 pass, 2 pre-existing failures (unrelated config test)
- [x] TypeScript typecheck passes (`npx tsc --noEmit`)
- [x] `asm bundle list --predefined` shows all 5 shipped bundles
- [x] `asm bundle install frontend-dev` installs a predefined bundle by name without saving
- [x] User-saved bundle with same name takes priority over predefined bundle
- [x] All 5 JSON files validate against the `BundleManifest` v1 schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)