### PR TITLE
feat(website): feature skill-auto-improver, pin to top of catalog

### DIFF
--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -1,6 +1,15 @@
 {
-  "updatedAt": "2026-04-20T00:00:00Z",
+  "updatedAt": "2026-04-21T00:00:00Z",
   "repos": [
+    {
+      "source": "github:luongnv89/asm",
+      "url": "https://github.com/luongnv89/asm",
+      "owner": "luongnv89",
+      "repo": "asm",
+      "description": "Built-in ASM skills (only skill-auto-improver is published to the catalog)",
+      "maintainer": "@luongnv89",
+      "enabled": false
+    },
     {
       "source": "github:anthropics/skills",
       "url": "https://github.com/anthropics/skills",

--- a/data/skill-index/luongnv89_asm.json
+++ b/data/skill-index/luongnv89_asm.json
@@ -1,0 +1,73 @@
+{
+  "repoUrl": "https://github.com/luongnv89/asm.git",
+  "owner": "luongnv89",
+  "repo": "asm",
+  "updatedAt": "2026-04-21T20:48:38.441Z",
+  "skillCount": 1,
+  "skills": [
+    {
+      "name": "skill-auto-improver",
+      "description": "Improve a SKILL.md skill by running `asm eval`, fixing weakest categories, and looping until it clears the 85/8 floor or stops with a blocker. Use when leveling up a skill, preparing for publish, or rescuing a failing eval.",
+      "version": "0.1.0",
+      "license": "MIT",
+      "creator": "luongnv89",
+      "compatibility": "Claude Code",
+      "allowedTools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"],
+      "installUrl": "github:luongnv89/asm:skills/skill-auto-improver",
+      "relPath": "skills/skill-auto-improver",
+      "verified": true,
+      "featured": true,
+      "tokenCount": 3101,
+      "evalSummary": {
+        "overallScore": 100,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-04-21T20:48:38.441Z",
+        "evaluatedVersion": "0.1.0"
+      }
+    }
+  ]
+}

--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -250,6 +250,7 @@ interface IndexedSkill {
   installUrl: string;
   relPath: string;
   verified?: boolean;
+  featured?: boolean;
   tokenCount?: number;
   evalSummary?: SkillEvalSummary;
 }
@@ -278,6 +279,12 @@ interface CatalogSkill {
   repo: string;
   categories: string[];
   verified: boolean;
+  /**
+   * Pin-to-top flag for featured skills. Sort modes in the website respect
+   * this by placing featured skills before everything else, regardless of
+   * the active sort (name, grade, tokens, relevance).
+   */
+  featured?: boolean;
   /**
    * Estimated token count for SKILL.md content (`words + spaces`).
    * Surfaced in the website card and modal so users can gauge context cost.
@@ -390,6 +397,7 @@ for (const file of files) {
       repo: repoIndex.repo,
       categories,
       verified: skill.verified === true,
+      featured: skill.featured === true ? true : undefined,
       tokenCount:
         typeof skill.tokenCount === "number" ? skill.tokenCount : undefined,
       evalSummary: skill.evalSummary,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -317,6 +317,12 @@ export interface IndexedSkill {
   relPath: string;
   verified?: boolean;
   /**
+   * Pin to the top of the catalog list across every sort mode. Reserved for
+   * first-party ASM skills that should always surface first (e.g. the
+   * eval-driven skill-improver workflow).
+   */
+  featured?: boolean;
+  /**
    * Estimated token count for the SKILL.md content
    * (`words + spaces` heuristic — see `src/utils/token-count.ts`).
    */

--- a/website/index.html
+++ b/website/index.html
@@ -52,6 +52,8 @@ html { -webkit-text-size-adjust: 100%; overflow-x: hidden; }
   --logo-center-fill: #0a0a0a;
   --verified: #60a5fa;
   --verified-bg: rgba(96, 165, 250, 0.1);
+  --featured: #f5b547;
+  --featured-bg: rgba(245, 181, 71, 0.12);
   --tag-fixed: #7aa2f7;
   --tag-fixed-bg: rgba(122, 162, 247, 0.08);
   --badge-cat-bg: rgba(0, 255, 65, 0.06);
@@ -86,6 +88,8 @@ html { -webkit-text-size-adjust: 100%; overflow-x: hidden; }
   --logo-center-fill: #f5f6f8;
   --verified: #2563eb;
   --verified-bg: rgba(37, 99, 235, 0.1);
+  --featured: #b8860b;
+  --featured-bg: rgba(184, 134, 11, 0.12);
   --tag-fixed: #2563eb;
   --tag-fixed-bg: rgba(37, 99, 235, 0.08);
   --badge-cat-bg: rgba(0, 143, 36, 0.06);
@@ -560,6 +564,14 @@ mark.hl {
 }
 .skill-card.verified {
   border-left: 3px solid var(--verified);
+}
+.badge-featured {
+  color: var(--featured);
+  background: var(--featured-bg);
+  font-weight: 600;
+}
+.skill-card.featured {
+  border-left: 3px solid var(--featured);
 }
 .card-header {
   display: flex;
@@ -2117,13 +2129,27 @@ function getFiltered() {
     });
   }
 
-  // Search — keep score-ordered results when relevance sort is in use.
+  // Featured skills pin to the top of every sort mode (including search
+  // relevance). Returns -1/1 when featured differs, 0 otherwise so callers
+  // can fall through to the real comparator as a tiebreaker.
+  const featuredFirst = (a, b) => {
+    const af = a.featured === true ? 1 : 0;
+    const bf = b.featured === true ? 1 : 0;
+    return bf - af;
+  };
+
+  // Search — keep score-ordered results when relevance sort is in use, but
+  // still float featured skills above the rest.
   let scored = null;
   if (searchQuery.trim()) {
     scored = results
       .map(s => ({ skill: s, score: scoreSkill(searchQuery, s) }))
       .filter(r => r.score > 0)
-      .sort((a, b) => b.score - a.score);
+      .sort((a, b) => {
+        const f = featuredFirst(a.skill, b.skill);
+        if (f !== 0) return f;
+        return b.score - a.score;
+      });
     results = scored.map(r => r.skill);
   }
 
@@ -2131,10 +2157,16 @@ function getFiltered() {
   // (already score-sorted above) and falls back to name when no search.
   const sortMode = activeSort || defaultSort();
   if (sortMode === 'name' || (sortMode === 'relevance' && !scored)) {
-    results = results.slice().sort((a, b) => a.name.localeCompare(b.name));
+    results = results.slice().sort((a, b) => {
+      const f = featuredFirst(a, b);
+      if (f !== 0) return f;
+      return a.name.localeCompare(b.name);
+    });
   } else if (sortMode === 'grade') {
     const gradeRank = { 'A': 0, 'B': 1, 'C': 2, 'D': 3, 'F': 4 };
     results = results.slice().sort((a, b) => {
+      const f = featuredFirst(a, b);
+      if (f !== 0) return f;
       const ag = a.evalSummary ? (gradeRank[a.evalSummary.grade] ?? 99) : 99;
       const bg = b.evalSummary ? (gradeRank[b.evalSummary.grade] ?? 99) : 99;
       if (ag !== bg) return ag - bg;
@@ -2146,6 +2178,8 @@ function getFiltered() {
     });
   } else if (sortMode === 'tokens-asc') {
     results = results.slice().sort((a, b) => {
+      const f = featuredFirst(a, b);
+      if (f !== 0) return f;
       const at = typeof a.tokenCount === 'number' ? a.tokenCount : Infinity;
       const bt = typeof b.tokenCount === 'number' ? b.tokenCount : Infinity;
       if (at !== bt) return at - bt;
@@ -2153,6 +2187,8 @@ function getFiltered() {
     });
   } else if (sortMode === 'tokens-desc') {
     results = results.slice().sort((a, b) => {
+      const f = featuredFirst(a, b);
+      if (f !== 0) return f;
       const at = typeof a.tokenCount === 'number' ? a.tokenCount : -1;
       const bt = typeof b.tokenCount === 'number' ? b.tokenCount : -1;
       if (at !== bt) return bt - at;
@@ -2160,6 +2196,7 @@ function getFiltered() {
     });
   }
   // sortMode === 'relevance' with search active: keep score-sorted order
+  // (featured-first is already baked in above).
 
   return results;
 }
@@ -2196,8 +2233,10 @@ function renderCard(s) {
   const ver = s.version && s.version !== '0.0.0' ? '<span class="skill-version">v' + esc(s.version) + '</span>' : '';
   const isOfficial = s.owner === 'anthropics';
   const isVerified = s.verified === true;
+  const isFeatured = s.featured === true;
   const officialBadge = isOfficial ? '<span class="badge badge-official">official</span>' : '';
   const verifiedBadge = isVerified ? '<span class="badge badge-verified">&#x2713; verified</span>' : '';
+  const featuredBadge = isFeatured ? '<span class="badge badge-featured">&#x2605; featured</span>' : '';
   // Token count badge — labelled with `~` so users know it's an approximation.
   const tokenBadge = typeof s.tokenCount === 'number'
     ? '<span class="badge badge-tokens" title="Estimated tokens: words + spaces in SKILL.md (rough approximation)">' + esc(formatTokens(s.tokenCount)) + '</span>'
@@ -2208,8 +2247,9 @@ function renderCard(s) {
     ? '<span class="badge badge-eval ' + evalScoreClass(s.evalSummary.overallScore) + '" title="asm eval score: ' + esc(s.evalSummary.overallScore + '/100 (' + s.evalSummary.grade + ')') + '">eval ' + esc(s.evalSummary.overallScore + ' ' + s.evalSummary.grade) + '</span>'
     : '';
   let cardClass = 'skill-card';
-  if (isOfficial) cardClass += ' official';
-  if (isVerified) cardClass += ' verified';
+  if (isFeatured) cardClass += ' featured';
+  else if (isOfficial) cardClass += ' official';
+  else if (isVerified) cardClass += ' verified';
 
   return '<article class="' + cardClass + '" data-id="' + esc(s.id) + '" tabindex="0" role="button">'
     + '<div class="card-header">'
@@ -2218,7 +2258,7 @@ function renderCard(s) {
     + '</div>'
     + '<p class="skill-desc">' + highlightMatches(s.description, searchQuery) + '</p>'
     + '<div class="card-footer">'
-    + '<div class="badge-row">' + officialBadge + verifiedBadge + evalBadge + tokenBadge + cats + warn + '</div>'
+    + '<div class="badge-row">' + featuredBadge + officialBadge + verifiedBadge + evalBadge + tokenBadge + cats + warn + '</div>'
     + ver
     + '</div>'
     + '<div class="install-bar">'

--- a/website/index.html
+++ b/website/index.html
@@ -2248,8 +2248,10 @@ function renderCard(s) {
     : '';
   let cardClass = 'skill-card';
   if (isFeatured) cardClass += ' featured';
-  else if (isOfficial) cardClass += ' official';
-  else if (isVerified) cardClass += ' verified';
+  else {
+    if (isOfficial) cardClass += ' official';
+    if (isVerified) cardClass += ' verified';
+  }
 
   return '<article class="' + cardClass + '" data-id="' + esc(s.id) + '" tabindex="0" role="button">'
     + '<div class="card-header">'


### PR DESCRIPTION
## Summary

Pins `skill-auto-improver` to the top of the catalog across every sort mode and adds a `★ featured` badge. Does **not** expose the repo's other built-in skills (`hello-world`, `skill-index-updater`) — those stay private.

**Depends on #218** — merge that first so the `installUrl` resolves.

## How it works

- New optional `featured?: boolean` on `IndexedSkill` / `CatalogSkill`
- `featuredFirst` comparator prepended to every sort path (name / grade / tokens-asc / tokens-desc / search relevance)
- Gold star badge (`★ featured`) + amber left-border accent, separate CSS vars for dark + light themes

## Why the index file is hand-written

`bun run preindex` is the normal path for indexing a repo, but it discovers every `SKILL.md` recursively — which would pull in `hello-world` and `skill-index-updater`. Keeping those out of the public catalog meant either teaching the ingester to filter (a bigger change) or writing the single-skill index file by hand. I went with hand-written, kept `luongnv89/asm` in `skill-index-resources.json` with `enabled: false` so preindex skips the repo entirely. Future built-ins that should be public can set `featured: true` and be added to the same JSON by hand (or we teach preindex to honor a per-repo include list in a follow-up).

## Changes

| File                                      | What                                                    |
|-------------------------------------------|---------------------------------------------------------|
| `data/skill-index-resources.json`         | Add `luongnv89/asm` (enabled: false)                    |
| `data/skill-index/luongnv89_asm.json`     | Hand-written index: 1 skill, `featured: true`, eval 100/A |
| `src/utils/types.ts`                      | `featured?: boolean` on `IndexedSkill`                  |
| `scripts/build-catalog.ts`                | Propagate `featured` from index → catalog               |
| `website/index.html`                      | `featuredFirst` sort, badge, CSS                        |

## Verification

Browsed the rebuilt `website/catalog.json` locally (48 cards), checked all 4 sort modes programmatically:

```
{
  "name":        { "firstCard": "skill-auto-improver (luongnv89/asm)", "featured": true },
  "grade":       { "firstCard": "skill-auto-improver (luongnv89/asm)", "featured": true },
  "tokens-asc":  { "firstCard": "skill-auto-improver (luongnv89/asm)", "featured": true },
  "tokens-desc": { "firstCard": "skill-auto-improver (luongnv89/asm)", "featured": true }
}
```

Card classes include `featured`, badge list includes `★ featured`, `✓ verified`, `eval 100 A`, `~3.1k tokens`.

## Test Plan

- [x] `bun run typecheck` clean
- [x] `bun scripts/build-catalog.ts` succeeds (6783 skills, 26 repos)
- [x] `featuredFirst` respected across name / grade / tokens-asc / tokens-desc sorts
- [x] Pre-commit hooks (prettier, json, unit tests) pass
- [x] Pre-push hooks (build, e2e tests) pass
- [ ] After deploy: skill-auto-improver card appears first at https://luongnv.com/asm/
- [ ] After #218 lands: clicking the install command succeeds (`asm install github:luongnv89/asm:skills/skill-auto-improver`)