### PR TITLE
perf(website): split catalog.json into compact list + MiniSearch index (#214)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,10 @@ Thumbs.db
 # Coverage
 coverage/
 
-# Website (generated at build time)
+# Website (generated at build time by `bun scripts/build-catalog.ts`, also
+# run by .github/workflows/deploy-website.yml before the Pages upload).
+# Kept out of git to avoid noisy diffs and keep data/skill-index/*.json as
+# the single source of truth.
 website/catalog.json
 website/bundles.json
 website/skills.min.json

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ coverage/
 # Website (generated at build time)
 website/catalog.json
 website/bundles.json
+website/skills.min.json
+website/search.idx.json
+website/skills/
 website/assets/favicon.svg
 
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Generated website artifacts
+website/catalog.json
+website/bundles.json
+website/skills.min.json
+website/search.idx.json
+website/skills/
+
+# Vendored third-party bundles — do not reformat
+website/assets/minisearch.min.js
+
+# Build output
+dist/
+node_modules/

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "devDependencies": {
     "bun-types": "^1.3.10",
+    "minisearch": "7.2.0",
     "prettier": "^3.8.1"
   }
 }

--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -13,15 +13,19 @@ import {
   mkdirSync,
   copyFileSync,
   existsSync,
+  rmSync,
 } from "fs";
+import { createHash } from "crypto";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+import MiniSearch from "minisearch";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const indexDir = join(root, "data", "skill-index");
 const resourcesPath = join(root, "data", "skill-index-resources.json");
 const outDir = join(root, "website");
 const assetsOutDir = join(outDir, "assets");
+const skillsDetailDir = join(outDir, "skills");
 
 // ─── Category Taxonomy ───────────────────────────────────────────────────────
 
@@ -467,6 +471,193 @@ mkdirSync(assetsOutDir, { recursive: true });
 
 writeFileSync(join(outDir, "catalog.json"), JSON.stringify(catalog), "utf-8");
 
+// ─── Split artifacts (issue #214) ────────────────────────────────────────────
+// Emit three browser-facing artifacts so visitors download only what they need:
+//
+//   1. website/skills.min.json   — compact list (cards, filters, sorts)
+//   2. website/search.idx.json   — MiniSearch index serialized with toJSON
+//   3. website/skills/<slug>.json — one per skill, fetched on demand
+//
+// catalog.json stays the authoritative internal source (upstream tooling and
+// tests still consume it); the split artifacts are derived deterministically.
+
+// Filesystem-safe slug for each skill. IDs contain `/` and `::` so we hash
+// them; 16 hex chars (64 bits) collision-free for 6.7K skills. The slug is
+// embedded in every slim row so the frontend never has to recompute it.
+function slugForId(id: string): string {
+  return createHash("sha1").update(id).digest("hex").slice(0, 16);
+}
+
+interface SkillsMinRow {
+  /** Original catalog id — kept so deep-linking and card `data-id` still work. */
+  id: string;
+  /** Relative path the browser fetches to hydrate the detail view. */
+  detailPath: string;
+  name: string;
+  description: string;
+  owner: string;
+  repo: string;
+  categories: string[];
+  installUrl: string;
+  license: string;
+  version: string;
+  verified: boolean;
+  featured?: boolean;
+  /** Derived flag — avoids shipping the full allowedTools array on the list. */
+  hasTools: boolean;
+  tokenCount?: number;
+  /** Slimmed eval summary — only what the card badge needs. */
+  evalSummary?: { overallScore: number; grade: "A" | "B" | "C" | "D" | "F" };
+}
+
+interface SkillsMin {
+  generatedAt: string;
+  version: string;
+  totalSkills: number;
+  totalRepos: number;
+  stars: number;
+  categories: string[];
+  repos: CatalogRepo[];
+  skills: SkillsMinRow[];
+}
+
+// Build the slim rows in the same order as catalog.skills so the frontend can
+// rely on deterministic ordering when the backing index drops out of sync.
+const slimSkills: SkillsMinRow[] = skills.map((s) => {
+  const slug = slugForId(s.id);
+  const row: SkillsMinRow = {
+    id: s.id,
+    detailPath: `skills/${slug}.json`,
+    name: s.name,
+    description: s.description,
+    owner: s.owner,
+    repo: s.repo,
+    categories: s.categories,
+    installUrl: s.installUrl,
+    license: s.license,
+    version: s.version,
+    verified: s.verified,
+    hasTools: Array.isArray(s.allowedTools) && s.allowedTools.length > 0,
+  };
+  if (s.featured === true) row.featured = true;
+  if (typeof s.tokenCount === "number") row.tokenCount = s.tokenCount;
+  if (s.evalSummary) {
+    row.evalSummary = {
+      overallScore: s.evalSummary.overallScore,
+      grade: s.evalSummary.grade,
+    };
+  }
+  return row;
+});
+
+const skillsMin: SkillsMin = {
+  generatedAt: catalog.generatedAt,
+  version: catalog.version,
+  totalSkills: catalog.totalSkills,
+  totalRepos: catalog.totalRepos,
+  stars: catalog.stars,
+  categories: catalog.categories,
+  repos: catalog.repos,
+  skills: slimSkills,
+};
+
+writeFileSync(
+  join(outDir, "skills.min.json"),
+  JSON.stringify(skillsMin),
+  "utf-8",
+);
+
+// MiniSearch options — MUST stay in lockstep with the frontend loader in
+// website/index.html (search `MINISEARCH_OPTIONS`). The index deserializer
+// requires the exact same options that were used at build time.
+//
+// `id` is the row's position in skills.min.json.skills (so the frontend can
+// look the row up by array index instead of re-storing the full string ID
+// twice in the serialized index — saves ~1.5 MB on search.idx.json).
+const miniSearchOptions = {
+  idField: "id",
+  fields: ["name", "description", "categoriesStr"],
+  storeFields: [] as string[],
+  searchOptions: {
+    boost: { name: 3, description: 1, categoriesStr: 1 },
+    prefix: true,
+    fuzzy: 0.2,
+  },
+};
+
+const miniSearch = new MiniSearch(miniSearchOptions);
+miniSearch.addAll(
+  skills.map((s, i) => ({
+    id: i,
+    name: s.name,
+    description: s.description,
+    categoriesStr: (s.categories || []).join(" "),
+  })),
+);
+
+writeFileSync(
+  join(outDir, "search.idx.json"),
+  JSON.stringify(miniSearch),
+  "utf-8",
+);
+
+// Per-skill detail files. Clear the directory first so slugs that no longer
+// correspond to a live skill don't linger across rebuilds.
+if (existsSync(skillsDetailDir)) {
+  rmSync(skillsDetailDir, { recursive: true, force: true });
+}
+mkdirSync(skillsDetailDir, { recursive: true });
+
+interface SkillDetail {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  license: string;
+  creator: string;
+  compatibility: string;
+  allowedTools: string[];
+  installUrl: string;
+  skillUrl: string;
+  owner: string;
+  repo: string;
+  categories: string[];
+  verified: boolean;
+  featured?: boolean;
+  tokenCount?: number;
+  evalSummary?: SkillEvalSummary;
+}
+
+let detailFilesWritten = 0;
+for (const s of skills) {
+  const slug = slugForId(s.id);
+  const detail: SkillDetail = {
+    id: s.id,
+    name: s.name,
+    description: s.description,
+    version: s.version,
+    license: s.license,
+    creator: s.creator,
+    compatibility: s.compatibility,
+    allowedTools: s.allowedTools,
+    installUrl: s.installUrl,
+    skillUrl: s.skillUrl,
+    owner: s.owner,
+    repo: s.repo,
+    categories: s.categories,
+    verified: s.verified,
+  };
+  if (s.featured === true) detail.featured = true;
+  if (typeof s.tokenCount === "number") detail.tokenCount = s.tokenCount;
+  if (s.evalSummary) detail.evalSummary = s.evalSummary;
+  writeFileSync(
+    join(skillsDetailDir, `${slug}.json`),
+    JSON.stringify(detail),
+    "utf-8",
+  );
+  detailFilesWritten++;
+}
+
 // ─── Bundles ─────────────────────────────────────────────────────────────────
 
 interface BundleSkill {
@@ -527,11 +718,27 @@ if (existsSync(faviconSrc)) {
 
 // ─── Stats ───────────────────────────────────────────────────────────────────
 
+function kb(bytes: number): string {
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(2)} MB`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
 console.log(`Catalog built successfully:`);
 console.log(`  Skills: ${skills.length}`);
 console.log(`  Repos:  ${repos.length}`);
 console.log(`  Categories: ${categories.join(", ")}`);
 console.log(`  Bundles: ${bundles.length}`);
+console.log(`  Split artifacts (issue #214):`);
+console.log(
+  `    catalog.json:     ${kb(Bun.file(join(outDir, "catalog.json")).size)}`,
+);
+console.log(
+  `    skills.min.json:  ${kb(Bun.file(join(outDir, "skills.min.json")).size)}`,
+);
+console.log(
+  `    search.idx.json:  ${kb(Bun.file(join(outDir, "search.idx.json")).size)}`,
+);
+console.log(`    skills/*.json:    ${detailFilesWritten} files`);
 
 // Category distribution
 const catCounts: Record<string, number> = {};

--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -19,6 +19,7 @@ import { createHash } from "crypto";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import MiniSearch from "minisearch";
+import { MINISEARCH_OPTIONS } from "./minisearch-options";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const indexDir = join(root, "data", "skill-index");
@@ -482,10 +483,22 @@ writeFileSync(join(outDir, "catalog.json"), JSON.stringify(catalog), "utf-8");
 // tests still consume it); the split artifacts are derived deterministically.
 
 // Filesystem-safe slug for each skill. IDs contain `/` and `::` so we hash
-// them; 16 hex chars (64 bits) collision-free for 6.7K skills. The slug is
-// embedded in every slim row so the frontend never has to recompute it.
+// them; 16 hex chars (64 bits) collision-free for 6.7K skills (~2.5e-9
+// probability). The slug is embedded in every slim row so the frontend
+// never has to recompute it. Defence-in-depth: track seen slugs and throw
+// on collision so a silently-overwritten detail file can't ship.
+const seenSlugs = new Map<string, string>();
 function slugForId(id: string): string {
-  return createHash("sha1").update(id).digest("hex").slice(0, 16);
+  const slug = createHash("sha1").update(id).digest("hex").slice(0, 16);
+  const prior = seenSlugs.get(slug);
+  if (prior !== undefined && prior !== id) {
+    throw new Error(
+      `Slug collision: SHA1(${id}) and SHA1(${prior}) both truncate to ${slug}. ` +
+        `Widen slice in slugForId or disambiguate inputs.`,
+    );
+  }
+  seenSlugs.set(slug, id);
+  return slug;
 }
 
 interface SkillsMinRow {
@@ -567,25 +580,14 @@ writeFileSync(
   "utf-8",
 );
 
-// MiniSearch options — MUST stay in lockstep with the frontend loader in
-// website/index.html (search `MINISEARCH_OPTIONS`). The index deserializer
-// requires the exact same options that were used at build time.
+// MiniSearch options live in ./minisearch-options.ts so the build-verification
+// test can import them and compare against the frontend's inline copy — see
+// that file's doc comment for why we split it out.
 //
-// `id` is the row's position in skills.min.json.skills (so the frontend can
+// `id` is the row's position in skills.min.json.skills so the frontend can
 // look the row up by array index instead of re-storing the full string ID
-// twice in the serialized index — saves ~1.5 MB on search.idx.json).
-const miniSearchOptions = {
-  idField: "id",
-  fields: ["name", "description", "categoriesStr"],
-  storeFields: [] as string[],
-  searchOptions: {
-    boost: { name: 3, description: 1, categoriesStr: 1 },
-    prefix: true,
-    fuzzy: 0.2,
-  },
-};
-
-const miniSearch = new MiniSearch(miniSearchOptions);
+// twice in the serialized index — saves ~1.5 MB on search.idx.json.
+const miniSearch = new MiniSearch(MINISEARCH_OPTIONS);
 miniSearch.addAll(
   skills.map((s, i) => ({
     id: i,

--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -597,9 +597,16 @@ miniSearch.addAll(
   })),
 );
 
+// Embed generatedAt so the frontend can detect when skills.min.json and
+// search.idx.json come from different builds (CDN/cache skew would otherwise
+// silently map every hit to the wrong slim row). loadJS ignores unknown keys.
+const miniSearchSerialized = {
+  ...miniSearch.toJSON(),
+  generatedAt: catalog.generatedAt,
+};
 writeFileSync(
   join(outDir, "search.idx.json"),
-  JSON.stringify(miniSearch),
+  JSON.stringify(miniSearchSerialized),
   "utf-8",
 );
 

--- a/scripts/minisearch-options.ts
+++ b/scripts/minisearch-options.ts
@@ -1,0 +1,21 @@
+/**
+ * MiniSearch configuration shared between the build script and the
+ * frontend loader. Kept in one place so a future edit to scoring or
+ * tokenization can't drift silently between build-time serialization
+ * and runtime deserialization — a mismatch corrupts search ranking
+ * without any thrown error.
+ *
+ * The frontend (website/index.html) keeps its own inline copy of
+ * these options because plain HTML can't import TypeScript. The
+ * build-verification test compares the two against this module.
+ */
+export const MINISEARCH_OPTIONS = {
+  idField: "id",
+  fields: ["name", "description", "categoriesStr"],
+  storeFields: [] as string[],
+  searchOptions: {
+    boost: { name: 3, description: 1, categoriesStr: 1 },
+    prefix: true,
+    fuzzy: 0.2,
+  },
+};

--- a/tests/e2e/build-verification.test.ts
+++ b/tests/e2e/build-verification.test.ts
@@ -246,7 +246,10 @@ describe("website: token count + eval surfaces", () => {
   });
 
   test("formatTokens always prefixes its output with `~` (approximation)", () => {
-    expect(html).toMatch(/return\s+'~'\s*\+\s*count\s*\+\s*' tokens'/);
+    // Keep this resilient to formatter-driven quote/line-wrap changes.
+    expect(html).toMatch(
+      /return\s+["']~["']\s*\+\s*count\s*\+\s*["'] tokens["']/,
+    );
   });
 });
 
@@ -422,8 +425,10 @@ describe("website: loader uses split artifacts (issue #214)", () => {
   const html = readFileSync(join(WEBSITE_DIR, "index.html"), "utf-8");
 
   test("boot fetches skills.min.json + search.idx.json in parallel", () => {
-    expect(html).toContain("fetch('skills.min.json')");
-    expect(html).toContain("fetch('search.idx.json')");
+    // Assert the resources + Promise.all are present without coupling to
+    // quote style or formatter line wrapping inside the HTML script block.
+    expect(html).toMatch(/fetch\(["']skills\.min\.json["']\)/);
+    expect(html).toMatch(/fetch\(["']search\.idx\.json["']\)/);
     expect(html).toContain("Promise.all");
   });
 

--- a/tests/e2e/build-verification.test.ts
+++ b/tests/e2e/build-verification.test.ts
@@ -248,3 +248,187 @@ describe("website: token count + eval surfaces", () => {
     expect(html).toMatch(/return\s+'~'\s*\+\s*count\s*\+\s*' tokens'/);
   });
 });
+
+// ─── split artifacts (issue #214) ──────────────────────────────────────────
+// The build emits three browser-facing artifacts derived from catalog.json so
+// the frontend can fetch only what it needs on page load. catalog.json stays
+// the authoritative internal source (tests above still pass against it).
+
+const SKILLS_MIN_PATH = join(WEBSITE_DIR, "skills.min.json");
+const SEARCH_IDX_PATH = join(WEBSITE_DIR, "search.idx.json");
+const SKILLS_DETAIL_DIR = join(WEBSITE_DIR, "skills");
+
+describe("catalog: split artifacts (issue #214)", () => {
+  if (!catalogExists || !existsSync(SKILLS_MIN_PATH)) {
+    test.skip("split artifacts not present — run `bun scripts/build-catalog.ts` to generate them", () => {});
+    return;
+  }
+  const catalog = JSON.parse(readFileSync(CATALOG_PATH, "utf-8"));
+  const skillsMin = JSON.parse(readFileSync(SKILLS_MIN_PATH, "utf-8"));
+
+  test("skills.min.json mirrors catalog totalSkills and top-level aggregates", () => {
+    expect(skillsMin.totalSkills).toBe(catalog.totalSkills);
+    expect(skillsMin.totalRepos).toBe(catalog.totalRepos);
+    expect(skillsMin.categories).toEqual(catalog.categories);
+    expect(skillsMin.skills.length).toBe(catalog.skills.length);
+    expect(skillsMin.version).toBe(catalog.version);
+  });
+
+  test("every slim skill row carries the fields the card + filters need", () => {
+    for (const s of skillsMin.skills) {
+      expect(typeof s.id).toBe("string");
+      expect(typeof s.detailPath).toBe("string");
+      expect(s.detailPath).toMatch(/^skills\/[0-9a-f]{16}\.json$/);
+      expect(typeof s.name).toBe("string");
+      expect(typeof s.description).toBe("string");
+      expect(typeof s.owner).toBe("string");
+      expect(typeof s.repo).toBe("string");
+      expect(Array.isArray(s.categories)).toBe(true);
+      expect(typeof s.installUrl).toBe("string");
+      expect(typeof s.hasTools).toBe("boolean");
+      expect(typeof s.verified).toBe("boolean");
+    }
+  });
+
+  test("every detailPath resolves to an on-disk skill file", () => {
+    for (const s of skillsMin.skills) {
+      const p = join(WEBSITE_DIR, s.detailPath);
+      expect(existsSync(p)).toBe(true);
+    }
+  });
+
+  test("skills/ directory count matches catalog.skills.length", () => {
+    const files = readdirSync(SKILLS_DETAIL_DIR).filter((f) =>
+      f.endsWith(".json"),
+    );
+    expect(files.length).toBe(catalog.skills.length);
+  });
+
+  test("search.idx.json is a MiniSearch serialization with the expected shape", () => {
+    const idx = JSON.parse(readFileSync(SEARCH_IDX_PATH, "utf-8"));
+    expect(idx.documentCount).toBe(catalog.skills.length);
+    expect(idx.serializationVersion).toBeDefined();
+    // The build script uses numeric ids (row index in catalog.skills) to
+    // shrink the index — guard that invariant because the frontend relies on
+    // `catalog.skills[hit.id]` to map hits back to slim rows. Must be a
+    // real number, not a string-of-digits.
+    expect(typeof idx.documentIds).toBe("object");
+    const firstKey = Object.keys(idx.documentIds)[0];
+    expect(typeof idx.documentIds[firstKey]).toBe("number");
+  });
+
+  test("slim rows align 1:1 with catalog.skills by id + derived fields", () => {
+    // Ordering must match because the search index uses array indices as
+    // document IDs — if these ever diverge, `catalog.skills[hit.id]` maps
+    // to the wrong slim row silently.
+    for (let i = 0; i < catalog.skills.length; i++) {
+      const full = catalog.skills[i];
+      const slim = skillsMin.skills[i];
+      expect(slim.id).toBe(full.id);
+      expect(slim.name).toBe(full.name);
+      expect(slim.owner).toBe(full.owner);
+      expect(slim.repo).toBe(full.repo);
+      expect(slim.hasTools).toBe(
+        Array.isArray(full.allowedTools) && full.allowedTools.length > 0,
+      );
+      if (full.evalSummary) {
+        expect(slim.evalSummary?.grade).toBe(full.evalSummary.grade);
+        expect(slim.evalSummary?.overallScore).toBe(
+          full.evalSummary.overallScore,
+        );
+      }
+    }
+  });
+
+  test("MiniSearch options match between build script and frontend loader", () => {
+    // Guard against silent scoring drift: if the `fields`, `idField`, or
+    // `boost` weights diverge between the build-time construction and the
+    // frontend's loadJSON call, search relevance breaks without any error.
+    const buildTs = readFileSync(
+      join(WEBSITE_DIR, "..", "scripts", "build-catalog.ts"),
+      "utf-8",
+    );
+    const html = readFileSync(join(WEBSITE_DIR, "index.html"), "utf-8");
+
+    // Extract an option value from each source, normalizing quote style so
+    // "x" and 'x' compare equal (build uses double, frontend single).
+    function extractOption(src: string, key: string): string | null {
+      const m = src.match(
+        new RegExp(`${key}\\s*:\\s*(\\[[^\\]]*\\]|['"][^'"]*['"]|\\d+)`),
+      );
+      return m ? m[1].replace(/\s+/g, "").replace(/'/g, '"') : null;
+    }
+    for (const key of ["idField", "fields"]) {
+      const build = extractOption(buildTs, key);
+      const front = extractOption(html, key);
+      expect(build).not.toBeNull();
+      expect(front).toBe(build);
+    }
+  });
+
+  test("search.idx.json deserializes and finds a known query (smoke test)", async () => {
+    const idxText = readFileSync(SEARCH_IDX_PATH, "utf-8");
+    // Import dynamically so the tests don't pay the load cost when the
+    // artifact isn't present (already guarded above).
+    const { default: MiniSearch } = await import("minisearch");
+    const opts = {
+      idField: "id",
+      fields: ["name", "description", "categoriesStr"],
+      storeFields: [],
+      searchOptions: {
+        boost: { name: 3, description: 1, categoriesStr: 1 },
+        prefix: true,
+        fuzzy: 0.2,
+      },
+    };
+    const idx = MiniSearch.loadJSON(idxText, opts);
+    const hits = idx.search("skill");
+    expect(hits.length).toBeGreaterThan(0);
+    expect(typeof hits[0].id).toBe("number");
+    expect(catalog.skills[hits[0].id]).toBeDefined();
+  });
+
+  test("skills.min.json is materially smaller than catalog.json (raw bytes)", () => {
+    const catalogSize = statSync(CATALOG_PATH).size;
+    const slimSize = statSync(SKILLS_MIN_PATH).size;
+    // Conservative lower-bound check — the whole point of the split. If this
+    // ever regresses, either the slim shape drifted or catalog.json shrunk
+    // for other reasons; either way, worth looking at.
+    expect(slimSize).toBeLessThan(catalogSize * 0.75);
+  });
+});
+
+// ─── website loader swap (issue #214) ──────────────────────────────────────
+
+describe("website: loader uses split artifacts (issue #214)", () => {
+  const html = readFileSync(join(WEBSITE_DIR, "index.html"), "utf-8");
+
+  test("boot fetches skills.min.json + search.idx.json in parallel", () => {
+    expect(html).toContain("fetch('skills.min.json')");
+    expect(html).toContain("fetch('search.idx.json')");
+    expect(html).toContain("Promise.all");
+  });
+
+  test("boot no longer fetches catalog.json directly", () => {
+    // The string "catalog.json" survives in gitignore comments etc., so
+    // scope the check to a literal fetch call.
+    expect(html).not.toContain("fetch('catalog.json')");
+  });
+
+  test("MiniSearch runtime is vendored (not CDN-loaded)", () => {
+    expect(html).toContain('src="assets/minisearch.min.js"');
+  });
+
+  test("old linear scoreSkill / tokenize path is removed", () => {
+    // The linear Array.filter + scoreSkill path was the thing being replaced.
+    // If either name reappears we likely regressed into dual-path code.
+    expect(html).not.toContain("function scoreSkill");
+    expect(html).not.toContain("SCORE_NAME_EXACT");
+  });
+
+  test("openModal fetches the per-skill detail on demand", () => {
+    expect(html).toContain("fetchSkillDetail");
+    expect(html).toContain("detailPath");
+    expect(html).toContain("detailCache");
+  });
+});

--- a/tests/e2e/build-verification.test.ts
+++ b/tests/e2e/build-verification.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { join, resolve } from "path";
 import { readFileSync, existsSync, readdirSync, statSync } from "fs";
+import { MINISEARCH_OPTIONS } from "../../scripts/minisearch-options";
 
 const WEBSITE_DIR = resolve(import.meta.dir, "..", "..", "website");
 
@@ -341,29 +342,46 @@ describe("catalog: split artifacts (issue #214)", () => {
   });
 
   test("MiniSearch options match between build script and frontend loader", () => {
-    // Guard against silent scoring drift: if the `fields`, `idField`, or
-    // `boost` weights diverge between the build-time construction and the
-    // frontend's loadJSON call, search relevance breaks without any error.
-    const buildTs = readFileSync(
-      join(WEBSITE_DIR, "..", "scripts", "build-catalog.ts"),
-      "utf-8",
-    );
+    // Guard against silent scoring drift: if any option (fields, idField,
+    // boost weights, fuzzy, prefix, storeFields) diverges between the
+    // build-time serialization and the frontend's loadJSON call, relevance
+    // ranking breaks without any thrown error. The build script imports
+    // MINISEARCH_OPTIONS directly from scripts/minisearch-options.ts, so
+    // we compare the frontend's inline copy against that canonical module.
     const html = readFileSync(join(WEBSITE_DIR, "index.html"), "utf-8");
 
-    // Extract an option value from each source, normalizing quote style so
-    // "x" and 'x' compare equal (build uses double, frontend single).
-    function extractOption(src: string, key: string): string | null {
-      const m = src.match(
-        new RegExp(`${key}\\s*:\\s*(\\[[^\\]]*\\]|['"][^'"]*['"]|\\d+)`),
-      );
-      return m ? m[1].replace(/\s+/g, "").replace(/'/g, '"') : null;
+    // Find the frontend options literal and slice its balanced-brace body.
+    // A regex with `\[[^\]]*\]` would silently return null on multi-line
+    // arrays and let the test pass vacuously, so we walk braces instead.
+    const marker = "const MINISEARCH_OPTIONS = {";
+    const start = html.indexOf(marker);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const braceStart = html.indexOf("{", start);
+    let depth = 0;
+    let end = -1;
+    for (let i = braceStart; i < html.length; i++) {
+      const ch = html[i];
+      if (ch === "{") depth++;
+      else if (ch === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
     }
-    for (const key of ["idField", "fields"]) {
-      const build = extractOption(buildTs, key);
-      const front = extractOption(html, key);
-      expect(build).not.toBeNull();
-      expect(front).toBe(build);
-    }
+    expect(end).toBeGreaterThan(braceStart);
+    const literal = html.slice(braceStart, end + 1);
+
+    // The inline copy is JS (unquoted keys, single quotes, optional trailing
+    // commas). Convert to strict JSON: double-quote keys, swap quote style,
+    // strip trailing commas.
+    const jsonLike = literal
+      .replace(/([{,]\s*)([A-Za-z_][A-Za-z0-9_]*)(\s*:)/g, '$1"$2"$3')
+      .replace(/'([^']*)'/g, '"$1"')
+      .replace(/,(\s*[}\]])/g, "$1");
+    const frontendOptions = JSON.parse(jsonLike);
+    expect(frontendOptions).toEqual(MINISEARCH_OPTIONS);
   });
 
   test("search.idx.json deserializes and finds a known query (smoke test)", async () => {

--- a/tests/e2e/build-verification.test.ts
+++ b/tests/e2e/build-verification.test.ts
@@ -389,21 +389,21 @@ describe("catalog: split artifacts (issue #214)", () => {
     // Import dynamically so the tests don't pay the load cost when the
     // artifact isn't present (already guarded above).
     const { default: MiniSearch } = await import("minisearch");
-    const opts = {
-      idField: "id",
-      fields: ["name", "description", "categoriesStr"],
-      storeFields: [],
-      searchOptions: {
-        boost: { name: 3, description: 1, categoriesStr: 1 },
-        prefix: true,
-        fuzzy: 0.2,
-      },
-    };
-    const idx = MiniSearch.loadJSON(idxText, opts);
+    const idx = MiniSearch.loadJSON(idxText, MINISEARCH_OPTIONS);
     const hits = idx.search("skill");
     expect(hits.length).toBeGreaterThan(0);
     expect(typeof hits[0].id).toBe("number");
     expect(catalog.skills[hits[0].id]).toBeDefined();
+  });
+
+  test("search.idx.json and skills.min.json share the same generatedAt", () => {
+    // The frontend boot guard compares these two fields to detect CDN/cache
+    // skew between artifacts — without matching generatedAt values the array-
+    // index invariant (hit.id → catalog.skills[i]) silently misaligns.
+    const idx = JSON.parse(readFileSync(SEARCH_IDX_PATH, "utf-8"));
+    const slim = JSON.parse(readFileSync(SKILLS_MIN_PATH, "utf-8"));
+    expect(typeof idx.generatedAt).toBe("string");
+    expect(idx.generatedAt).toBe(slim.generatedAt);
   });
 
   test("skills.min.json is materially smaller than catalog.json (raw bytes)", () => {

--- a/website/assets/minisearch.min.js
+++ b/website/assets/minisearch.min.js
@@ -1,3 +1,8 @@
+/*! MiniSearch 7.2.0 UMD — vendored from npm (devDependency). Do not edit
+ *  manually. To update: `npm view minisearch@<version> dist`, download the
+ *  UMD bundle, replace this file, bump the devDependency in package.json,
+ *  and update the version in this header. The serializationVersion is
+ *  asserted by tests/e2e/build-verification.test.ts. */
 (function (global, factory) {
   typeof exports === "object" && typeof module !== "undefined"
     ? (module.exports = factory())

--- a/website/assets/minisearch.min.js
+++ b/website/assets/minisearch.min.js
@@ -1,0 +1,2211 @@
+(function (global, factory) {
+  typeof exports === "object" && typeof module !== "undefined"
+    ? (module.exports = factory())
+    : typeof define === "function" && define.amd
+      ? define(factory)
+      : ((global =
+          typeof globalThis !== "undefined" ? globalThis : global || self),
+        (global.MiniSearch = factory()));
+})(this, function () {
+  "use strict";
+
+  /** @ignore */
+  const ENTRIES = "ENTRIES";
+  /** @ignore */
+  const KEYS = "KEYS";
+  /** @ignore */
+  const VALUES = "VALUES";
+  /** @ignore */
+  const LEAF = "";
+  /**
+   * @private
+   */
+  class TreeIterator {
+    constructor(set, type) {
+      const node = set._tree;
+      const keys = Array.from(node.keys());
+      this.set = set;
+      this._type = type;
+      this._path = keys.length > 0 ? [{ node, keys }] : [];
+    }
+    next() {
+      const value = this.dive();
+      this.backtrack();
+      return value;
+    }
+    dive() {
+      if (this._path.length === 0) {
+        return { done: true, value: undefined };
+      }
+      const { node, keys } = last$1(this._path);
+      if (last$1(keys) === LEAF) {
+        return { done: false, value: this.result() };
+      }
+      const child = node.get(last$1(keys));
+      this._path.push({ node: child, keys: Array.from(child.keys()) });
+      return this.dive();
+    }
+    backtrack() {
+      if (this._path.length === 0) {
+        return;
+      }
+      const keys = last$1(this._path).keys;
+      keys.pop();
+      if (keys.length > 0) {
+        return;
+      }
+      this._path.pop();
+      this.backtrack();
+    }
+    key() {
+      return (
+        this.set._prefix +
+        this._path
+          .map(({ keys }) => last$1(keys))
+          .filter((key) => key !== LEAF)
+          .join("")
+      );
+    }
+    value() {
+      return last$1(this._path).node.get(LEAF);
+    }
+    result() {
+      switch (this._type) {
+        case VALUES:
+          return this.value();
+        case KEYS:
+          return this.key();
+        default:
+          return [this.key(), this.value()];
+      }
+    }
+    [Symbol.iterator]() {
+      return this;
+    }
+  }
+  const last$1 = (array) => {
+    return array[array.length - 1];
+  };
+
+  /* eslint-disable no-labels */
+  /**
+   * @ignore
+   */
+  const fuzzySearch = (node, query, maxDistance) => {
+    const results = new Map();
+    if (query === undefined) return results;
+    // Number of columns in the Levenshtein matrix.
+    const n = query.length + 1;
+    // Matching terms can never be longer than N + maxDistance.
+    const m = n + maxDistance;
+    // Fill first matrix row and column with numbers: 0 1 2 3 ...
+    const matrix = new Uint8Array(m * n).fill(maxDistance + 1);
+    for (let j = 0; j < n; ++j) matrix[j] = j;
+    for (let i = 1; i < m; ++i) matrix[i * n] = i;
+    recurse(node, query, maxDistance, results, matrix, 1, n, "");
+    return results;
+  };
+  // Modified version of http://stevehanov.ca/blog/?id=114
+  // This builds a Levenshtein matrix for a given query and continuously updates
+  // it for nodes in the radix tree that fall within the given maximum edit
+  // distance. Keeping the same matrix around is beneficial especially for larger
+  // edit distances.
+  //
+  //           k   a   t   e   <-- query
+  //       0   1   2   3   4
+  //   c   1   1   2   3   4
+  //   a   2   2   1   2   3
+  //   t   3   3   2   1  [2]  <-- edit distance
+  //   ^
+  //   ^ term in radix tree, rows are added and removed as needed
+  const recurse = (node, query, maxDistance, results, matrix, m, n, prefix) => {
+    const offset = m * n;
+    key: for (const key of node.keys()) {
+      if (key === LEAF) {
+        // We've reached a leaf node. Check if the edit distance acceptable and
+        // store the result if it is.
+        const distance = matrix[offset - 1];
+        if (distance <= maxDistance) {
+          results.set(prefix, [node.get(key), distance]);
+        }
+      } else {
+        // Iterate over all characters in the key. Update the Levenshtein matrix
+        // and check if the minimum distance in the last row is still within the
+        // maximum edit distance. If it is, we can recurse over all child nodes.
+        let i = m;
+        for (let pos = 0; pos < key.length; ++pos, ++i) {
+          const char = key[pos];
+          const thisRowOffset = n * i;
+          const prevRowOffset = thisRowOffset - n;
+          // Set the first column based on the previous row, and initialize the
+          // minimum distance in the current row.
+          let minDistance = matrix[thisRowOffset];
+          const jmin = Math.max(0, i - maxDistance - 1);
+          const jmax = Math.min(n - 1, i + maxDistance);
+          // Iterate over remaining columns (characters in the query).
+          for (let j = jmin; j < jmax; ++j) {
+            const different = char !== query[j];
+            // It might make sense to only read the matrix positions used for
+            // deletion/insertion if the characters are different. But we want to
+            // avoid conditional reads for performance reasons.
+            const rpl = matrix[prevRowOffset + j] + +different;
+            const del = matrix[prevRowOffset + j + 1] + 1;
+            const ins = matrix[thisRowOffset + j] + 1;
+            const dist = (matrix[thisRowOffset + j + 1] = Math.min(
+              rpl,
+              del,
+              ins,
+            ));
+            if (dist < minDistance) minDistance = dist;
+          }
+          // Because distance will never decrease, we can stop. There will be no
+          // matching child nodes.
+          if (minDistance > maxDistance) {
+            continue key;
+          }
+        }
+        recurse(
+          node.get(key),
+          query,
+          maxDistance,
+          results,
+          matrix,
+          i,
+          n,
+          prefix + key,
+        );
+      }
+    }
+  };
+
+  /* eslint-disable no-labels */
+  /**
+   * A class implementing the same interface as a standard JavaScript
+   * [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
+   * with string keys, but adding support for efficiently searching entries with
+   * prefix or fuzzy search. This class is used internally by {@link MiniSearch}
+   * as the inverted index data structure. The implementation is a radix tree
+   * (compressed prefix tree).
+   *
+   * Since this class can be of general utility beyond _MiniSearch_, it is
+   * exported by the `minisearch` package and can be imported (or required) as
+   * `minisearch/SearchableMap`.
+   *
+   * @typeParam T  The type of the values stored in the map.
+   */
+  class SearchableMap {
+    /**
+     * The constructor is normally called without arguments, creating an empty
+     * map. In order to create a {@link SearchableMap} from an iterable or from an
+     * object, check {@link SearchableMap.from} and {@link
+     * SearchableMap.fromObject}.
+     *
+     * The constructor arguments are for internal use, when creating derived
+     * mutable views of a map at a prefix.
+     */
+    constructor(tree = new Map(), prefix = "") {
+      this._size = undefined;
+      this._tree = tree;
+      this._prefix = prefix;
+    }
+    /**
+     * Creates and returns a mutable view of this {@link SearchableMap},
+     * containing only entries that share the given prefix.
+     *
+     * ### Usage:
+     *
+     * ```javascript
+     * let map = new SearchableMap()
+     * map.set("unicorn", 1)
+     * map.set("universe", 2)
+     * map.set("university", 3)
+     * map.set("unique", 4)
+     * map.set("hello", 5)
+     *
+     * let uni = map.atPrefix("uni")
+     * uni.get("unique") // => 4
+     * uni.get("unicorn") // => 1
+     * uni.get("hello") // => undefined
+     *
+     * let univer = map.atPrefix("univer")
+     * univer.get("unique") // => undefined
+     * univer.get("universe") // => 2
+     * univer.get("university") // => 3
+     * ```
+     *
+     * @param prefix  The prefix
+     * @return A {@link SearchableMap} representing a mutable view of the original
+     * Map at the given prefix
+     */
+    atPrefix(prefix) {
+      if (!prefix.startsWith(this._prefix)) {
+        throw new Error("Mismatched prefix");
+      }
+      const [node, path] = trackDown(
+        this._tree,
+        prefix.slice(this._prefix.length),
+      );
+      if (node === undefined) {
+        const [parentNode, key] = last(path);
+        for (const k of parentNode.keys()) {
+          if (k !== LEAF && k.startsWith(key)) {
+            const node = new Map();
+            node.set(k.slice(key.length), parentNode.get(k));
+            return new SearchableMap(node, prefix);
+          }
+        }
+      }
+      return new SearchableMap(node, prefix);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear
+     */
+    clear() {
+      this._size = undefined;
+      this._tree.clear();
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete
+     * @param key  Key to delete
+     */
+    delete(key) {
+      this._size = undefined;
+      return remove(this._tree, key);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries
+     * @return An iterator iterating through `[key, value]` entries.
+     */
+    entries() {
+      return new TreeIterator(this, ENTRIES);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach
+     * @param fn  Iteration function
+     */
+    forEach(fn) {
+      for (const [key, value] of this) {
+        fn(key, value, this);
+      }
+    }
+    /**
+     * Returns a Map of all the entries that have a key within the given edit
+     * distance from the search key. The keys of the returned Map are the matching
+     * keys, while the values are two-element arrays where the first element is
+     * the value associated to the key, and the second is the edit distance of the
+     * key to the search key.
+     *
+     * ### Usage:
+     *
+     * ```javascript
+     * let map = new SearchableMap()
+     * map.set('hello', 'world')
+     * map.set('hell', 'yeah')
+     * map.set('ciao', 'mondo')
+     *
+     * // Get all entries that match the key 'hallo' with a maximum edit distance of 2
+     * map.fuzzyGet('hallo', 2)
+     * // => Map(2) { 'hello' => ['world', 1], 'hell' => ['yeah', 2] }
+     *
+     * // In the example, the "hello" key has value "world" and edit distance of 1
+     * // (change "e" to "a"), the key "hell" has value "yeah" and edit distance of 2
+     * // (change "e" to "a", delete "o")
+     * ```
+     *
+     * @param key  The search key
+     * @param maxEditDistance  The maximum edit distance (Levenshtein)
+     * @return A Map of the matching keys to their value and edit distance
+     */
+    fuzzyGet(key, maxEditDistance) {
+      return fuzzySearch(this._tree, key, maxEditDistance);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get
+     * @param key  Key to get
+     * @return Value associated to the key, or `undefined` if the key is not
+     * found.
+     */
+    get(key) {
+      const node = lookup(this._tree, key);
+      return node !== undefined ? node.get(LEAF) : undefined;
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
+     * @param key  Key
+     * @return True if the key is in the map, false otherwise
+     */
+    has(key) {
+      const node = lookup(this._tree, key);
+      return node !== undefined && node.has(LEAF);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys
+     * @return An `Iterable` iterating through keys
+     */
+    keys() {
+      return new TreeIterator(this, KEYS);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set
+     * @param key  Key to set
+     * @param value  Value to associate to the key
+     * @return The {@link SearchableMap} itself, to allow chaining
+     */
+    set(key, value) {
+      if (typeof key !== "string") {
+        throw new Error("key must be a string");
+      }
+      this._size = undefined;
+      const node = createPath(this._tree, key);
+      node.set(LEAF, value);
+      return this;
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size
+     */
+    get size() {
+      if (this._size) {
+        return this._size;
+      }
+      /** @ignore */
+      this._size = 0;
+      const iter = this.entries();
+      while (!iter.next().done) this._size += 1;
+      return this._size;
+    }
+    /**
+     * Updates the value at the given key using the provided function. The function
+     * is called with the current value at the key, and its return value is used as
+     * the new value to be set.
+     *
+     * ### Example:
+     *
+     * ```javascript
+     * // Increment the current value by one
+     * searchableMap.update('somekey', (currentValue) => currentValue == null ? 0 : currentValue + 1)
+     * ```
+     *
+     * If the value at the given key is or will be an object, it might not require
+     * re-assignment. In that case it is better to use `fetch()`, because it is
+     * faster.
+     *
+     * @param key  The key to update
+     * @param fn  The function used to compute the new value from the current one
+     * @return The {@link SearchableMap} itself, to allow chaining
+     */
+    update(key, fn) {
+      if (typeof key !== "string") {
+        throw new Error("key must be a string");
+      }
+      this._size = undefined;
+      const node = createPath(this._tree, key);
+      node.set(LEAF, fn(node.get(LEAF)));
+      return this;
+    }
+    /**
+     * Fetches the value of the given key. If the value does not exist, calls the
+     * given function to create a new value, which is inserted at the given key
+     * and subsequently returned.
+     *
+     * ### Example:
+     *
+     * ```javascript
+     * const map = searchableMap.fetch('somekey', () => new Map())
+     * map.set('foo', 'bar')
+     * ```
+     *
+     * @param key  The key to update
+     * @param initial  A function that creates a new value if the key does not exist
+     * @return The existing or new value at the given key
+     */
+    fetch(key, initial) {
+      if (typeof key !== "string") {
+        throw new Error("key must be a string");
+      }
+      this._size = undefined;
+      const node = createPath(this._tree, key);
+      let value = node.get(LEAF);
+      if (value === undefined) {
+        node.set(LEAF, (value = initial()));
+      }
+      return value;
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values
+     * @return An `Iterable` iterating through values.
+     */
+    values() {
+      return new TreeIterator(this, VALUES);
+    }
+    /**
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator
+     */
+    [Symbol.iterator]() {
+      return this.entries();
+    }
+    /**
+     * Creates a {@link SearchableMap} from an `Iterable` of entries
+     *
+     * @param entries  Entries to be inserted in the {@link SearchableMap}
+     * @return A new {@link SearchableMap} with the given entries
+     */
+    static from(entries) {
+      const tree = new SearchableMap();
+      for (const [key, value] of entries) {
+        tree.set(key, value);
+      }
+      return tree;
+    }
+    /**
+     * Creates a {@link SearchableMap} from the iterable properties of a JavaScript object
+     *
+     * @param object  Object of entries for the {@link SearchableMap}
+     * @return A new {@link SearchableMap} with the given entries
+     */
+    static fromObject(object) {
+      return SearchableMap.from(Object.entries(object));
+    }
+  }
+  const trackDown = (tree, key, path = []) => {
+    if (key.length === 0 || tree == null) {
+      return [tree, path];
+    }
+    for (const k of tree.keys()) {
+      if (k !== LEAF && key.startsWith(k)) {
+        path.push([tree, k]); // performance: update in place
+        return trackDown(tree.get(k), key.slice(k.length), path);
+      }
+    }
+    path.push([tree, key]); // performance: update in place
+    return trackDown(undefined, "", path);
+  };
+  const lookup = (tree, key) => {
+    if (key.length === 0 || tree == null) {
+      return tree;
+    }
+    for (const k of tree.keys()) {
+      if (k !== LEAF && key.startsWith(k)) {
+        return lookup(tree.get(k), key.slice(k.length));
+      }
+    }
+  };
+  // Create a path in the radix tree for the given key, and returns the deepest
+  // node. This function is in the hot path for indexing. It avoids unnecessary
+  // string operations and recursion for performance.
+  const createPath = (node, key) => {
+    const keyLength = key.length;
+    outer: for (let pos = 0; node && pos < keyLength; ) {
+      for (const k of node.keys()) {
+        // Check whether this key is a candidate: the first characters must match.
+        if (k !== LEAF && key[pos] === k[0]) {
+          const len = Math.min(keyLength - pos, k.length);
+          // Advance offset to the point where key and k no longer match.
+          let offset = 1;
+          while (offset < len && key[pos + offset] === k[offset]) ++offset;
+          const child = node.get(k);
+          if (offset === k.length) {
+            // The existing key is shorter than the key we need to create.
+            node = child;
+          } else {
+            // Partial match: we need to insert an intermediate node to contain
+            // both the existing subtree and the new node.
+            const intermediate = new Map();
+            intermediate.set(k.slice(offset), child);
+            node.set(key.slice(pos, pos + offset), intermediate);
+            node.delete(k);
+            node = intermediate;
+          }
+          pos += offset;
+          continue outer;
+        }
+      }
+      // Create a final child node to contain the final suffix of the key.
+      const child = new Map();
+      node.set(key.slice(pos), child);
+      return child;
+    }
+    return node;
+  };
+  const remove = (tree, key) => {
+    const [node, path] = trackDown(tree, key);
+    if (node === undefined) {
+      return;
+    }
+    node.delete(LEAF);
+    if (node.size === 0) {
+      cleanup(path);
+    } else if (node.size === 1) {
+      const [key, value] = node.entries().next().value;
+      merge(path, key, value);
+    }
+  };
+  const cleanup = (path) => {
+    if (path.length === 0) {
+      return;
+    }
+    const [node, key] = last(path);
+    node.delete(key);
+    if (node.size === 0) {
+      cleanup(path.slice(0, -1));
+    } else if (node.size === 1) {
+      const [key, value] = node.entries().next().value;
+      if (key !== LEAF) {
+        merge(path.slice(0, -1), key, value);
+      }
+    }
+  };
+  const merge = (path, key, value) => {
+    if (path.length === 0) {
+      return;
+    }
+    const [node, nodeKey] = last(path);
+    node.set(nodeKey + key, value);
+    node.delete(nodeKey);
+  };
+  const last = (array) => {
+    return array[array.length - 1];
+  };
+
+  const OR = "or";
+  const AND = "and";
+  const AND_NOT = "and_not";
+  /**
+   * {@link MiniSearch} is the main entrypoint class, implementing a full-text
+   * search engine in memory.
+   *
+   * @typeParam T  The type of the documents being indexed.
+   *
+   * ### Basic example:
+   *
+   * ```javascript
+   * const documents = [
+   *   {
+   *     id: 1,
+   *     title: 'Moby Dick',
+   *     text: 'Call me Ishmael. Some years ago...',
+   *     category: 'fiction'
+   *   },
+   *   {
+   *     id: 2,
+   *     title: 'Zen and the Art of Motorcycle Maintenance',
+   *     text: 'I can see by my watch...',
+   *     category: 'fiction'
+   *   },
+   *   {
+   *     id: 3,
+   *     title: 'Neuromancer',
+   *     text: 'The sky above the port was...',
+   *     category: 'fiction'
+   *   },
+   *   {
+   *     id: 4,
+   *     title: 'Zen and the Art of Archery',
+   *     text: 'At first sight it must seem...',
+   *     category: 'non-fiction'
+   *   },
+   *   // ...and more
+   * ]
+   *
+   * // Create a search engine that indexes the 'title' and 'text' fields for
+   * // full-text search. Search results will include 'title' and 'category' (plus the
+   * // id field, that is always stored and returned)
+   * const miniSearch = new MiniSearch({
+   *   fields: ['title', 'text'],
+   *   storeFields: ['title', 'category']
+   * })
+   *
+   * // Add documents to the index
+   * miniSearch.addAll(documents)
+   *
+   * // Search for documents:
+   * let results = miniSearch.search('zen art motorcycle')
+   * // => [
+   * //   { id: 2, title: 'Zen and the Art of Motorcycle Maintenance', category: 'fiction', score: 2.77258 },
+   * //   { id: 4, title: 'Zen and the Art of Archery', category: 'non-fiction', score: 1.38629 }
+   * // ]
+   * ```
+   */
+  class MiniSearch {
+    /**
+     * @param options  Configuration options
+     *
+     * ### Examples:
+     *
+     * ```javascript
+     * // Create a search engine that indexes the 'title' and 'text' fields of your
+     * // documents:
+     * const miniSearch = new MiniSearch({ fields: ['title', 'text'] })
+     * ```
+     *
+     * ### ID Field:
+     *
+     * ```javascript
+     * // Your documents are assumed to include a unique 'id' field, but if you want
+     * // to use a different field for document identification, you can set the
+     * // 'idField' option:
+     * const miniSearch = new MiniSearch({ idField: 'key', fields: ['title', 'text'] })
+     * ```
+     *
+     * ### Options and defaults:
+     *
+     * ```javascript
+     * // The full set of options (here with their default value) is:
+     * const miniSearch = new MiniSearch({
+     *   // idField: field that uniquely identifies a document
+     *   idField: 'id',
+     *
+     *   // extractField: function used to get the value of a field in a document.
+     *   // By default, it assumes the document is a flat object with field names as
+     *   // property keys and field values as string property values, but custom logic
+     *   // can be implemented by setting this option to a custom extractor function.
+     *   extractField: (document, fieldName) => document[fieldName],
+     *
+     *   // tokenize: function used to split fields into individual terms. By
+     *   // default, it is also used to tokenize search queries, unless a specific
+     *   // `tokenize` search option is supplied. When tokenizing an indexed field,
+     *   // the field name is passed as the second argument.
+     *   tokenize: (string, _fieldName) => string.split(SPACE_OR_PUNCTUATION),
+     *
+     *   // processTerm: function used to process each tokenized term before
+     *   // indexing. It can be used for stemming and normalization. Return a falsy
+     *   // value in order to discard a term. By default, it is also used to process
+     *   // search queries, unless a specific `processTerm` option is supplied as a
+     *   // search option. When processing a term from a indexed field, the field
+     *   // name is passed as the second argument.
+     *   processTerm: (term, _fieldName) => term.toLowerCase(),
+     *
+     *   // searchOptions: default search options, see the `search` method for
+     *   // details
+     *   searchOptions: undefined,
+     *
+     *   // fields: document fields to be indexed. Mandatory, but not set by default
+     *   fields: undefined
+     *
+     *   // storeFields: document fields to be stored and returned as part of the
+     *   // search results.
+     *   storeFields: []
+     * })
+     * ```
+     */
+    constructor(options) {
+      if (
+        (options === null || options === void 0 ? void 0 : options.fields) ==
+        null
+      ) {
+        throw new Error('MiniSearch: option "fields" must be provided');
+      }
+      const autoVacuum =
+        options.autoVacuum == null || options.autoVacuum === true
+          ? defaultAutoVacuumOptions
+          : options.autoVacuum;
+      this._options = {
+        ...defaultOptions,
+        ...options,
+        autoVacuum,
+        searchOptions: {
+          ...defaultSearchOptions,
+          ...(options.searchOptions || {}),
+        },
+        autoSuggestOptions: {
+          ...defaultAutoSuggestOptions,
+          ...(options.autoSuggestOptions || {}),
+        },
+      };
+      this._index = new SearchableMap();
+      this._documentCount = 0;
+      this._documentIds = new Map();
+      this._idToShortId = new Map();
+      // Fields are defined during initialization, don't change, are few in
+      // number, rarely need iterating over, and have string keys. Therefore in
+      // this case an object is a better candidate than a Map to store the mapping
+      // from field key to ID.
+      this._fieldIds = {};
+      this._fieldLength = new Map();
+      this._avgFieldLength = [];
+      this._nextId = 0;
+      this._storedFields = new Map();
+      this._dirtCount = 0;
+      this._currentVacuum = null;
+      this._enqueuedVacuum = null;
+      this._enqueuedVacuumConditions = defaultVacuumConditions;
+      this.addFields(this._options.fields);
+    }
+    /**
+     * Adds a document to the index
+     *
+     * @param document  The document to be indexed
+     */
+    add(document) {
+      const {
+        extractField,
+        stringifyField,
+        tokenize,
+        processTerm,
+        fields,
+        idField,
+      } = this._options;
+      const id = extractField(document, idField);
+      if (id == null) {
+        throw new Error(
+          `MiniSearch: document does not have ID field "${idField}"`,
+        );
+      }
+      if (this._idToShortId.has(id)) {
+        throw new Error(`MiniSearch: duplicate ID ${id}`);
+      }
+      const shortDocumentId = this.addDocumentId(id);
+      this.saveStoredFields(shortDocumentId, document);
+      for (const field of fields) {
+        const fieldValue = extractField(document, field);
+        if (fieldValue == null) continue;
+        const tokens = tokenize(stringifyField(fieldValue, field), field);
+        const fieldId = this._fieldIds[field];
+        const uniqueTerms = new Set(tokens).size;
+        this.addFieldLength(
+          shortDocumentId,
+          fieldId,
+          this._documentCount - 1,
+          uniqueTerms,
+        );
+        for (const term of tokens) {
+          const processedTerm = processTerm(term, field);
+          if (Array.isArray(processedTerm)) {
+            for (const t of processedTerm) {
+              this.addTerm(fieldId, shortDocumentId, t);
+            }
+          } else if (processedTerm) {
+            this.addTerm(fieldId, shortDocumentId, processedTerm);
+          }
+        }
+      }
+    }
+    /**
+     * Adds all the given documents to the index
+     *
+     * @param documents  An array of documents to be indexed
+     */
+    addAll(documents) {
+      for (const document of documents) this.add(document);
+    }
+    /**
+     * Adds all the given documents to the index asynchronously.
+     *
+     * Returns a promise that resolves (to `undefined`) when the indexing is done.
+     * This method is useful when index many documents, to avoid blocking the main
+     * thread. The indexing is performed asynchronously and in chunks.
+     *
+     * @param documents  An array of documents to be indexed
+     * @param options  Configuration options
+     * @return A promise resolving to `undefined` when the indexing is done
+     */
+    addAllAsync(documents, options = {}) {
+      const { chunkSize = 10 } = options;
+      const acc = { chunk: [], promise: Promise.resolve() };
+      const { chunk, promise } = documents.reduce(
+        ({ chunk, promise }, document, i) => {
+          chunk.push(document);
+          if ((i + 1) % chunkSize === 0) {
+            return {
+              chunk: [],
+              promise: promise
+                .then(() => new Promise((resolve) => setTimeout(resolve, 0)))
+                .then(() => this.addAll(chunk)),
+            };
+          } else {
+            return { chunk, promise };
+          }
+        },
+        acc,
+      );
+      return promise.then(() => this.addAll(chunk));
+    }
+    /**
+     * Removes the given document from the index.
+     *
+     * The document to remove must NOT have changed between indexing and removal,
+     * otherwise the index will be corrupted.
+     *
+     * This method requires passing the full document to be removed (not just the
+     * ID), and immediately removes the document from the inverted index, allowing
+     * memory to be released. A convenient alternative is {@link
+     * MiniSearch#discard}, which needs only the document ID, and has the same
+     * visible effect, but delays cleaning up the index until the next vacuuming.
+     *
+     * @param document  The document to be removed
+     */
+    remove(document) {
+      const {
+        tokenize,
+        processTerm,
+        extractField,
+        stringifyField,
+        fields,
+        idField,
+      } = this._options;
+      const id = extractField(document, idField);
+      if (id == null) {
+        throw new Error(
+          `MiniSearch: document does not have ID field "${idField}"`,
+        );
+      }
+      const shortId = this._idToShortId.get(id);
+      if (shortId == null) {
+        throw new Error(
+          `MiniSearch: cannot remove document with ID ${id}: it is not in the index`,
+        );
+      }
+      for (const field of fields) {
+        const fieldValue = extractField(document, field);
+        if (fieldValue == null) continue;
+        const tokens = tokenize(stringifyField(fieldValue, field), field);
+        const fieldId = this._fieldIds[field];
+        const uniqueTerms = new Set(tokens).size;
+        this.removeFieldLength(
+          shortId,
+          fieldId,
+          this._documentCount,
+          uniqueTerms,
+        );
+        for (const term of tokens) {
+          const processedTerm = processTerm(term, field);
+          if (Array.isArray(processedTerm)) {
+            for (const t of processedTerm) {
+              this.removeTerm(fieldId, shortId, t);
+            }
+          } else if (processedTerm) {
+            this.removeTerm(fieldId, shortId, processedTerm);
+          }
+        }
+      }
+      this._storedFields.delete(shortId);
+      this._documentIds.delete(shortId);
+      this._idToShortId.delete(id);
+      this._fieldLength.delete(shortId);
+      this._documentCount -= 1;
+    }
+    /**
+     * Removes all the given documents from the index. If called with no arguments,
+     * it removes _all_ documents from the index.
+     *
+     * @param documents  The documents to be removed. If this argument is omitted,
+     * all documents are removed. Note that, for removing all documents, it is
+     * more efficient to call this method with no arguments than to pass all
+     * documents.
+     */
+    removeAll(documents) {
+      if (documents) {
+        for (const document of documents) this.remove(document);
+      } else if (arguments.length > 0) {
+        throw new Error(
+          "Expected documents to be present. Omit the argument to remove all documents.",
+        );
+      } else {
+        this._index = new SearchableMap();
+        this._documentCount = 0;
+        this._documentIds = new Map();
+        this._idToShortId = new Map();
+        this._fieldLength = new Map();
+        this._avgFieldLength = [];
+        this._storedFields = new Map();
+        this._nextId = 0;
+      }
+    }
+    /**
+     * Discards the document with the given ID, so it won't appear in search results
+     *
+     * It has the same visible effect of {@link MiniSearch.remove} (both cause the
+     * document to stop appearing in searches), but a different effect on the
+     * internal data structures:
+     *
+     *   - {@link MiniSearch#remove} requires passing the full document to be
+     *   removed as argument, and removes it from the inverted index immediately.
+     *
+     *   - {@link MiniSearch#discard} instead only needs the document ID, and
+     *   works by marking the current version of the document as discarded, so it
+     *   is immediately ignored by searches. This is faster and more convenient
+     *   than {@link MiniSearch#remove}, but the index is not immediately
+     *   modified. To take care of that, vacuuming is performed after a certain
+     *   number of documents are discarded, cleaning up the index and allowing
+     *   memory to be released.
+     *
+     * After discarding a document, it is possible to re-add a new version, and
+     * only the new version will appear in searches. In other words, discarding
+     * and re-adding a document works exactly like removing and re-adding it. The
+     * {@link MiniSearch.replace} method can also be used to replace a document
+     * with a new version.
+     *
+     * #### Details about vacuuming
+     *
+     * Repetite calls to this method would leave obsolete document references in
+     * the index, invisible to searches. Two mechanisms take care of cleaning up:
+     * clean up during search, and vacuuming.
+     *
+     *   - Upon search, whenever a discarded ID is found (and ignored for the
+     *   results), references to the discarded document are removed from the
+     *   inverted index entries for the search terms. This ensures that subsequent
+     *   searches for the same terms do not need to skip these obsolete references
+     *   again.
+     *
+     *   - In addition, vacuuming is performed automatically by default (see the
+     *   `autoVacuum` field in {@link Options}) after a certain number of
+     *   documents are discarded. Vacuuming traverses all terms in the index,
+     *   cleaning up all references to discarded documents. Vacuuming can also be
+     *   triggered manually by calling {@link MiniSearch#vacuum}.
+     *
+     * @param id  The ID of the document to be discarded
+     */
+    discard(id) {
+      const shortId = this._idToShortId.get(id);
+      if (shortId == null) {
+        throw new Error(
+          `MiniSearch: cannot discard document with ID ${id}: it is not in the index`,
+        );
+      }
+      this._idToShortId.delete(id);
+      this._documentIds.delete(shortId);
+      this._storedFields.delete(shortId);
+      (this._fieldLength.get(shortId) || []).forEach((fieldLength, fieldId) => {
+        this.removeFieldLength(
+          shortId,
+          fieldId,
+          this._documentCount,
+          fieldLength,
+        );
+      });
+      this._fieldLength.delete(shortId);
+      this._documentCount -= 1;
+      this._dirtCount += 1;
+      this.maybeAutoVacuum();
+    }
+    maybeAutoVacuum() {
+      if (this._options.autoVacuum === false) {
+        return;
+      }
+      const { minDirtFactor, minDirtCount, batchSize, batchWait } =
+        this._options.autoVacuum;
+      this.conditionalVacuum(
+        { batchSize, batchWait },
+        { minDirtCount, minDirtFactor },
+      );
+    }
+    /**
+     * Discards the documents with the given IDs, so they won't appear in search
+     * results
+     *
+     * It is equivalent to calling {@link MiniSearch#discard} for all the given
+     * IDs, but with the optimization of triggering at most one automatic
+     * vacuuming at the end.
+     *
+     * Note: to remove all documents from the index, it is faster and more
+     * convenient to call {@link MiniSearch.removeAll} with no argument, instead
+     * of passing all IDs to this method.
+     */
+    discardAll(ids) {
+      const autoVacuum = this._options.autoVacuum;
+      try {
+        this._options.autoVacuum = false;
+        for (const id of ids) {
+          this.discard(id);
+        }
+      } finally {
+        this._options.autoVacuum = autoVacuum;
+      }
+      this.maybeAutoVacuum();
+    }
+    /**
+     * It replaces an existing document with the given updated version
+     *
+     * It works by discarding the current version and adding the updated one, so
+     * it is functionally equivalent to calling {@link MiniSearch#discard}
+     * followed by {@link MiniSearch#add}. The ID of the updated document should
+     * be the same as the original one.
+     *
+     * Since it uses {@link MiniSearch#discard} internally, this method relies on
+     * vacuuming to clean up obsolete document references from the index, allowing
+     * memory to be released (see {@link MiniSearch#discard}).
+     *
+     * @param updatedDocument  The updated document to replace the old version
+     * with
+     */
+    replace(updatedDocument) {
+      const { idField, extractField } = this._options;
+      const id = extractField(updatedDocument, idField);
+      this.discard(id);
+      this.add(updatedDocument);
+    }
+    /**
+     * Triggers a manual vacuuming, cleaning up references to discarded documents
+     * from the inverted index
+     *
+     * Vacuuming is only useful for applications that use the {@link
+     * MiniSearch#discard} or {@link MiniSearch#replace} methods.
+     *
+     * By default, vacuuming is performed automatically when needed (controlled by
+     * the `autoVacuum` field in {@link Options}), so there is usually no need to
+     * call this method, unless one wants to make sure to perform vacuuming at a
+     * specific moment.
+     *
+     * Vacuuming traverses all terms in the inverted index in batches, and cleans
+     * up references to discarded documents from the posting list, allowing memory
+     * to be released.
+     *
+     * The method takes an optional object as argument with the following keys:
+     *
+     *   - `batchSize`: the size of each batch (1000 by default)
+     *
+     *   - `batchWait`: the number of milliseconds to wait between batches (10 by
+     *   default)
+     *
+     * On large indexes, vacuuming could have a non-negligible cost: batching
+     * avoids blocking the thread for long, diluting this cost so that it is not
+     * negatively affecting the application. Nonetheless, this method should only
+     * be called when necessary, and relying on automatic vacuuming is usually
+     * better.
+     *
+     * It returns a promise that resolves (to undefined) when the clean up is
+     * completed. If vacuuming is already ongoing at the time this method is
+     * called, a new one is enqueued immediately after the ongoing one, and a
+     * corresponding promise is returned. However, no more than one vacuuming is
+     * enqueued on top of the ongoing one, even if this method is called more
+     * times (enqueuing multiple ones would be useless).
+     *
+     * @param options  Configuration options for the batch size and delay. See
+     * {@link VacuumOptions}.
+     */
+    vacuum(options = {}) {
+      return this.conditionalVacuum(options);
+    }
+    conditionalVacuum(options, conditions) {
+      // If a vacuum is already ongoing, schedule another as soon as it finishes,
+      // unless there's already one enqueued. If one was already enqueued, do not
+      // enqueue another on top, but make sure that the conditions are the
+      // broadest.
+      if (this._currentVacuum) {
+        this._enqueuedVacuumConditions =
+          this._enqueuedVacuumConditions && conditions;
+        if (this._enqueuedVacuum != null) {
+          return this._enqueuedVacuum;
+        }
+        this._enqueuedVacuum = this._currentVacuum.then(() => {
+          const conditions = this._enqueuedVacuumConditions;
+          this._enqueuedVacuumConditions = defaultVacuumConditions;
+          return this.performVacuuming(options, conditions);
+        });
+        return this._enqueuedVacuum;
+      }
+      if (this.vacuumConditionsMet(conditions) === false) {
+        return Promise.resolve();
+      }
+      this._currentVacuum = this.performVacuuming(options);
+      return this._currentVacuum;
+    }
+    async performVacuuming(options, conditions) {
+      const initialDirtCount = this._dirtCount;
+      if (this.vacuumConditionsMet(conditions)) {
+        const batchSize = options.batchSize || defaultVacuumOptions.batchSize;
+        const batchWait = options.batchWait || defaultVacuumOptions.batchWait;
+        let i = 1;
+        for (const [term, fieldsData] of this._index) {
+          for (const [fieldId, fieldIndex] of fieldsData) {
+            for (const [shortId] of fieldIndex) {
+              if (this._documentIds.has(shortId)) {
+                continue;
+              }
+              if (fieldIndex.size <= 1) {
+                fieldsData.delete(fieldId);
+              } else {
+                fieldIndex.delete(shortId);
+              }
+            }
+          }
+          if (this._index.get(term).size === 0) {
+            this._index.delete(term);
+          }
+          if (i % batchSize === 0) {
+            await new Promise((resolve) => setTimeout(resolve, batchWait));
+          }
+          i += 1;
+        }
+        this._dirtCount -= initialDirtCount;
+      }
+      // Make the next lines always async, so they execute after this function returns
+      await null;
+      this._currentVacuum = this._enqueuedVacuum;
+      this._enqueuedVacuum = null;
+    }
+    vacuumConditionsMet(conditions) {
+      if (conditions == null) {
+        return true;
+      }
+      let { minDirtCount, minDirtFactor } = conditions;
+      minDirtCount = minDirtCount || defaultAutoVacuumOptions.minDirtCount;
+      minDirtFactor = minDirtFactor || defaultAutoVacuumOptions.minDirtFactor;
+      return this.dirtCount >= minDirtCount && this.dirtFactor >= minDirtFactor;
+    }
+    /**
+     * Is `true` if a vacuuming operation is ongoing, `false` otherwise
+     */
+    get isVacuuming() {
+      return this._currentVacuum != null;
+    }
+    /**
+     * The number of documents discarded since the most recent vacuuming
+     */
+    get dirtCount() {
+      return this._dirtCount;
+    }
+    /**
+     * A number between 0 and 1 giving an indication about the proportion of
+     * documents that are discarded, and can therefore be cleaned up by vacuuming.
+     * A value close to 0 means that the index is relatively clean, while a higher
+     * value means that the index is relatively dirty, and vacuuming could release
+     * memory.
+     */
+    get dirtFactor() {
+      return this._dirtCount / (1 + this._documentCount + this._dirtCount);
+    }
+    /**
+     * Returns `true` if a document with the given ID is present in the index and
+     * available for search, `false` otherwise
+     *
+     * @param id  The document ID
+     */
+    has(id) {
+      return this._idToShortId.has(id);
+    }
+    /**
+     * Returns the stored fields (as configured in the `storeFields` constructor
+     * option) for the given document ID. Returns `undefined` if the document is
+     * not present in the index.
+     *
+     * @param id  The document ID
+     */
+    getStoredFields(id) {
+      const shortId = this._idToShortId.get(id);
+      if (shortId == null) {
+        return undefined;
+      }
+      return this._storedFields.get(shortId);
+    }
+    /**
+     * Search for documents matching the given search query.
+     *
+     * The result is a list of scored document IDs matching the query, sorted by
+     * descending score, and each including data about which terms were matched and
+     * in which fields.
+     *
+     * ### Basic usage:
+     *
+     * ```javascript
+     * // Search for "zen art motorcycle" with default options: terms have to match
+     * // exactly, and individual terms are joined with OR
+     * miniSearch.search('zen art motorcycle')
+     * // => [ { id: 2, score: 2.77258, match: { ... } }, { id: 4, score: 1.38629, match: { ... } } ]
+     * ```
+     *
+     * ### Restrict search to specific fields:
+     *
+     * ```javascript
+     * // Search only in the 'title' field
+     * miniSearch.search('zen', { fields: ['title'] })
+     * ```
+     *
+     * ### Field boosting:
+     *
+     * ```javascript
+     * // Boost a field
+     * miniSearch.search('zen', { boost: { title: 2 } })
+     * ```
+     *
+     * ### Prefix search:
+     *
+     * ```javascript
+     * // Search for "moto" with prefix search (it will match documents
+     * // containing terms that start with "moto" or "neuro")
+     * miniSearch.search('moto neuro', { prefix: true })
+     * ```
+     *
+     * ### Fuzzy search:
+     *
+     * ```javascript
+     * // Search for "ismael" with fuzzy search (it will match documents containing
+     * // terms similar to "ismael", with a maximum edit distance of 0.2 term.length
+     * // (rounded to nearest integer)
+     * miniSearch.search('ismael', { fuzzy: 0.2 })
+     * ```
+     *
+     * ### Combining strategies:
+     *
+     * ```javascript
+     * // Mix of exact match, prefix search, and fuzzy search
+     * miniSearch.search('ismael mob', {
+     *  prefix: true,
+     *  fuzzy: 0.2
+     * })
+     * ```
+     *
+     * ### Advanced prefix and fuzzy search:
+     *
+     * ```javascript
+     * // Perform fuzzy and prefix search depending on the search term. Here
+     * // performing prefix and fuzzy search only on terms longer than 3 characters
+     * miniSearch.search('ismael mob', {
+     *  prefix: term => term.length > 3
+     *  fuzzy: term => term.length > 3 ? 0.2 : null
+     * })
+     * ```
+     *
+     * ### Combine with AND:
+     *
+     * ```javascript
+     * // Combine search terms with AND (to match only documents that contain both
+     * // "motorcycle" and "art")
+     * miniSearch.search('motorcycle art', { combineWith: 'AND' })
+     * ```
+     *
+     * ### Combine with AND_NOT:
+     *
+     * There is also an AND_NOT combinator, that finds documents that match the
+     * first term, but do not match any of the other terms. This combinator is
+     * rarely useful with simple queries, and is meant to be used with advanced
+     * query combinations (see later for more details).
+     *
+     * ### Filtering results:
+     *
+     * ```javascript
+     * // Filter only results in the 'fiction' category (assuming that 'category'
+     * // is a stored field)
+     * miniSearch.search('motorcycle art', {
+     *   filter: (result) => result.category === 'fiction'
+     * })
+     * ```
+     *
+     * ### Wildcard query
+     *
+     * Searching for an empty string (assuming the default tokenizer) returns no
+     * results. Sometimes though, one needs to match all documents, like in a
+     * "wildcard" search. This is possible by passing the special value
+     * {@link MiniSearch.wildcard} as the query:
+     *
+     * ```javascript
+     * // Return search results for all documents
+     * miniSearch.search(MiniSearch.wildcard)
+     * ```
+     *
+     * Note that search options such as `filter` and `boostDocument` are still
+     * applied, influencing which results are returned, and their order:
+     *
+     * ```javascript
+     * // Return search results for all documents in the 'fiction' category
+     * miniSearch.search(MiniSearch.wildcard, {
+     *   filter: (result) => result.category === 'fiction'
+     * })
+     * ```
+     *
+     * ### Advanced combination of queries:
+     *
+     * It is possible to combine different subqueries with OR, AND, and AND_NOT,
+     * and even with different search options, by passing a query expression
+     * tree object as the first argument, instead of a string.
+     *
+     * ```javascript
+     * // Search for documents that contain "zen" and ("motorcycle" or "archery")
+     * miniSearch.search({
+     *   combineWith: 'AND',
+     *   queries: [
+     *     'zen',
+     *     {
+     *       combineWith: 'OR',
+     *       queries: ['motorcycle', 'archery']
+     *     }
+     *   ]
+     * })
+     *
+     * // Search for documents that contain ("apple" or "pear") but not "juice" and
+     * // not "tree"
+     * miniSearch.search({
+     *   combineWith: 'AND_NOT',
+     *   queries: [
+     *     {
+     *       combineWith: 'OR',
+     *       queries: ['apple', 'pear']
+     *     },
+     *     'juice',
+     *     'tree'
+     *   ]
+     * })
+     * ```
+     *
+     * Each node in the expression tree can be either a string, or an object that
+     * supports all {@link SearchOptions} fields, plus a `queries` array field for
+     * subqueries.
+     *
+     * Note that, while this can become complicated to do by hand for complex or
+     * deeply nested queries, it provides a formalized expression tree API for
+     * external libraries that implement a parser for custom query languages.
+     *
+     * @param query  Search query
+     * @param searchOptions  Search options. Each option, if not given, defaults to the corresponding value of `searchOptions` given to the constructor, or to the library default.
+     */
+    search(query, searchOptions = {}) {
+      const { searchOptions: globalSearchOptions } = this._options;
+      const searchOptionsWithDefaults = {
+        ...globalSearchOptions,
+        ...searchOptions,
+      };
+      const rawResults = this.executeQuery(query, searchOptions);
+      const results = [];
+      for (const [docId, { score, terms, match }] of rawResults) {
+        // terms are the matched query terms, which will be returned to the user
+        // as queryTerms. The quality is calculated based on them, as opposed to
+        // the matched terms in the document (which can be different due to
+        // prefix and fuzzy match)
+        const quality = terms.length || 1;
+        const result = {
+          id: this._documentIds.get(docId),
+          score: score * quality,
+          terms: Object.keys(match),
+          queryTerms: terms,
+          match,
+        };
+        Object.assign(result, this._storedFields.get(docId));
+        if (
+          searchOptionsWithDefaults.filter == null ||
+          searchOptionsWithDefaults.filter(result)
+        ) {
+          results.push(result);
+        }
+      }
+      // If it's a wildcard query, and no document boost is applied, skip sorting
+      // the results, as all results have the same score of 1
+      if (
+        query === MiniSearch.wildcard &&
+        searchOptionsWithDefaults.boostDocument == null
+      ) {
+        return results;
+      }
+      results.sort(byScore);
+      return results;
+    }
+    /**
+     * Provide suggestions for the given search query
+     *
+     * The result is a list of suggested modified search queries, derived from the
+     * given search query, each with a relevance score, sorted by descending score.
+     *
+     * By default, it uses the same options used for search, except that by
+     * default it performs prefix search on the last term of the query, and
+     * combine terms with `'AND'` (requiring all query terms to match). Custom
+     * options can be passed as a second argument. Defaults can be changed upon
+     * calling the {@link MiniSearch} constructor, by passing a
+     * `autoSuggestOptions` option.
+     *
+     * ### Basic usage:
+     *
+     * ```javascript
+     * // Get suggestions for 'neuro':
+     * miniSearch.autoSuggest('neuro')
+     * // => [ { suggestion: 'neuromancer', terms: [ 'neuromancer' ], score: 0.46240 } ]
+     * ```
+     *
+     * ### Multiple words:
+     *
+     * ```javascript
+     * // Get suggestions for 'zen ar':
+     * miniSearch.autoSuggest('zen ar')
+     * // => [
+     * //  { suggestion: 'zen archery art', terms: [ 'zen', 'archery', 'art' ], score: 1.73332 },
+     * //  { suggestion: 'zen art', terms: [ 'zen', 'art' ], score: 1.21313 }
+     * // ]
+     * ```
+     *
+     * ### Fuzzy suggestions:
+     *
+     * ```javascript
+     * // Correct spelling mistakes using fuzzy search:
+     * miniSearch.autoSuggest('neromancer', { fuzzy: 0.2 })
+     * // => [ { suggestion: 'neuromancer', terms: [ 'neuromancer' ], score: 1.03998 } ]
+     * ```
+     *
+     * ### Filtering:
+     *
+     * ```javascript
+     * // Get suggestions for 'zen ar', but only within the 'fiction' category
+     * // (assuming that 'category' is a stored field):
+     * miniSearch.autoSuggest('zen ar', {
+     *   filter: (result) => result.category === 'fiction'
+     * })
+     * // => [
+     * //  { suggestion: 'zen archery art', terms: [ 'zen', 'archery', 'art' ], score: 1.73332 },
+     * //  { suggestion: 'zen art', terms: [ 'zen', 'art' ], score: 1.21313 }
+     * // ]
+     * ```
+     *
+     * @param queryString  Query string to be expanded into suggestions
+     * @param options  Search options. The supported options and default values
+     * are the same as for the {@link MiniSearch#search} method, except that by
+     * default prefix search is performed on the last term in the query, and terms
+     * are combined with `'AND'`.
+     * @return  A sorted array of suggestions sorted by relevance score.
+     */
+    autoSuggest(queryString, options = {}) {
+      options = { ...this._options.autoSuggestOptions, ...options };
+      const suggestions = new Map();
+      for (const { score, terms } of this.search(queryString, options)) {
+        const phrase = terms.join(" ");
+        const suggestion = suggestions.get(phrase);
+        if (suggestion != null) {
+          suggestion.score += score;
+          suggestion.count += 1;
+        } else {
+          suggestions.set(phrase, { score, terms, count: 1 });
+        }
+      }
+      const results = [];
+      for (const [suggestion, { score, terms, count }] of suggestions) {
+        results.push({ suggestion, terms, score: score / count });
+      }
+      results.sort(byScore);
+      return results;
+    }
+    /**
+     * Total number of documents available to search
+     */
+    get documentCount() {
+      return this._documentCount;
+    }
+    /**
+     * Number of terms in the index
+     */
+    get termCount() {
+      return this._index.size;
+    }
+    /**
+     * Deserializes a JSON index (serialized with `JSON.stringify(miniSearch)`)
+     * and instantiates a MiniSearch instance. It should be given the same options
+     * originally used when serializing the index.
+     *
+     * ### Usage:
+     *
+     * ```javascript
+     * // If the index was serialized with:
+     * let miniSearch = new MiniSearch({ fields: ['title', 'text'] })
+     * miniSearch.addAll(documents)
+     *
+     * const json = JSON.stringify(miniSearch)
+     * // It can later be deserialized like this:
+     * miniSearch = MiniSearch.loadJSON(json, { fields: ['title', 'text'] })
+     * ```
+     *
+     * @param json  JSON-serialized index
+     * @param options  configuration options, same as the constructor
+     * @return An instance of MiniSearch deserialized from the given JSON.
+     */
+    static loadJSON(json, options) {
+      if (options == null) {
+        throw new Error(
+          "MiniSearch: loadJSON should be given the same options used when serializing the index",
+        );
+      }
+      return this.loadJS(JSON.parse(json), options);
+    }
+    /**
+     * Async equivalent of {@link MiniSearch.loadJSON}
+     *
+     * This function is an alternative to {@link MiniSearch.loadJSON} that returns
+     * a promise, and loads the index in batches, leaving pauses between them to avoid
+     * blocking the main thread. It tends to be slower than the synchronous
+     * version, but does not block the main thread, so it can be a better choice
+     * when deserializing very large indexes.
+     *
+     * @param json  JSON-serialized index
+     * @param options  configuration options, same as the constructor
+     * @return A Promise that will resolve to an instance of MiniSearch deserialized from the given JSON.
+     */
+    static async loadJSONAsync(json, options) {
+      if (options == null) {
+        throw new Error(
+          "MiniSearch: loadJSON should be given the same options used when serializing the index",
+        );
+      }
+      return this.loadJSAsync(JSON.parse(json), options);
+    }
+    /**
+     * Returns the default value of an option. It will throw an error if no option
+     * with the given name exists.
+     *
+     * @param optionName  Name of the option
+     * @return The default value of the given option
+     *
+     * ### Usage:
+     *
+     * ```javascript
+     * // Get default tokenizer
+     * MiniSearch.getDefault('tokenize')
+     *
+     * // Get default term processor
+     * MiniSearch.getDefault('processTerm')
+     *
+     * // Unknown options will throw an error
+     * MiniSearch.getDefault('notExisting')
+     * // => throws 'MiniSearch: unknown option "notExisting"'
+     * ```
+     */
+    static getDefault(optionName) {
+      if (defaultOptions.hasOwnProperty(optionName)) {
+        return getOwnProperty(defaultOptions, optionName);
+      } else {
+        throw new Error(`MiniSearch: unknown option "${optionName}"`);
+      }
+    }
+    /**
+     * @ignore
+     */
+    static loadJS(js, options) {
+      const {
+        index,
+        documentIds,
+        fieldLength,
+        storedFields,
+        serializationVersion,
+      } = js;
+      const miniSearch = this.instantiateMiniSearch(js, options);
+      miniSearch._documentIds = objectToNumericMap(documentIds);
+      miniSearch._fieldLength = objectToNumericMap(fieldLength);
+      miniSearch._storedFields = objectToNumericMap(storedFields);
+      for (const [shortId, id] of miniSearch._documentIds) {
+        miniSearch._idToShortId.set(id, shortId);
+      }
+      for (const [term, data] of index) {
+        const dataMap = new Map();
+        for (const fieldId of Object.keys(data)) {
+          let indexEntry = data[fieldId];
+          // Version 1 used to nest the index entry inside a field called ds
+          if (serializationVersion === 1) {
+            indexEntry = indexEntry.ds;
+          }
+          dataMap.set(parseInt(fieldId, 10), objectToNumericMap(indexEntry));
+        }
+        miniSearch._index.set(term, dataMap);
+      }
+      return miniSearch;
+    }
+    /**
+     * @ignore
+     */
+    static async loadJSAsync(js, options) {
+      const {
+        index,
+        documentIds,
+        fieldLength,
+        storedFields,
+        serializationVersion,
+      } = js;
+      const miniSearch = this.instantiateMiniSearch(js, options);
+      miniSearch._documentIds = await objectToNumericMapAsync(documentIds);
+      miniSearch._fieldLength = await objectToNumericMapAsync(fieldLength);
+      miniSearch._storedFields = await objectToNumericMapAsync(storedFields);
+      for (const [shortId, id] of miniSearch._documentIds) {
+        miniSearch._idToShortId.set(id, shortId);
+      }
+      let count = 0;
+      for (const [term, data] of index) {
+        const dataMap = new Map();
+        for (const fieldId of Object.keys(data)) {
+          let indexEntry = data[fieldId];
+          // Version 1 used to nest the index entry inside a field called ds
+          if (serializationVersion === 1) {
+            indexEntry = indexEntry.ds;
+          }
+          dataMap.set(
+            parseInt(fieldId, 10),
+            await objectToNumericMapAsync(indexEntry),
+          );
+        }
+        if (++count % 1000 === 0) await wait(0);
+        miniSearch._index.set(term, dataMap);
+      }
+      return miniSearch;
+    }
+    /**
+     * @ignore
+     */
+    static instantiateMiniSearch(js, options) {
+      const {
+        documentCount,
+        nextId,
+        fieldIds,
+        averageFieldLength,
+        dirtCount,
+        serializationVersion,
+      } = js;
+      if (serializationVersion !== 1 && serializationVersion !== 2) {
+        throw new Error(
+          "MiniSearch: cannot deserialize an index created with an incompatible version",
+        );
+      }
+      const miniSearch = new MiniSearch(options);
+      miniSearch._documentCount = documentCount;
+      miniSearch._nextId = nextId;
+      miniSearch._idToShortId = new Map();
+      miniSearch._fieldIds = fieldIds;
+      miniSearch._avgFieldLength = averageFieldLength;
+      miniSearch._dirtCount = dirtCount || 0;
+      miniSearch._index = new SearchableMap();
+      return miniSearch;
+    }
+    /**
+     * @ignore
+     */
+    executeQuery(query, searchOptions = {}) {
+      if (query === MiniSearch.wildcard) {
+        return this.executeWildcardQuery(searchOptions);
+      }
+      if (typeof query !== "string") {
+        const options = { ...searchOptions, ...query, queries: undefined };
+        const results = query.queries.map((subquery) =>
+          this.executeQuery(subquery, options),
+        );
+        return this.combineResults(results, options.combineWith);
+      }
+      const {
+        tokenize,
+        processTerm,
+        searchOptions: globalSearchOptions,
+      } = this._options;
+      const options = {
+        tokenize,
+        processTerm,
+        ...globalSearchOptions,
+        ...searchOptions,
+      };
+      const { tokenize: searchTokenize, processTerm: searchProcessTerm } =
+        options;
+      const terms = searchTokenize(query)
+        .flatMap((term) => searchProcessTerm(term))
+        .filter((term) => !!term);
+      const queries = terms.map(termToQuerySpec(options));
+      const results = queries.map((query) =>
+        this.executeQuerySpec(query, options),
+      );
+      return this.combineResults(results, options.combineWith);
+    }
+    /**
+     * @ignore
+     */
+    executeQuerySpec(query, searchOptions) {
+      const options = { ...this._options.searchOptions, ...searchOptions };
+      const boosts = (options.fields || this._options.fields).reduce(
+        (boosts, field) => ({
+          ...boosts,
+          [field]: getOwnProperty(options.boost, field) || 1,
+        }),
+        {},
+      );
+      const { boostDocument, weights, maxFuzzy, bm25: bm25params } = options;
+      const { fuzzy: fuzzyWeight, prefix: prefixWeight } = {
+        ...defaultSearchOptions.weights,
+        ...weights,
+      };
+      const data = this._index.get(query.term);
+      const results = this.termResults(
+        query.term,
+        query.term,
+        1,
+        query.termBoost,
+        data,
+        boosts,
+        boostDocument,
+        bm25params,
+      );
+      let prefixMatches;
+      let fuzzyMatches;
+      if (query.prefix) {
+        prefixMatches = this._index.atPrefix(query.term);
+      }
+      if (query.fuzzy) {
+        const fuzzy = query.fuzzy === true ? 0.2 : query.fuzzy;
+        const maxDistance =
+          fuzzy < 1
+            ? Math.min(maxFuzzy, Math.round(query.term.length * fuzzy))
+            : fuzzy;
+        if (maxDistance)
+          fuzzyMatches = this._index.fuzzyGet(query.term, maxDistance);
+      }
+      if (prefixMatches) {
+        for (const [term, data] of prefixMatches) {
+          const distance = term.length - query.term.length;
+          if (!distance) {
+            continue;
+          } // Skip exact match.
+          // Delete the term from fuzzy results (if present) if it is also a
+          // prefix result. This entry will always be scored as a prefix result.
+          fuzzyMatches === null || fuzzyMatches === void 0
+            ? void 0
+            : fuzzyMatches.delete(term);
+          // Weight gradually approaches 0 as distance goes to infinity, with the
+          // weight for the hypothetical distance 0 being equal to prefixWeight.
+          // The rate of change is much lower than that of fuzzy matches to
+          // account for the fact that prefix matches stay more relevant than
+          // fuzzy matches for longer distances.
+          const weight =
+            (prefixWeight * term.length) / (term.length + 0.3 * distance);
+          this.termResults(
+            query.term,
+            term,
+            weight,
+            query.termBoost,
+            data,
+            boosts,
+            boostDocument,
+            bm25params,
+            results,
+          );
+        }
+      }
+      if (fuzzyMatches) {
+        for (const term of fuzzyMatches.keys()) {
+          const [data, distance] = fuzzyMatches.get(term);
+          if (!distance) {
+            continue;
+          } // Skip exact match.
+          // Weight gradually approaches 0 as distance goes to infinity, with the
+          // weight for the hypothetical distance 0 being equal to fuzzyWeight.
+          const weight = (fuzzyWeight * term.length) / (term.length + distance);
+          this.termResults(
+            query.term,
+            term,
+            weight,
+            query.termBoost,
+            data,
+            boosts,
+            boostDocument,
+            bm25params,
+            results,
+          );
+        }
+      }
+      return results;
+    }
+    /**
+     * @ignore
+     */
+    executeWildcardQuery(searchOptions) {
+      const results = new Map();
+      const options = { ...this._options.searchOptions, ...searchOptions };
+      for (const [shortId, id] of this._documentIds) {
+        const score = options.boostDocument
+          ? options.boostDocument(id, "", this._storedFields.get(shortId))
+          : 1;
+        results.set(shortId, {
+          score,
+          terms: [],
+          match: {},
+        });
+      }
+      return results;
+    }
+    /**
+     * @ignore
+     */
+    combineResults(results, combineWith = OR) {
+      if (results.length === 0) {
+        return new Map();
+      }
+      const operator = combineWith.toLowerCase();
+      const combinator = combinators[operator];
+      if (!combinator) {
+        throw new Error(`Invalid combination operator: ${combineWith}`);
+      }
+      return results.reduce(combinator) || new Map();
+    }
+    /**
+     * Allows serialization of the index to JSON, to possibly store it and later
+     * deserialize it with {@link MiniSearch.loadJSON}.
+     *
+     * Normally one does not directly call this method, but rather call the
+     * standard JavaScript `JSON.stringify()` passing the {@link MiniSearch}
+     * instance, and JavaScript will internally call this method. Upon
+     * deserialization, one must pass to {@link MiniSearch.loadJSON} the same
+     * options used to create the original instance that was serialized.
+     *
+     * ### Usage:
+     *
+     * ```javascript
+     * // Serialize the index:
+     * let miniSearch = new MiniSearch({ fields: ['title', 'text'] })
+     * miniSearch.addAll(documents)
+     * const json = JSON.stringify(miniSearch)
+     *
+     * // Later, to deserialize it:
+     * miniSearch = MiniSearch.loadJSON(json, { fields: ['title', 'text'] })
+     * ```
+     *
+     * @return A plain-object serializable representation of the search index.
+     */
+    toJSON() {
+      const index = [];
+      for (const [term, fieldIndex] of this._index) {
+        const data = {};
+        for (const [fieldId, freqs] of fieldIndex) {
+          data[fieldId] = Object.fromEntries(freqs);
+        }
+        index.push([term, data]);
+      }
+      return {
+        documentCount: this._documentCount,
+        nextId: this._nextId,
+        documentIds: Object.fromEntries(this._documentIds),
+        fieldIds: this._fieldIds,
+        fieldLength: Object.fromEntries(this._fieldLength),
+        averageFieldLength: this._avgFieldLength,
+        storedFields: Object.fromEntries(this._storedFields),
+        dirtCount: this._dirtCount,
+        index,
+        serializationVersion: 2,
+      };
+    }
+    /**
+     * @ignore
+     */
+    termResults(
+      sourceTerm,
+      derivedTerm,
+      termWeight,
+      termBoost,
+      fieldTermData,
+      fieldBoosts,
+      boostDocumentFn,
+      bm25params,
+      results = new Map(),
+    ) {
+      if (fieldTermData == null) return results;
+      for (const field of Object.keys(fieldBoosts)) {
+        const fieldBoost = fieldBoosts[field];
+        const fieldId = this._fieldIds[field];
+        const fieldTermFreqs = fieldTermData.get(fieldId);
+        if (fieldTermFreqs == null) continue;
+        let matchingFields = fieldTermFreqs.size;
+        const avgFieldLength = this._avgFieldLength[fieldId];
+        for (const docId of fieldTermFreqs.keys()) {
+          if (!this._documentIds.has(docId)) {
+            this.removeTerm(fieldId, docId, derivedTerm);
+            matchingFields -= 1;
+            continue;
+          }
+          const docBoost = boostDocumentFn
+            ? boostDocumentFn(
+                this._documentIds.get(docId),
+                derivedTerm,
+                this._storedFields.get(docId),
+              )
+            : 1;
+          if (!docBoost) continue;
+          const termFreq = fieldTermFreqs.get(docId);
+          const fieldLength = this._fieldLength.get(docId)[fieldId];
+          // NOTE: The total number of fields is set to the number of documents
+          // `this._documentCount`. It could also make sense to use the number of
+          // documents where the current field is non-blank as a normalization
+          // factor. This will make a difference in scoring if the field is rarely
+          // present. This is currently not supported, and may require further
+          // analysis to see if it is a valid use case.
+          const rawScore = calcBM25Score(
+            termFreq,
+            matchingFields,
+            this._documentCount,
+            fieldLength,
+            avgFieldLength,
+            bm25params,
+          );
+          const weightedScore =
+            termWeight * termBoost * fieldBoost * docBoost * rawScore;
+          const result = results.get(docId);
+          if (result) {
+            result.score += weightedScore;
+            assignUniqueTerm(result.terms, sourceTerm);
+            const match = getOwnProperty(result.match, derivedTerm);
+            if (match) {
+              match.push(field);
+            } else {
+              result.match[derivedTerm] = [field];
+            }
+          } else {
+            results.set(docId, {
+              score: weightedScore,
+              terms: [sourceTerm],
+              match: { [derivedTerm]: [field] },
+            });
+          }
+        }
+      }
+      return results;
+    }
+    /**
+     * @ignore
+     */
+    addTerm(fieldId, documentId, term) {
+      const indexData = this._index.fetch(term, createMap);
+      let fieldIndex = indexData.get(fieldId);
+      if (fieldIndex == null) {
+        fieldIndex = new Map();
+        fieldIndex.set(documentId, 1);
+        indexData.set(fieldId, fieldIndex);
+      } else {
+        const docs = fieldIndex.get(documentId);
+        fieldIndex.set(documentId, (docs || 0) + 1);
+      }
+    }
+    /**
+     * @ignore
+     */
+    removeTerm(fieldId, documentId, term) {
+      if (!this._index.has(term)) {
+        this.warnDocumentChanged(documentId, fieldId, term);
+        return;
+      }
+      const indexData = this._index.fetch(term, createMap);
+      const fieldIndex = indexData.get(fieldId);
+      if (fieldIndex == null || fieldIndex.get(documentId) == null) {
+        this.warnDocumentChanged(documentId, fieldId, term);
+      } else if (fieldIndex.get(documentId) <= 1) {
+        if (fieldIndex.size <= 1) {
+          indexData.delete(fieldId);
+        } else {
+          fieldIndex.delete(documentId);
+        }
+      } else {
+        fieldIndex.set(documentId, fieldIndex.get(documentId) - 1);
+      }
+      if (this._index.get(term).size === 0) {
+        this._index.delete(term);
+      }
+    }
+    /**
+     * @ignore
+     */
+    warnDocumentChanged(shortDocumentId, fieldId, term) {
+      for (const fieldName of Object.keys(this._fieldIds)) {
+        if (this._fieldIds[fieldName] === fieldId) {
+          this._options.logger(
+            "warn",
+            `MiniSearch: document with ID ${this._documentIds.get(shortDocumentId)} has changed before removal: term "${term}" was not present in field "${fieldName}". Removing a document after it has changed can corrupt the index!`,
+            "version_conflict",
+          );
+          return;
+        }
+      }
+    }
+    /**
+     * @ignore
+     */
+    addDocumentId(documentId) {
+      const shortDocumentId = this._nextId;
+      this._idToShortId.set(documentId, shortDocumentId);
+      this._documentIds.set(shortDocumentId, documentId);
+      this._documentCount += 1;
+      this._nextId += 1;
+      return shortDocumentId;
+    }
+    /**
+     * @ignore
+     */
+    addFields(fields) {
+      for (let i = 0; i < fields.length; i++) {
+        this._fieldIds[fields[i]] = i;
+      }
+    }
+    /**
+     * @ignore
+     */
+    addFieldLength(documentId, fieldId, count, length) {
+      let fieldLengths = this._fieldLength.get(documentId);
+      if (fieldLengths == null)
+        this._fieldLength.set(documentId, (fieldLengths = []));
+      fieldLengths[fieldId] = length;
+      const averageFieldLength = this._avgFieldLength[fieldId] || 0;
+      const totalFieldLength = averageFieldLength * count + length;
+      this._avgFieldLength[fieldId] = totalFieldLength / (count + 1);
+    }
+    /**
+     * @ignore
+     */
+    removeFieldLength(documentId, fieldId, count, length) {
+      if (count === 1) {
+        this._avgFieldLength[fieldId] = 0;
+        return;
+      }
+      const totalFieldLength = this._avgFieldLength[fieldId] * count - length;
+      this._avgFieldLength[fieldId] = totalFieldLength / (count - 1);
+    }
+    /**
+     * @ignore
+     */
+    saveStoredFields(documentId, doc) {
+      const { storeFields, extractField } = this._options;
+      if (storeFields == null || storeFields.length === 0) {
+        return;
+      }
+      let documentFields = this._storedFields.get(documentId);
+      if (documentFields == null)
+        this._storedFields.set(documentId, (documentFields = {}));
+      for (const fieldName of storeFields) {
+        const fieldValue = extractField(doc, fieldName);
+        if (fieldValue !== undefined) documentFields[fieldName] = fieldValue;
+      }
+    }
+  }
+  /**
+   * The special wildcard symbol that can be passed to {@link MiniSearch#search}
+   * to match all documents
+   */
+  MiniSearch.wildcard = Symbol("*");
+  const getOwnProperty = (object, property) =>
+    Object.prototype.hasOwnProperty.call(object, property)
+      ? object[property]
+      : undefined;
+  const combinators = {
+    [OR]: (a, b) => {
+      for (const docId of b.keys()) {
+        const existing = a.get(docId);
+        if (existing == null) {
+          a.set(docId, b.get(docId));
+        } else {
+          const { score, terms, match } = b.get(docId);
+          existing.score = existing.score + score;
+          existing.match = Object.assign(existing.match, match);
+          assignUniqueTerms(existing.terms, terms);
+        }
+      }
+      return a;
+    },
+    [AND]: (a, b) => {
+      const combined = new Map();
+      for (const docId of b.keys()) {
+        const existing = a.get(docId);
+        if (existing == null) continue;
+        const { score, terms, match } = b.get(docId);
+        assignUniqueTerms(existing.terms, terms);
+        combined.set(docId, {
+          score: existing.score + score,
+          terms: existing.terms,
+          match: Object.assign(existing.match, match),
+        });
+      }
+      return combined;
+    },
+    [AND_NOT]: (a, b) => {
+      for (const docId of b.keys()) a.delete(docId);
+      return a;
+    },
+  };
+  const defaultBM25params = { k: 1.2, b: 0.7, d: 0.5 };
+  const calcBM25Score = (
+    termFreq,
+    matchingCount,
+    totalCount,
+    fieldLength,
+    avgFieldLength,
+    bm25params,
+  ) => {
+    const { k, b, d } = bm25params;
+    const invDocFreq = Math.log(
+      1 + (totalCount - matchingCount + 0.5) / (matchingCount + 0.5),
+    );
+    return (
+      invDocFreq *
+      (d +
+        (termFreq * (k + 1)) /
+          (termFreq + k * (1 - b + (b * fieldLength) / avgFieldLength)))
+    );
+  };
+  const termToQuerySpec = (options) => (term, i, terms) => {
+    const fuzzy =
+      typeof options.fuzzy === "function"
+        ? options.fuzzy(term, i, terms)
+        : options.fuzzy || false;
+    const prefix =
+      typeof options.prefix === "function"
+        ? options.prefix(term, i, terms)
+        : options.prefix === true;
+    const termBoost =
+      typeof options.boostTerm === "function"
+        ? options.boostTerm(term, i, terms)
+        : 1;
+    return { term, fuzzy, prefix, termBoost };
+  };
+  const defaultOptions = {
+    idField: "id",
+    extractField: (document, fieldName) => document[fieldName],
+    stringifyField: (fieldValue, fieldName) => fieldValue.toString(),
+    tokenize: (text) => text.split(SPACE_OR_PUNCTUATION),
+    processTerm: (term) => term.toLowerCase(),
+    fields: undefined,
+    searchOptions: undefined,
+    storeFields: [],
+    logger: (level, message) => {
+      if (
+        typeof (console === null || console === void 0
+          ? void 0
+          : console[level]) === "function"
+      )
+        console[level](message);
+    },
+    autoVacuum: true,
+  };
+  const defaultSearchOptions = {
+    combineWith: OR,
+    prefix: false,
+    fuzzy: false,
+    maxFuzzy: 6,
+    boost: {},
+    weights: { fuzzy: 0.45, prefix: 0.375 },
+    bm25: defaultBM25params,
+  };
+  const defaultAutoSuggestOptions = {
+    combineWith: AND,
+    prefix: (term, i, terms) => i === terms.length - 1,
+  };
+  const defaultVacuumOptions = { batchSize: 1000, batchWait: 10 };
+  const defaultVacuumConditions = { minDirtFactor: 0.1, minDirtCount: 20 };
+  const defaultAutoVacuumOptions = {
+    ...defaultVacuumOptions,
+    ...defaultVacuumConditions,
+  };
+  const assignUniqueTerm = (target, term) => {
+    // Avoid adding duplicate terms.
+    if (!target.includes(term)) target.push(term);
+  };
+  const assignUniqueTerms = (target, source) => {
+    for (const term of source) {
+      // Avoid adding duplicate terms.
+      if (!target.includes(term)) target.push(term);
+    }
+  };
+  const byScore = ({ score: a }, { score: b }) => b - a;
+  const createMap = () => new Map();
+  const objectToNumericMap = (object) => {
+    const map = new Map();
+    for (const key of Object.keys(object)) {
+      map.set(parseInt(key, 10), object[key]);
+    }
+    return map;
+  };
+  const objectToNumericMapAsync = async (object) => {
+    const map = new Map();
+    let count = 0;
+    for (const key of Object.keys(object)) {
+      map.set(parseInt(key, 10), object[key]);
+      if (++count % 1000 === 0) {
+        await wait(0);
+      }
+    }
+    return map;
+  };
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  // This regular expression matches any Unicode space, newline, or punctuation
+  // character
+  const SPACE_OR_PUNCTUATION = /[\n\r\p{Z}\p{P}]+/u;
+
+  return MiniSearch;
+});
+//# sourceMappingURL=index.js.map

--- a/website/index.html
+++ b/website/index.html
@@ -2382,7 +2382,8 @@ function getPaginationRange(current, total) {
 // Stores the in-flight promise so concurrent opens don't double-fetch.
 const detailCache = new Map();
 // Request token to guard against race conditions when the user clicks
-// card A then card B before A's detail resolves.
+// card A then card B before A's detail resolves. closeModal() bumps it
+// too so an in-flight fetch doesn't inject into a closed overlay.
 let openModalToken = 0;
 
 function fetchSkillDetail(slimSkill) {
@@ -2525,6 +2526,12 @@ function trapFocus(el) {
 }
 
 function closeModal() {
+  // Invalidate any in-flight detail fetch so its resolution doesn't inject
+  // stale content into the hidden modal DOM. (The network request itself
+  // still completes; the ~1.4 KB payload isn't worth an AbortController
+  // that would break rapid same-card re-clicks by aborting the shared
+  // promise in the detailCache.)
+  ++openModalToken;
   document.getElementById('modal-overlay').classList.remove('open');
   document.body.style.overflow = '';
   if (_focusTrapHandler) {

--- a/website/index.html
+++ b/website/index.html
@@ -784,6 +784,15 @@ mark.hl {
   line-height: 1.6;
   margin-bottom: 20px;
 }
+.modal-loading, .modal-error {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-bottom: 20px;
+  padding: 12px 14px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+}
+.modal-error { color: var(--accent-warn, #c94a4a); border-style: solid; }
 .modal-meta {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -1897,6 +1906,7 @@ mark.hl {
   </p>
 </footer>
 
+<script src="assets/minisearch.min.js"></script>
 <script>
 // ─── Theme ─────────────────────────────────────────────────────────────────
 (function initTheme() {
@@ -2039,10 +2049,20 @@ function esc(str) {
 // Wrap query-token matches in <mark class="hl">. Operates on already-escaped
 // HTML so it stays XSS-safe — esc() never produces angle brackets, and the
 // regex only inserts fixed <mark> tags.
-function highlightMatches(text, query) {
+//
+// `terms` — optional explicit token list from MiniSearch's `search()` result
+// (`hit.terms`). When provided, these are used as-is so prefix/fuzzy
+// expansions ("clade" → "claude") are highlighted correctly. When absent,
+// falls back to tokenizing the raw query (same behaviour as before).
+function highlightMatches(text, query, terms) {
   const escaped = esc(text);
-  if (!query || !query.trim()) return escaped;
-  const tokens = query.trim().toLowerCase().split(/[\s\-_.,;:()[\]{}"']+/).filter(t => t.length >= 2);
+  let tokens;
+  if (terms && terms.length) {
+    tokens = terms.map(t => String(t).toLowerCase()).filter(t => t.length >= 2);
+  } else {
+    if (!query || !query.trim()) return escaped;
+    tokens = query.trim().toLowerCase().split(/[\s\-_.,;:()[\]{}"']+/).filter(t => t.length >= 2);
+  }
   if (!tokens.length) return escaped;
   // Dedupe + sort by length (longest first) so overlapping matches prefer the
   // most specific token, and escape regex metacharacters in tokens.
@@ -2059,39 +2079,34 @@ function highlightMatches(text, query) {
     .join('');
 }
 
-// ─── Search (originally mirrored src/skill-index.ts scoring; #186 extends it
-// with category-aware scoring so search also surfaces "writing" / "design" /
-// etc. Drift from skill-index.ts accepted — tracked as follow-up.)
-const SCORE_NAME_EXACT = 10;
-const SCORE_NAME_PARTIAL = 5;
-const SCORE_DESC_EXACT = 3;
-const SCORE_DESC_PARTIAL = 1;
-
-function tokenize(text) {
-  const tokens = new Set();
-  const words = text.toLowerCase().split(/[\s\-_.,;:()[\]{}"']+/);
-  for (const w of words) {
-    if (w.length >= 2) tokens.add(w);
+// ─── Search (MiniSearch, issue #214) ───────────────────────────────────────
+// Options MUST match the build script (scripts/build-catalog.ts — search for
+// `miniSearchOptions`). The serialized index depends on the exact same
+// tokenization + field config.
+const MINISEARCH_OPTIONS = {
+  idField: 'id',
+  fields: ['name', 'description', 'categoriesStr'],
+  storeFields: [],
+  searchOptions: {
+    boost: { name: 3, description: 1, categoriesStr: 1 },
+    prefix: true,
+    fuzzy: 0.2
   }
-  return tokens;
-}
+};
+// Populated in boot(). Null until the index finishes loading.
+let miniSearch = null;
+// Last search terms (incl. prefix/fuzzy expansions) so highlightMatches can
+// mark the actual matched tokens rather than the raw query string.
+let lastSearchTerms = null;
 
-function scoreSkill(query, skill) {
-  const qt = tokenize(query);
-  const nt = tokenize(skill.name);
-  const dt = tokenize(skill.description);
-  const catStr = (skill.categories || []).join(' ').toLowerCase();
-  const ct = tokenize(catStr);
-  let score = 0;
-  for (const q of qt) {
-    if (nt.has(q)) score += SCORE_NAME_EXACT;
-    if (dt.has(q)) score += SCORE_DESC_EXACT;
-    if (skill.name.toLowerCase().includes(q)) score += SCORE_NAME_PARTIAL;
-    if (skill.description.toLowerCase().includes(q)) score += SCORE_DESC_PARTIAL;
-    // Category match — low weight, helps surface obvious topical hits
-    if (ct.has(q)) score += SCORE_DESC_PARTIAL;
+// Flatten the per-hit `terms` arrays into a deduped list for highlight use.
+function extractTerms(hits) {
+  const seen = new Set();
+  for (const h of hits) {
+    if (!Array.isArray(h.terms)) continue;
+    for (const t of h.terms) if (t) seen.add(String(t).toLowerCase());
   }
-  return score;
+  return Array.from(seen);
 }
 
 // ─── Filter & Search ───────────────────────────────────────────────────────
@@ -2124,7 +2139,9 @@ function getFiltered() {
   }
   if (activeFacets.usesTools.size > 0) {
     results = results.filter(s => {
-      const yes = !!(s.allowedTools && s.allowedTools.length > 0);
+      // Slim rows carry `hasTools`; fall back to allowedTools for anywhere
+      // the full-catalog shape is still passed in.
+      const yes = s.hasTools === true || !!(s.allowedTools && s.allowedTools.length > 0);
       return (yes && activeFacets.usesTools.has('yes')) || (!yes && activeFacets.usesTools.has('no'));
     });
   }
@@ -2138,19 +2155,31 @@ function getFiltered() {
     return bf - af;
   };
 
-  // Search — keep score-ordered results when relevance sort is in use, but
-  // still float featured skills above the rest.
+  // Search — MiniSearch with prefix + fuzzy. We build a Set of matching IDs
+  // up front, intersect with the filter-narrowed `results`, then reorder by
+  // score. Featured-first pinning is preserved above score order.
   let scored = null;
-  if (searchQuery.trim()) {
+  if (searchQuery.trim() && miniSearch) {
+    const hits = miniSearch.search(searchQuery.trim());
+    lastSearchTerms = extractTerms(hits);
+    // hit.id is the row's position in catalog.skills (built that way at
+    // build-time; see scripts/build-catalog.ts).
+    const scoreById = new Map();
+    for (const h of hits) {
+      const skill = catalog.skills[h.id];
+      if (skill) scoreById.set(skill.id, h.score);
+    }
     scored = results
-      .map(s => ({ skill: s, score: scoreSkill(searchQuery, s) }))
-      .filter(r => r.score > 0)
+      .filter(s => scoreById.has(s.id))
+      .map(s => ({ skill: s, score: scoreById.get(s.id) }))
       .sort((a, b) => {
         const f = featuredFirst(a.skill, b.skill);
         if (f !== 0) return f;
         return b.score - a.score;
       });
     results = scored.map(r => r.skill);
+  } else {
+    lastSearchTerms = null;
   }
 
   // Sort — apply AFTER filters. 'relevance' is a no-op when search is active
@@ -2227,8 +2256,14 @@ function evalScoreClass(score) {
 function renderCard(s) {
   const cmd = 'asm install ' + s.installUrl;
   const cats = s.categories.map(c => '<span class="badge badge-cat">' + esc(c) + '</span>').join('');
-  const warn = s.allowedTools && s.allowedTools.length > 0
-    ? '<span class="badge badge-warn" tabindex="0" title="Tool access: ' + esc(s.allowedTools.join(', ')) + '">&#x1F527; uses tools</span>'
+  // `s.hasTools` is the slim-file equivalent of `allowedTools.length > 0`.
+  // The full allowedTools array only ships with the lazy-loaded detail.
+  const usesTools = s.hasTools === true || (Array.isArray(s.allowedTools) && s.allowedTools.length > 0);
+  const toolsTitle = Array.isArray(s.allowedTools) && s.allowedTools.length > 0
+    ? 'Tool access: ' + s.allowedTools.join(', ')
+    : 'This skill uses tools';
+  const warn = usesTools
+    ? '<span class="badge badge-warn" tabindex="0" title="' + esc(toolsTitle) + '">&#x1F527; uses tools</span>'
     : '';
   const ver = s.version && s.version !== '0.0.0' ? '<span class="skill-version">v' + esc(s.version) + '</span>' : '';
   const isOfficial = s.owner === 'anthropics';
@@ -2255,10 +2290,10 @@ function renderCard(s) {
 
   return '<article class="' + cardClass + '" data-id="' + esc(s.id) + '" tabindex="0" role="button">'
     + '<div class="card-header">'
-    + '<span class="skill-name">' + highlightMatches(s.name, searchQuery) + '</span>'
+    + '<span class="skill-name">' + highlightMatches(s.name, searchQuery, lastSearchTerms) + '</span>'
     + '<span class="skill-repo">' + esc(s.owner) + '/' + esc(s.repo) + '</span>'
     + '</div>'
-    + '<p class="skill-desc">' + highlightMatches(s.description, searchQuery) + '</p>'
+    + '<p class="skill-desc">' + highlightMatches(s.description, searchQuery, lastSearchTerms) + '</p>'
     + '<div class="card-footer">'
     + '<div class="badge-row">' + featuredBadge + officialBadge + verifiedBadge + evalBadge + tokenBadge + cats + warn + '</div>'
     + ver
@@ -2342,9 +2377,66 @@ function getPaginationRange(current, total) {
 }
 
 // ─── Modal ─────────────────────────────────────────────────────────────────
-function openModal(skillId) {
-  const skill = catalog.skills.find(s => s.id === skillId);
-  if (!skill) return;
+// Per-skill detail fetch cache. Keyed by detailPath so two slim rows that
+// happen to share a path (shouldn't happen, but defensive) collapse cleanly.
+// Stores the in-flight promise so concurrent opens don't double-fetch.
+const detailCache = new Map();
+// Request token to guard against race conditions when the user clicks
+// card A then card B before A's detail resolves.
+let openModalToken = 0;
+
+function fetchSkillDetail(slimSkill) {
+  const key = slimSkill.detailPath || slimSkill.id;
+  if (detailCache.has(key)) return detailCache.get(key);
+  const p = (async () => {
+    const res = await fetch(slimSkill.detailPath);
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    return await res.json();
+  })();
+  // Don't cache failures — clear the entry on rejection so a retry can
+  // re-fetch (network blip shouldn't permanently poison the modal).
+  p.catch(() => detailCache.delete(key));
+  detailCache.set(key, p);
+  return p;
+}
+
+async function openModal(skillId) {
+  const slim = catalog.skills.find(s => s.id === skillId);
+  if (!slim) return;
+
+  const token = ++openModalToken;
+  const overlay = document.getElementById('modal-overlay');
+  const wasOpen = overlay.classList.contains('open');
+
+  // Show the overlay + loading state immediately so clicks feel responsive.
+  // The loading header uses the slim row (name/repo are always available).
+  document.getElementById('modal-content').innerHTML =
+    '<div class="modal-name" id="modal-title">' + esc(slim.name) + '</div>'
+    + '<div class="modal-repo">' + esc(slim.owner) + '/' + esc(slim.repo) + '</div>'
+    + '<div class="modal-desc">' + esc(slim.description) + '</div>'
+    + '<div class="modal-loading">Loading details&hellip;</div>';
+  if (!wasOpen) {
+    overlay.classList.add('open');
+    document.body.style.overflow = 'hidden';
+    document.getElementById('modal-close').focus();
+    trapFocus(document.getElementById('modal'));
+  }
+
+  let skill;
+  try {
+    skill = await fetchSkillDetail(slim);
+  } catch (err) {
+    // If another modal was opened in the meantime, don't clobber it.
+    if (token !== openModalToken) return;
+    document.getElementById('modal-content').innerHTML =
+      '<div class="modal-name" id="modal-title">' + esc(slim.name) + '</div>'
+      + '<div class="modal-repo">' + esc(slim.owner) + '/' + esc(slim.repo) + '</div>'
+      + '<div class="modal-error">&#x26a0; Could not load details: ' + esc(err.message) + '</div>';
+    return;
+  }
+
+  // Stale fetch — the user clicked a different card before this resolved.
+  if (token !== openModalToken) return;
 
   const cmd = 'asm install ' + skill.installUrl;
   const cats = skill.categories.map(c => '<span class="badge badge-cat">' + esc(c) + '</span>').join(' ');
@@ -2402,17 +2494,21 @@ function openModal(skillId) {
     + '<button class="copy-btn" data-cmd="' + esc(cmd) + '" onclick="copyCmd(this)">copy</button>'
     + '</div>'
     + (skill.skillUrl ? '<div class="modal-skill-link"><a href="' + esc(skill.skillUrl) + '" target="_blank" rel="noopener">View SKILL.md on GitHub &rarr;</a></div>' : '');
-
-  document.getElementById('modal-overlay').classList.add('open');
-  document.body.style.overflow = 'hidden';
-  document.getElementById('modal-close').focus();
-  trapFocus(document.getElementById('modal'));
+  // Overlay is already open + focus trapped from the synchronous pre-fetch
+  // block above — don't re-open here (would replace the focus trap handler).
 }
 
 let lastFocusedCard = null;
 let _focusTrapHandler = null;
 
 function trapFocus(el) {
+  // Defensively remove any previous handler so rapid close→reopen cycles
+  // (or an aborted open that never made it to closeModal) don't stack
+  // listeners on document.
+  if (_focusTrapHandler) {
+    document.removeEventListener('keydown', _focusTrapHandler);
+    _focusTrapHandler = null;
+  }
   _focusTrapHandler = function(e) {
     if (e.key !== 'Tab') return;
     const focusable = el.querySelectorAll('button, a[href], input, [tabindex]:not([tabindex="-1"])');
@@ -2556,7 +2652,7 @@ function computeFacetCounts() {
     }
     const src = skillSource(s);
     out.source[src] = (out.source[src] || 0) + 1;
-    const yes = !!(s.allowedTools && s.allowedTools.length > 0);
+    const yes = s.hasTools === true || !!(s.allowedTools && s.allowedTools.length > 0);
     out.usesTools[yes ? 'yes' : 'no']++;
   }
   return out;
@@ -4295,11 +4391,25 @@ function copyBundleCmd(btn, cmd) {
 }
 
 // ─── Boot ──────────────────────────────────────────────────────────────────
+// Fetch the slim catalog + search index in parallel, hydrate MiniSearch,
+// then render. Per-skill detail files are fetched lazily on modal open.
+// (issue #214 — splits catalog.json into list + search-index + per-skill
+//  detail artifacts so the browser only downloads what it needs for the grid.)
 async function boot() {
   try {
-    const res = await fetch('catalog.json');
-    if (!res.ok) throw new Error('HTTP ' + res.status);
-    catalog = await res.json();
+    const [skillsRes, idxRes] = await Promise.all([
+      fetch('skills.min.json'),
+      fetch('search.idx.json')
+    ]);
+    if (!skillsRes.ok) throw new Error('skills.min.json HTTP ' + skillsRes.status);
+    if (!idxRes.ok) throw new Error('search.idx.json HTTP ' + idxRes.status);
+    const [skillsData, idxText] = await Promise.all([
+      skillsRes.json(),
+      idxRes.text()
+    ]);
+    catalog = skillsData;
+    // loadJSON takes a string; pass the same options that were used at build.
+    miniSearch = MiniSearch.loadJSON(idxText, MINISEARCH_OPTIONS);
     readState();
     initControls();
     attachEvents();

--- a/website/index.html
+++ b/website/index.html
@@ -2387,7 +2387,10 @@ const detailCache = new Map();
 let openModalToken = 0;
 
 function fetchSkillDetail(slimSkill) {
-  const key = slimSkill.detailPath || slimSkill.id;
+  if (!slimSkill.detailPath) {
+    return Promise.reject(new Error('slim row missing detailPath: ' + slimSkill.id));
+  }
+  const key = slimSkill.detailPath;
   if (detailCache.has(key)) return detailCache.get(key);
   const p = (async () => {
     const res = await fetch(slimSkill.detailPath);
@@ -4415,6 +4418,14 @@ async function boot() {
       idxRes.text()
     ]);
     catalog = skillsData;
+    // Guard against CDN/cache skew where skills.min.json and search.idx.json
+    // come from different builds. Since hit.id is an array index into
+    // catalog.skills, a stale pairing would silently map every result to
+    // the wrong skill. build-catalog.ts embeds generatedAt on the index.
+    const idxMeta = JSON.parse(idxText);
+    if (catalog.generatedAt && idxMeta.generatedAt && catalog.generatedAt !== idxMeta.generatedAt) {
+      throw new Error('catalog build mismatch — reload the page');
+    }
     // loadJSON takes a string; pass the same options that were used at build.
     miniSearch = MiniSearch.loadJSON(idxText, MINISEARCH_OPTIONS);
     readState();


### PR DESCRIPTION
## Summary

Implements [#214](https://github.com/luongnv89/asm/issues/214) — splits the monolithic `catalog.json` (9.0 MB) into three purpose-built artifacts so the browser only downloads what it needs for grid + search, and fetches full per-skill detail on demand when the user opens a card.

## Approach

At build time, `scripts/build-catalog.ts` now emits three artifacts derived deterministically from `catalog.json`:

| Artifact | Raw | Gzipped | Purpose |
|---|---|---|---|
| `skills.min.json` | 4.61 MB | **602 KB** | Compact list — only fields cards + filters + sorts need |
| `search.idx.json` | 2.02 MB | **524 KB** | Prebuilt MiniSearch index |
| `skills/<slug>.json` | ~1.4 KB each × 6,783 | n/a | Full detail, fetched on modal open |

`catalog.json` stays the authoritative internal source (tests, upstream tooling, and CI still consume it unchanged). The split artifacts are derived outputs.

**Search library:** MiniSearch 7.2.0, vendored at `website/assets/minisearch.min.js` (86 KB raw / 19 KB gzipped). Chose it over FlexSearch for simpler API and the issue's own recommendation. Vendored rather than loaded via CDN for reliability on GitHub Pages.

**Index shrinking trick:** MiniSearch uses the skill's *array index* in `catalog.skills` as the document ID instead of the full string ID. That alone saves ~1.5 MB on the serialized index (the string IDs are long: `owner/repo::path::name`). The frontend maps hits back via `catalog.skills[hit.id]`. A test asserts this invariant.

**Filesystem-safe slug for detail files:** SHA1(id).slice(0, 16) — the full string ID contains `/` and `::` which aren't valid filenames. The slug is stored on each slim row as `detailPath` so the frontend never reconstructs it.

**Modal race protection:** `openModal` now fetches the detail on demand with a token guard (so click A → click B doesn't flicker A's data into B's modal), a promise-based cache (concurrent opens share one fetch), and negative-path eviction (failed fetches don't poison the cache).

## Benchmarks (6,783 skills, before → after)

### Transfer

| Metric | Before (catalog.json) | After (skills.min + search.idx) | Δ |
|---|---|---|---|
| Raw initial fetch | 9.04 MB | **6.63 MB** | −27% |
| Gzipped initial fetch | 642 KB | **1.13 MB** | +77% |

Note: gzipped total is higher because the search index ships as a parallel file. That's the real tradeoff this design makes — we pay some gzipped bytes up front to buy **35× faster search** and incremental per-skill fetches. The `skills.min.json` alone fits well under the issue's \"≤ 2 MB gzipped\" bound at 602 KB (just over the soft 500 KB target).

### Search latency (per keystroke)

| Engine | p50 latency (6,783 skills) |
|---|---|
| Old linear `Array.filter` + scoring | 29.7 ms |
| **New MiniSearch** | **0.85 ms** |
| **Speedup** | **~35×** |

### Per-skill payload

- Typical detail file: ~1.4 KB — served with browser cache headers by GitHub Pages, so repeat opens are instant.

## Changes

| File | What |
|---|---|
| `scripts/build-catalog.ts` | Emit `skills.min.json`, `search.idx.json`, per-skill detail files after `catalog.json` |
| `website/index.html` | Swap `fetch('catalog.json')` for parallel fetch of slim + index; MiniSearch-backed search with prefix + fuzzy; lazy modal detail fetch with race protection, cache, error states; `hasTools` boolean replaces `allowedTools.length` for slim rows |
| `website/assets/minisearch.min.js` | Vendored MiniSearch 7.2.0 UMD bundle (new file, 86 KB) |
| `tests/e2e/build-verification.test.ts` | 13 new tests: artifact shapes, slim/catalog parity, index deserialization smoke, option-drift guard, loader asserts |
| `.gitignore` | Ignore `website/skills.min.json`, `website/search.idx.json`, `website/skills/` (matches existing `catalog.json` pattern — all three are CI-built, not committed; this deviates from the issue's \"commit per-skill files\" wording but matches the project's existing convention for generated artifacts) |
| `.prettierignore` | New — exclude vendored minified JS and generated artifacts from prettier |
| `package.json` | Added `minisearch@7.2.0` as devDependency (used by build script only; frontend reads the vendored UMD) |

## Migration notes

- Feature flag intentionally omitted. The issue mentioned `?v2=1` as a rollback option, but the acceptance criteria explicitly required \"the old linear Array.filter code path is removed\". Shipping unflagged per the AC; rollback is a revert.
- Deep-linking to a specific skill modal was not added. `handleHashChange` currently only navigates between top-level pages; direct skill deep-links are out of scope for this PR.
- Category sharding (#214 Solution 1) and Web Worker offloading (Solution 3) remain tracked separately and compose cleanly on top of this change.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/` — 1,565 unit tests pass
- [x] `bun test tests/e2e/` — 225 e2e tests pass (13 new for this PR)
- [x] `bun run test:all` — full suite passes
- [x] `bun scripts/build-catalog.ts` — emits all 3 artifacts + 6,783 detail files
- [x] Local smoke test (Chromium via gstack browse):
  - [x] Grid renders 48 cards on initial load
  - [x] `?v=2.3.0` version badge populates from `skills.min.json`
  - [x] Search `\"clau\"` (prefix match) returns 223 hits, 94 highlighted `<mark>` elements
  - [x] Fuzzy search expansion works (MiniSearch terms feed `highlightMatches`)
  - [x] Card click → modal opens with loading state → detail fetched → meta + eval + install bar render
  - [x] No console errors

Closes #214