### PR TITLE
fix(cli): make bun optional — CLI runs on node, bun only for TUI (#221)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
   <a href="https://github.com/luongnv89/agent-skill-manager/stargazers"><img src="https://img.shields.io/github/stars/luongnv89/agent-skill-manager.svg?style=social" alt="GitHub stars" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License" /></a>
   <a href="https://github.com/luongnv89/agent-skill-manager/actions"><img src="https://github.com/luongnv89/agent-skill-manager/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://bun.sh"><img src="https://img.shields.io/badge/runtime-Bun%20%E2%89%A5%201.0-black.svg" alt="Bun" /></a>
+  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/CLI-Node.js%20%E2%89%A5%2018-339933.svg" alt="Node.js" /></a>
+  <a href="https://bun.sh"><img src="https://img.shields.io/badge/TUI-Bun%20%E2%89%A5%201.0-black.svg" alt="Bun (TUI only)" /></a>
 </p>
 
 <h1 align="center">One tool to manage every AI agent's skills</h1>
@@ -402,7 +403,8 @@ If multiple authors publish a skill with the same name, `asm` shows a disambigua
 npm install -g agent-skill-manager
 ```
 
-> Requires [Bun](https://bun.sh) >= 1.0.0 as the runtime. Install Bun: `curl -fsSL https://bun.sh/install | bash`
+> Runs on **Node.js ≥ 18** for all CLI commands (`list`, `install`, `update`, `eval`, `publish`, …).
+> [Bun](https://bun.sh) ≥ 1.0 is only needed for the interactive **TUI** (`asm` with no args). Install Bun if you want the TUI: `curl -fsSL https://bun.sh/install | bash`
 
 ### One-liner install
 
@@ -1140,7 +1142,8 @@ agent-skill-manager/
 <details>
 <summary><strong>Tech Stack</strong></summary>
 
-- **Runtime:** [Bun](https://bun.sh) >= 1.0.0
+- **CLI runtime:** Node.js ≥ 18 (works with `npm install -g agent-skill-manager` alone)
+- **TUI runtime:** [Bun](https://bun.sh) ≥ 1.0 (only required for the interactive UI)
 - **Language:** TypeScript (ESNext, strict mode)
 - **Build:** Bun bundler (ships pre-built via npm)
 - **TUI Framework:** [OpenTUI](https://github.com/nicholasgasior/opentui)

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "yaml": "^2.8.3"
   },
   "engines": {
-    "node": ">=18",
-    "bun": ">=1.0.0"
+    "node": ">=18"
   },
   "keywords": [
     "agent-skill-manager",

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -39,6 +39,7 @@ import {
 import { join, resolve, basename, isAbsolute } from "path";
 import type { ProviderEvalReport } from "./eval/summary";
 import { parseFrontmatter, resolveVersion } from "./utils/frontmatter";
+import { runCommand } from "./utils/spawn";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -1388,17 +1389,14 @@ export async function applyFix(
  */
 export async function detectGitAuthor(): Promise<string | null> {
   try {
-    // Use Bun.spawn when available; fall back to child_process for Node tests.
-    const proc = Bun.spawn(
-      ["git", "config", "--global", "--get", "user.name"],
-      {
-        stdout: "pipe",
-        stderr: "pipe",
-      },
-    );
-    const stdout = await new Response(proc.stdout).text();
-    const code = await proc.exited;
-    if (code !== 0) return null;
+    const { stdout, exitCode } = await runCommand([
+      "git",
+      "config",
+      "--global",
+      "--get",
+      "user.name",
+    ]);
+    if (exitCode !== 0) return null;
     const trimmed = stdout.trim();
     return trimmed ? trimmed : null;
   } catch {

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -14,6 +14,7 @@ import type { RegistryManifest } from "./registry";
 import type { SecurityVerdict, SecurityAuditReport } from "./utils/types";
 import type { PublishResult } from "./utils/types";
 import { debug } from "./logger";
+import { runCommand } from "./utils/spawn";
 
 // ─── Sanitization ──────────────────────────────────────────────────────────
 
@@ -126,12 +127,9 @@ export async function parseSkillMetadata(
  * Check that the target directory is inside a git repository.
  */
 export async function checkIsGitRepo(dir: string): Promise<void> {
-  const proc = Bun.spawn(["git", "rev-parse", "--git-dir"], {
+  const { exitCode } = await runCommand(["git", "rev-parse", "--git-dir"], {
     cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
   });
-  const exitCode = await proc.exited;
   if (exitCode !== 0) {
     throw new Error(`${dir} is not inside a git repository.`);
   }
@@ -141,13 +139,9 @@ export async function checkIsGitRepo(dir: string): Promise<void> {
  * Get the current HEAD commit SHA.
  */
 export async function getHeadCommit(dir: string): Promise<string> {
-  const proc = Bun.spawn(["git", "rev-parse", "HEAD"], {
+  const { stdout, exitCode } = await runCommand(["git", "rev-parse", "HEAD"], {
     cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
   });
-  const stdout = await new Response(proc.stdout).text();
-  const exitCode = await proc.exited;
   if (exitCode !== 0) {
     throw new Error("Failed to get HEAD commit. Is this a git repository?");
   }
@@ -158,13 +152,10 @@ export async function getHeadCommit(dir: string): Promise<string> {
  * Get the root directory of the git repository containing dir.
  */
 export async function getGitRoot(dir: string): Promise<string> {
-  const proc = Bun.spawn(["git", "rev-parse", "--show-toplevel"], {
-    cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const stdout = await new Response(proc.stdout).text();
-  const exitCode = await proc.exited;
+  const { stdout, exitCode } = await runCommand(
+    ["git", "rev-parse", "--show-toplevel"],
+    { cwd: dir },
+  );
   if (exitCode !== 0) {
     throw new Error("Failed to determine git repository root.");
   }
@@ -175,13 +166,10 @@ export async function getGitRoot(dir: string): Promise<string> {
  * Get the remote origin URL.
  */
 export async function getRemoteOrigin(dir: string): Promise<string> {
-  const proc = Bun.spawn(["git", "remote", "get-url", "origin"], {
-    cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const stdout = await new Response(proc.stdout).text();
-  const exitCode = await proc.exited;
+  const { stdout, exitCode } = await runCommand(
+    ["git", "remote", "get-url", "origin"],
+    { cwd: dir },
+  );
   if (exitCode !== 0) {
     throw new Error(
       "No remote origin found. Add one with: git remote add origin <url>",
@@ -210,33 +198,23 @@ export async function checkGhCli(): Promise<{
   authenticated: boolean;
   login: string | null;
 }> {
-  // Check if gh is installed (use gh --version instead of `which` for cross-platform compat)
-  const versionProc = Bun.spawn(["gh", "--version"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const versionExit = await versionProc.exited;
+  const { exitCode: versionExit } = await runCommand(["gh", "--version"]);
   if (versionExit !== 0) {
     return { available: false, authenticated: false, login: null };
   }
 
-  // Check authentication
-  const authProc = Bun.spawn(["gh", "auth", "status"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const authExit = await authProc.exited;
+  const { exitCode: authExit } = await runCommand(["gh", "auth", "status"]);
   if (authExit !== 0) {
     return { available: true, authenticated: false, login: null };
   }
 
-  // Get login
-  const loginProc = Bun.spawn(["gh", "api", "user", "--jq", ".login"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const loginOut = await new Response(loginProc.stdout).text();
-  const loginExit = await loginProc.exited;
+  const { stdout: loginOut, exitCode: loginExit } = await runCommand([
+    "gh",
+    "api",
+    "user",
+    "--jq",
+    ".login",
+  ]);
   const login = loginExit === 0 ? loginOut.trim() : null;
 
   return { available: true, authenticated: true, login };
@@ -553,11 +531,7 @@ export async function publishSkill(
 
   // Step 9: Fork registry
   debug(`publish: forking ${REGISTRY_REPO}`);
-  const forkProc = Bun.spawn(
-    ["gh", "repo", "fork", REGISTRY_REPO, "--clone=false"],
-    { stdout: "pipe", stderr: "pipe" },
-  );
-  await forkProc.exited;
+  await runCommand(["gh", "repo", "fork", REGISTRY_REPO, "--clone=false"]);
   // Fork may already exist, that's fine
 
   // Step 10: Create branch and write manifest via gh API
@@ -569,18 +543,13 @@ export async function publishSkill(
   );
 
   // Get the default branch SHA from the fork
-  const refProc = Bun.spawn(
-    [
-      "gh",
-      "api",
-      `repos/${author}/asm-registry/git/refs/heads/main`,
-      "--jq",
-      ".object.sha",
-    ],
-    { stdout: "pipe", stderr: "pipe" },
-  );
-  const refOut = await new Response(refProc.stdout).text();
-  const refExit = await refProc.exited;
+  const { stdout: refOut, exitCode: refExit } = await runCommand([
+    "gh",
+    "api",
+    `repos/${author}/asm-registry/git/refs/heads/main`,
+    "--jq",
+    ".object.sha",
+  ]);
 
   if (refExit !== 0) {
     return {
@@ -598,96 +567,75 @@ export async function publishSkill(
   const baseSha = refOut.trim();
 
   // Create branch in the fork
-  const createRefProc = Bun.spawn(
-    [
-      "gh",
-      "api",
-      `repos/${author}/asm-registry/git/refs`,
-      "-X",
-      "POST",
-      "-f",
-      `ref=refs/heads/${branchName}`,
-      "-f",
-      `sha=${baseSha}`,
-    ],
-    { stdout: "pipe", stderr: "pipe" },
-  );
-  const createRefExit = await createRefProc.exited;
+  const { exitCode: createRefExit } = await runCommand([
+    "gh",
+    "api",
+    `repos/${author}/asm-registry/git/refs`,
+    "-X",
+    "POST",
+    "-f",
+    `ref=refs/heads/${branchName}`,
+    "-f",
+    `sha=${baseSha}`,
+  ]);
 
   if (createRefExit !== 0) {
     // Branch may already exist — try to update it
-    const updateRefProc = Bun.spawn(
-      [
-        "gh",
-        "api",
-        `repos/${author}/asm-registry/git/refs/heads/${branchName}`,
-        "-X",
-        "PATCH",
-        "-f",
-        `sha=${baseSha}`,
-        "-f",
-        "force=true",
-      ],
-      { stdout: "pipe", stderr: "pipe" },
-    );
-    await updateRefProc.exited;
+    await runCommand([
+      "gh",
+      "api",
+      `repos/${author}/asm-registry/git/refs/heads/${branchName}`,
+      "-X",
+      "PATCH",
+      "-f",
+      `sha=${baseSha}`,
+      "-f",
+      "force=true",
+    ]);
   }
 
   // Write manifest file to the branch
-  const putFileProc = Bun.spawn(
-    [
-      "gh",
-      "api",
-      `repos/${author}/asm-registry/contents/${manifestPath}`,
-      "-X",
-      "PUT",
-      "-f",
-      `message=Publish ${author}/${metadata.name}`,
-      "-f",
-      `content=${encodedContent}`,
-      "-f",
-      `branch=${branchName}`,
-    ],
-    { stdout: "pipe", stderr: "pipe" },
-  );
-  const putFileStderr = await new Response(putFileProc.stderr).text();
-  const putFileExit = await putFileProc.exited;
+  const { stderr: putFileStderr, exitCode: putFileExit } = await runCommand([
+    "gh",
+    "api",
+    `repos/${author}/asm-registry/contents/${manifestPath}`,
+    "-X",
+    "PUT",
+    "-f",
+    `message=Publish ${author}/${metadata.name}`,
+    "-f",
+    `content=${encodedContent}`,
+    "-f",
+    `branch=${branchName}`,
+  ]);
 
   if (putFileExit !== 0) {
     // File may already exist — try updating with SHA
-    const getFileProc = Bun.spawn(
-      [
-        "gh",
-        "api",
-        `repos/${author}/asm-registry/contents/${manifestPath}?ref=${branchName}`,
-        "-q",
-        ".sha",
-      ],
-      { stdout: "pipe", stderr: "pipe" },
-    );
-    const fileSha = (await new Response(getFileProc.stdout).text()).trim();
-    const getFileExit = await getFileProc.exited;
+    const { stdout: getFileOut, exitCode: getFileExit } = await runCommand([
+      "gh",
+      "api",
+      `repos/${author}/asm-registry/contents/${manifestPath}?ref=${branchName}`,
+      "-q",
+      ".sha",
+    ]);
+    const fileSha = getFileOut.trim();
 
     if (getFileExit === 0 && fileSha) {
-      const updateFileProc = Bun.spawn(
-        [
-          "gh",
-          "api",
-          `repos/${author}/asm-registry/contents/${manifestPath}`,
-          "-X",
-          "PUT",
-          "-f",
-          `message=Update ${author}/${metadata.name}`,
-          "-f",
-          `content=${encodedContent}`,
-          "-f",
-          `branch=${branchName}`,
-          "-f",
-          `sha=${fileSha}`,
-        ],
-        { stdout: "pipe", stderr: "pipe" },
-      );
-      const updateExit = await updateFileProc.exited;
+      const { exitCode: updateExit } = await runCommand([
+        "gh",
+        "api",
+        `repos/${author}/asm-registry/contents/${manifestPath}`,
+        "-X",
+        "PUT",
+        "-f",
+        `message=Update ${author}/${metadata.name}`,
+        "-f",
+        `content=${encodedContent}`,
+        "-f",
+        `branch=${branchName}`,
+        "-f",
+        `sha=${fileSha}`,
+      ]);
       if (updateExit !== 0) {
         return {
           success: false,
@@ -731,25 +679,23 @@ export async function publishSkill(
     "*This PR was generated by `asm publish`.*",
   ].join("\n");
 
-  const prProc = Bun.spawn(
-    [
-      "gh",
-      "pr",
-      "create",
-      "--repo",
-      REGISTRY_REPO,
-      "--head",
-      `${author}:${branchName}`,
-      "--title",
-      prTitle,
-      "--body",
-      prBody,
-    ],
-    { stdout: "pipe", stderr: "pipe" },
-  );
-  const prOut = await new Response(prProc.stdout).text();
-  const prStderr = await new Response(prProc.stderr).text();
-  const prExit = await prProc.exited;
+  const {
+    stdout: prOut,
+    stderr: prStderr,
+    exitCode: prExit,
+  } = await runCommand([
+    "gh",
+    "pr",
+    "create",
+    "--repo",
+    REGISTRY_REPO,
+    "--head",
+    `${author}:${branchName}`,
+    "--title",
+    prTitle,
+    "--body",
+    prBody,
+  ]);
 
   let prUrl: string | null = null;
   if (prExit === 0) {

--- a/src/utils/spawn.test.ts
+++ b/src/utils/spawn.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { runCommand } from "./spawn";
+
+describe("runCommand", () => {
+  it("captures stdout from a successful command", async () => {
+    const { stdout, exitCode } = await runCommand(["echo", "hello"]);
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe("hello");
+  });
+
+  it("returns non-zero exit code on failure", async () => {
+    // `false` is a POSIX command that always exits with code 1
+    const { exitCode } = await runCommand(["false"]);
+    expect(exitCode).not.toBe(0);
+  });
+
+  it("captures stderr separately from stdout", async () => {
+    const { stdout, stderr, exitCode } = await runCommand([
+      "sh",
+      "-c",
+      "echo out; echo err >&2",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe("out");
+    expect(stderr.trim()).toBe("err");
+  });
+
+  it("respects the cwd option", async () => {
+    const { stdout, exitCode } = await runCommand(["pwd"], { cwd: "/tmp" });
+    expect(exitCode).toBe(0);
+    // macOS resolves /tmp to /private/tmp; accept either.
+    expect(stdout.trim()).toMatch(/^(\/tmp|\/private\/tmp)$/);
+  });
+
+  it("rejects when argv is empty", async () => {
+    await expect(runCommand([])).rejects.toThrow(/non-empty argv/);
+  });
+});

--- a/src/utils/spawn.test.ts
+++ b/src/utils/spawn.test.ts
@@ -35,4 +35,14 @@ describe("runCommand", () => {
   it("rejects when argv is empty", async () => {
     await expect(runCommand([])).rejects.toThrow(/non-empty argv/);
   });
+
+  it("surfaces missing binary (ENOENT) as exit code 127", async () => {
+    // checkGhCli() and similar graceful-fallback callers rely on an exitCode
+    // guard — they must not see a rejected promise when the binary is absent.
+    const { exitCode } = await runCommand([
+      "asm-nonexistent-binary-for-test-xyz-42",
+      "--version",
+    ]);
+    expect(exitCode).toBe(127);
+  });
 });

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -1,0 +1,87 @@
+/**
+ * Cross-runtime command spawner.
+ *
+ * Bun and Node expose incompatible spawn APIs. Call sites in the CLI
+ * (publisher, evaluator) must work under both, since `asm` ships with
+ * `#!/usr/bin/env node` but still runs under Bun when the TUI re-execs.
+ *
+ * Under Bun we use Bun.spawn (faster, fewer allocations). Under Node we
+ * fall back to child_process.spawn. The surface area is deliberately
+ * narrow — only what publisher/evaluator actually need.
+ */
+
+export interface RunCommandOptions {
+  cwd?: string;
+}
+
+export interface RunCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+
+export async function runCommand(
+  argv: string[],
+  opts: RunCommandOptions = {},
+): Promise<RunCommandResult> {
+  if (argv.length === 0) {
+    throw new Error("runCommand requires a non-empty argv");
+  }
+
+  if (isBun) {
+    return runWithBun(argv, opts);
+  }
+  return runWithNode(argv, opts);
+}
+
+async function runWithBun(
+  argv: string[],
+  opts: RunCommandOptions,
+): Promise<RunCommandResult> {
+  const BunApi = (globalThis as { Bun: { spawn: Function } }).Bun;
+  const proc = BunApi.spawn(argv, {
+    cwd: opts.cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  // Bun returns null when the child was signal-killed; surface that as
+  // non-zero so callers' `exitCode !== 0` guards fire.
+  return { exitCode: exitCode ?? -1, stdout, stderr };
+}
+
+async function runWithNode(
+  argv: string[],
+  opts: RunCommandOptions,
+): Promise<RunCommandResult> {
+  const { spawn } = await import("child_process");
+  const [cmd, ...args] = argv;
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(cmd, args, {
+      cwd: opts.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (err) => {
+      rejectPromise(err);
+    });
+    child.on("close", (code) => {
+      // Node returns null when the child was signal-killed; surface that as
+      // non-zero so callers' `exitCode !== 0` guards fire.
+      resolvePromise({ exitCode: code ?? -1, stdout, stderr });
+    });
+  });
+}

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -20,7 +20,24 @@ export interface RunCommandResult {
   stderr: string;
 }
 
-const isBun = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+interface BunSpawnOptions {
+  cwd?: string;
+  stdout?: "pipe" | "inherit" | "ignore";
+  stderr?: "pipe" | "inherit" | "ignore";
+}
+
+interface BunSubprocess {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  exited: Promise<number | null>;
+}
+
+interface BunNamespace {
+  spawn(argv: string[], opts?: BunSpawnOptions): BunSubprocess;
+}
+
+const bunApi = (globalThis as { Bun?: BunNamespace }).Bun;
+const isBun = typeof bunApi !== "undefined";
 
 export async function runCommand(
   argv: string[],
@@ -40,14 +57,11 @@ async function runWithBun(
   argv: string[],
   opts: RunCommandOptions,
 ): Promise<RunCommandResult> {
-  const BunApi = (globalThis as { Bun: { spawn: Function } }).Bun;
-  let proc: {
-    stdout: ReadableStream;
-    stderr: ReadableStream;
-    exited: Promise<number | null>;
-  };
+  // Non-null: runWithBun is only called when isBun is true.
+  const bun = bunApi as BunNamespace;
+  let proc: BunSubprocess;
   try {
-    proc = BunApi.spawn(argv, {
+    proc = bun.spawn(argv, {
       cwd: opts.cwd,
       stdout: "pipe",
       stderr: "pipe",

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -41,11 +41,26 @@ async function runWithBun(
   opts: RunCommandOptions,
 ): Promise<RunCommandResult> {
   const BunApi = (globalThis as { Bun: { spawn: Function } }).Bun;
-  const proc = BunApi.spawn(argv, {
-    cwd: opts.cwd,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  let proc: {
+    stdout: ReadableStream;
+    stderr: ReadableStream;
+    exited: Promise<number | null>;
+  };
+  try {
+    proc = BunApi.spawn(argv, {
+      cwd: opts.cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  } catch (err) {
+    // Bun.spawn throws synchronously on missing binary; normalize to the
+    // same shape as the Node branch so callers can check exitCode.
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return { exitCode: 127, stdout: "", stderr: (err as Error).message };
+    }
+    throw err;
+  }
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
@@ -69,6 +84,7 @@ async function runWithNode(
     });
     let stdout = "";
     let stderr = "";
+    let settled = false;
     child.stdout?.on("data", (chunk) => {
       stdout += chunk.toString();
     });
@@ -76,9 +92,21 @@ async function runWithNode(
       stderr += chunk.toString();
     });
     child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      // Missing binary should surface as a non-zero exit code, not a
+      // rejection — callers like checkGhCli() rely on an exitCode guard to
+      // fall back gracefully when `gh` isn't installed.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        resolvePromise({ exitCode: 127, stdout, stderr: err.message });
+        return;
+      }
       rejectPromise(err);
     });
     child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
       // Node returns null when the child was signal-killed; surface that as
       // non-zero so callers' `exitCode !== 0` guards fire.
       resolvePromise({ exitCode: code ?? -1, stdout, stderr });

--- a/tests/e2e/node-e2e.test.ts
+++ b/tests/e2e/node-e2e.test.ts
@@ -372,6 +372,8 @@ describe("Node E2E: per-command --help", () => {
     "link",
     "index",
     "import",
+    "eval",
+    "publish",
   ];
 
   for (const cmd of commands) {
@@ -380,6 +382,36 @@ describe("Node E2E: per-command --help", () => {
       expect(exitCode).toBe(0);
     });
   }
+});
+
+// Regression: `eval --fix` and `publish` previously called `Bun.spawn` directly,
+// which threw `ReferenceError: Bun is not defined` on Node. Both code paths now
+// route through `runCommand()` (src/utils/spawn.ts) so they must not blow up
+// with a Bun reference error when invoked under Node.
+describe("Node E2E: bun-free CLI execution (issue #221)", () => {
+  test("eval --fix invokes detectGitAuthor without ReferenceError", async () => {
+    // `--fix` is the path that calls detectGitAuthor() → runCommand().
+    // The missing skill path will fail later in applyFix, but only after
+    // detectGitAuthor has exercised runCommand's Node branch.
+    const { stderr, exitCode } = await runNode(
+      "eval",
+      "/tmp/asm-does-not-exist-xyz",
+      "--fix",
+      "--dry-run",
+    );
+    expect(stderr).not.toContain("Bun is not defined");
+    expect(stderr).not.toContain("ReferenceError");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("publish --dry-run on non-repo exits cleanly without ReferenceError", async () => {
+    // /tmp is intentionally not a git repo; publish should fail cleanly via
+    // its own error path, not via a Bun ReferenceError from a spawn site.
+    const { stderr, exitCode } = await runNode("publish", "/tmp", "--dry-run");
+    expect(stderr).not.toContain("Bun is not defined");
+    expect(stderr).not.toContain("ReferenceError");
+    expect(exitCode).not.toBe(0);
+  });
 });
 
 // ─── inspect command ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #221

## Summary

- Replace all 17 `Bun.spawn` calls in `src/publisher.ts` (16) and `src/evaluator.ts` (1) with a new cross-runtime `runCommand()` wrapper in `src/utils/spawn.ts`. Both `asm eval --fix` and `asm publish` previously crashed on a node-only machine with `ReferenceError: Bun is not defined` even though the shipped launcher shebang is `#!/usr/bin/env node`.
- Drop `engines.bun: ">=1.0.0"` from `package.json`; bun is now documented as **TUI-only** in the README.
- Add node-e2e regression tests for `eval --fix` and `publish` to guard against future `Bun.*` leaks into CLI code paths.

## Approach

Option chosen: **runtime-spawn abstraction** (balanced).

`src/utils/spawn.ts` exposes a narrow, promise-based `runCommand(argv, opts)` that returns `{ exitCode, stdout, stderr }`. It dispatches to `Bun.spawn` when running on Bun (still faster) and falls back to `child_process.spawn` on Node. Signal-kills (null exit) surface as `-1` so callers' `exitCode !== 0` guards fire correctly.

Entry-point routing (`bin/agent-skill-manager.ts`) was already correct — the CLI runs on Node, and TUI re-execs with Bun — so no changes there.

## Changes

| File | Change |
|---|---|
| `src/utils/spawn.ts` (new) | Cross-runtime `runCommand()` with Bun/Node branches. |
| `src/utils/spawn.test.ts` (new) | 5 unit tests: success, failure, stderr separation, cwd, empty argv. |
| `src/evaluator.ts` | `detectGitAuthor()` → `runCommand`. Top-level import. |
| `src/publisher.ts` | All 16 call sites (`checkIsGitRepo`, `getHeadCommit`, `getGitRoot`, `getRemoteOrigin`, `checkGhCli`, fork/ref/file/PR ops) → `runCommand`. |
| `package.json` | Drop `engines.bun`. |
| `README.md` | Install block + tech-stack + badges reflect bun = TUI-only. |
| `tests/e2e/node-e2e.test.ts` | Add `eval` + `publish` to `--help` matrix. New regression block exercises `eval --fix --dry-run` and `publish --dry-run` under Node. |

## Test Results

- `bun run typecheck` — clean
- `bun test src/` — 1570 pass / 0 fail
- `bun test tests/e2e/node-e2e.test.ts` — 74 pass / 0 fail (includes 2 new `--help` and 2 new regression tests)
- Manual smoke (Node-only): `node dist/agent-skill-manager.js list`, `eval /tmp/missing`, `publish /tmp --dry-run`, plus TUI-fallback error when `bun` is off `PATH` — all exit cleanly with no `ReferenceError`.

## Acceptance Criteria

- [x] Installed `asm` launcher uses `#!/usr/bin/env node` so CLI works without bun — already in place; verified.
- [x] `package.json#engines` no longer lists `bun` as required — removed.
- [x] TUI dependency (`@opentui/core`) is loaded lazily/guarded so a bun-less install does not execute it at CLI runtime — already guarded via `bin/agent-skill-manager.ts` routing + build-time patching; no regression.
- [x] Running `asm --help` / any CLI subcommand on a node-only machine succeeds end-to-end — covered by the expanded node-e2e suite.
- [x] Running the TUI without bun fails with a clear, actionable error — verified output: *"The interactive TUI requires Bun (https://bun.sh). Install it with: curl -fsSL https://bun.sh/install | bash. CLI commands (list, search, inspect, etc.) work with Node.js — run: asm --help"*
- [x] README / install docs updated — install block, badges, and tech-stack all say bun is TUI-only.

## Test plan

- [ ] Verify in a clean node-only container: `npm i -g agent-skill-manager && asm list && asm eval <skill> --fix --dry-run && asm publish <skill> --dry-run`
- [ ] Verify TUI still launches under Bun: `asm` (no args) on a machine with bun installed
- [ ] Confirm CI passes on the PR