### PR TITLE
feat(website): restore full nav, virtualize skill list, fix repo URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ website/skills.min.json
 website/search.idx.json
 website/skills/
 website/assets/favicon.svg
+website/assets/logo-mark.svg
 # Vite build output (React app bundle)
 website/index.html
 website/assets/index-*.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "ink": "^5",
         "react": "^18",
         "react-dom": "^18",
+        "react-window": "^2.2.7",
         "yaml": "^2.8.3"
       },
       "bin": {
@@ -5895,6 +5896,16 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.2.7.tgz",
+      "integrity": "sha512-SH5nvfUQwGHYyriDUAOt7wfPsfG9Qxd6OdzQxl5oQ4dsSsUicqQvjV7dR+NqZ4coY0fUn3w1jnC5PwzIUWEg5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ink": "^5",
     "react": "^18",
     "react-dom": "^18",
+    "react-window": "^2.2.7",
     "yaml": "^2.8.3"
   },
   "engines": {
@@ -56,13 +57,13 @@
   ],
   "author": "luongnv89",
   "license": "MIT",
-  "homepage": "https://github.com/luongnv89/agent-skill-manager#readme",
+  "homepage": "https://github.com/luongnv89/asm#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/luongnv89/agent-skill-manager.git"
+    "url": "git+https://github.com/luongnv89/asm.git"
   },
   "bugs": {
-    "url": "https://github.com/luongnv89/agent-skill-manager/issues"
+    "url": "https://github.com/luongnv89/asm/issues"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/scripts/build-catalog.ts
+++ b/scripts/build-catalog.ts
@@ -725,6 +725,10 @@ const faviconSrc = join(root, "assets", "logo", "favicon.svg");
 if (existsSync(faviconSrc)) {
   copyFileSync(faviconSrc, join(assetsOutDir, "favicon.svg"));
 }
+const logoMarkSrc = join(root, "assets", "logo", "logo-mark.svg");
+if (existsSync(logoMarkSrc)) {
+  copyFileSync(logoMarkSrc, join(assetsOutDir, "logo-mark.svg"));
+}
 
 // ─── Stats ───────────────────────────────────────────────────────────────────
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5165,9 +5165,7 @@ export async function runCLI(argv: string[]): Promise<void> {
         ),
       );
       console.error(
-        ansi.dim(
-          "  See: https://github.com/luongnv89/agent-skill-manager#troubleshooting",
-        ),
+        ansi.dim("  See: https://github.com/luongnv89/asm#troubleshooting"),
       );
     }
     return;

--- a/src/utils/machine.ts
+++ b/src/utils/machine.ts
@@ -1,7 +1,7 @@
 // ─── Machine Output (v1 envelope) ──────────────────────────────────────────
 //
 // Stable, versioned JSON envelope for programmatic consumption by AI agents.
-// See: https://github.com/luongnv89/agent-skill-manager/issues/109
+// See: https://github.com/luongnv89/asm/issues/109
 
 import { VERSION } from "./version";
 

--- a/website-src/src/App.jsx
+++ b/website-src/src/App.jsx
@@ -3,6 +3,8 @@ import Header from "./components/Header.jsx";
 import Footer from "./components/Footer.jsx";
 import CatalogPage from "./pages/CatalogPage.jsx";
 import BundlesPage from "./pages/BundlesPage.jsx";
+import DocsPage from "./pages/DocsPage.jsx";
+import ChangelogPage from "./pages/ChangelogPage.jsx";
 import { CatalogProvider } from "./hooks/useCatalog.jsx";
 
 /**
@@ -29,6 +31,8 @@ export default function App() {
             <Route path="/skills/:id" element={<CatalogPage />} />
             <Route path="/bundles" element={<BundlesPage />} />
             <Route path="/bundles/:name" element={<BundlesPage />} />
+            <Route path="/docs" element={<DocsPage />} />
+            <Route path="/changelog" element={<ChangelogPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </main>

--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -164,7 +164,9 @@ describe("App smoke", () => {
 
   it("loads the catalog and renders skills in the sidebar list", async () => {
     render(
-      <HashRouter>
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
         <App />
       </HashRouter>,
     );
@@ -179,7 +181,9 @@ describe("App smoke", () => {
 
   it("selecting a sidebar row updates the URL and renders detail", async () => {
     const { container } = render(
-      <HashRouter>
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
         <App />
       </HashRouter>,
     );
@@ -215,7 +219,9 @@ describe("App smoke", () => {
     // Start with a category filter already active in the URL.
     window.history.replaceState(null, "", "/#/?cat=demo");
     const { container } = render(
-      <HashRouter>
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
         <App />
       </HashRouter>,
     );
@@ -241,7 +247,9 @@ describe("App smoke", () => {
   it("bundles page renders a sidebar list and detail empty state", async () => {
     window.history.replaceState(null, "", "/#/bundles");
     const { container } = render(
-      <HashRouter>
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
         <App />
       </HashRouter>,
     );

--- a/website-src/src/__tests__/app-smoke.test.jsx
+++ b/website-src/src/__tests__/app-smoke.test.jsx
@@ -1,5 +1,16 @@
 /** @vitest-environment jsdom */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// jsdom doesn't ship ResizeObserver; react-window (used by the virtualized
+// sidebar) subscribes to one on mount. A no-op stub is sufficient — the
+// tests don't measure actual row heights.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
 import {
   act,
   cleanup,

--- a/website-src/src/components/BundleListItem.jsx
+++ b/website-src/src/components/BundleListItem.jsx
@@ -1,4 +1,5 @@
-import { Link, useLocation } from "react-router-dom";
+import { memo } from "react";
+import { Link } from "react-router-dom";
 import { Badge } from "./ui/badge.jsx";
 import { cn } from "../lib/cn.js";
 
@@ -8,15 +9,14 @@ import { cn } from "../lib/cn.js";
  * query (reserved for future filters) survives. `active` flips the
  * selected visual.
  */
-export default function BundleListItem({ bundle, active }) {
-  const location = useLocation();
+function BundleListItem({ bundle, active, locationSearch }) {
   const skillCount = (bundle.skills || []).length;
   const tags = bundle.tags || [];
   return (
     <Link
       to={{
         pathname: `/bundles/${encodeURIComponent(bundle.name)}`,
-        search: location.search,
+        search: locationSearch,
       }}
       aria-current={active ? "true" : undefined}
       className={cn(
@@ -63,3 +63,5 @@ export default function BundleListItem({ bundle, active }) {
     </Link>
   );
 }
+
+export default memo(BundleListItem);

--- a/website-src/src/components/Footer.jsx
+++ b/website-src/src/components/Footer.jsx
@@ -12,7 +12,7 @@ export default function Footer() {
       <div className="w-full max-w-[1280px] mx-auto px-4 sm:px-6 py-4 flex flex-wrap items-center gap-2">
         <a
           className="text-[var(--fg)] hover:text-[var(--brand)]"
-          href="https://github.com/luongnv89/agent-skill-manager"
+          href="https://github.com/luongnv89/asm"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/website-src/src/components/Header.jsx
+++ b/website-src/src/components/Header.jsx
@@ -70,7 +70,7 @@ export default function Header() {
           className="flex items-center gap-2 font-semibold text-[var(--fg)] text-lg"
         >
           <img
-            src="assets/logo-mark.svg"
+            src="./assets/logo-mark.svg"
             alt=""
             aria-hidden="true"
             className="w-7 h-7"
@@ -85,22 +85,12 @@ export default function Header() {
           <NavLink to="/bundles" className={linkClass}>
             Bundles
           </NavLink>
-          <a
-            className={linkClass({ isActive: false })}
-            href={`${REPO_URL}#readme`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <NavLink to="/docs" className={linkClass}>
             Docs
-          </a>
-          <a
-            className={linkClass({ isActive: false })}
-            href={`${REPO_URL}/blob/main/CHANGELOG.md`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          </NavLink>
+          <NavLink to="/changelog" className={linkClass}>
             Changelog
-          </a>
+          </NavLink>
         </nav>
         <div className="ml-auto flex items-center gap-2">
           {version && (

--- a/website-src/src/components/Header.jsx
+++ b/website-src/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, NavLink } from "react-router-dom";
+import { useCatalog } from "../hooks/useCatalog.jsx";
 
 function applyTheme(next) {
   document.documentElement.setAttribute("data-theme", next);
@@ -7,13 +8,23 @@ function applyTheme(next) {
 }
 
 /**
- * Top navigation bar. Port of the legacy `<header class="site-header">`
- * limited to the surfaces in scope for #229 (Skills + Bundles). Docs,
- * Registry, Best Practices, Changelog, and Thanks pages are out of
- * scope for this refactor (tracked separately) and intentionally
- * omitted from the React shell.
+ * Top navigation bar. Skills + Bundles route internally; Docs and
+ * Changelog link out to the repo README and CHANGELOG since those
+ * pages don't have React equivalents yet. Version + star count come
+ * from the loaded catalog.
  */
+const REPO_URL = "https://github.com/luongnv89/asm";
+
+function formatStars(n) {
+  if (typeof n !== "number" || n <= 0) return null;
+  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+  return String(n);
+}
+
 export default function Header() {
+  const { catalog } = useCatalog();
+  const version = catalog?.version;
+  const stars = formatStars(catalog?.stars);
   const [theme, setTheme] = useState(() =>
     typeof document === "undefined"
       ? "dark"
@@ -93,8 +104,32 @@ export default function Header() {
           <NavLink to="/bundles" className={linkClass}>
             Bundles
           </NavLink>
+          <a
+            className={linkClass({ isActive: false })}
+            href={`${REPO_URL}#readme`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Docs
+          </a>
+          <a
+            className={linkClass({ isActive: false })}
+            href={`${REPO_URL}/blob/main/CHANGELOG.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Changelog
+          </a>
         </nav>
         <div className="ml-auto flex items-center gap-2">
+          {version && (
+            <span
+              className="hidden sm:inline-block font-mono text-[11px] text-[var(--fg-muted)] px-2 py-0.5 border border-[var(--border)] rounded-md"
+              title="asm version"
+            >
+              v{version}
+            </span>
+          )}
           <button
             type="button"
             onClick={toggleTheme}
@@ -124,12 +159,25 @@ export default function Header() {
             )}
           </button>
           <a
-            className="text-[var(--fg-dim)] hover:text-[var(--fg)] text-sm px-2 py-1.5"
-            href="https://github.com/luongnv89/agent-skill-manager"
+            className="flex items-center gap-1.5 text-[var(--fg-dim)] hover:text-[var(--brand)] hover:border-[var(--brand)] text-sm px-2.5 py-1 border border-[var(--border)] rounded-md transition-colors"
+            href={REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
           >
-            GitHub
+            <svg
+              viewBox="0 0 16 16"
+              fill="currentColor"
+              className="w-4 h-4"
+              aria-hidden="true"
+            >
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+            </svg>
+            {stars && (
+              <span className="font-mono text-[11px] text-[var(--brand)]">
+                ★ {stars}
+              </span>
+            )}
+            <span>GitHub</span>
           </a>
         </div>
       </div>

--- a/website-src/src/components/Header.jsx
+++ b/website-src/src/components/Header.jsx
@@ -69,31 +69,12 @@ export default function Header() {
           to="/"
           className="flex items-center gap-2 font-semibold text-[var(--fg)] text-lg"
         >
-          <svg
-            viewBox="0 0 16 16"
-            fill="none"
-            className="w-5 h-5"
-            style={{ color: "var(--brand)" }}
+          <img
+            src="assets/logo-mark.svg"
+            alt=""
             aria-hidden="true"
-          >
-            <rect
-              x="1"
-              y="1"
-              width="14"
-              height="14"
-              rx="2"
-              stroke="currentColor"
-              strokeWidth="1.5"
-            />
-            <path
-              d="M5 8l2 2 4-4"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              fill="none"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+            className="w-7 h-7"
+          />
           <span>asm</span>
           <span className="text-[var(--fg-muted)] font-normal">catalog</span>
         </Link>

--- a/website-src/src/components/SidebarDrawer.jsx
+++ b/website-src/src/components/SidebarDrawer.jsx
@@ -67,7 +67,7 @@ export default function SidebarDrawer({
           "lg:max-h-[calc(100vh-var(--header-offset,5rem))]",
         )}
       >
-        <div className="p-3 lg:p-0 lg:pr-4">{children}</div>
+        <div className="p-3 lg:p-0 lg:pr-4 h-full">{children}</div>
       </aside>
     </>
   );

--- a/website-src/src/components/SkillListItem.jsx
+++ b/website-src/src/components/SkillListItem.jsx
@@ -1,4 +1,5 @@
-import { Link, useLocation } from "react-router-dom";
+import { memo } from "react";
+import { Link } from "react-router-dom";
 import { Wrench } from "lucide-react";
 import { Badge } from "./ui/badge.jsx";
 import { cn } from "../lib/cn.js";
@@ -20,13 +21,13 @@ import {
  * contrasting background) so the user never loses the currently
  * focused skill while scrolling.
  */
-export default function SkillListItem({
+function SkillListItem({
   skill,
   active,
   searchQuery,
   searchTerms,
+  locationSearch,
 }) {
-  const location = useLocation();
   const nameHtml = highlightMatches(skill.name, searchQuery, searchTerms);
   const descHtml = highlightMatches(
     skill.description,
@@ -47,7 +48,7 @@ export default function SkillListItem({
     <Link
       to={{
         pathname: `/skills/${encodeSkillId(skill.id)}`,
-        search: location.search,
+        search: locationSearch,
       }}
       aria-current={active ? "true" : undefined}
       className={cn(
@@ -63,17 +64,15 @@ export default function SkillListItem({
           className="absolute left-0 top-2 bottom-2 w-[3px] rounded-r bg-[var(--brand)]"
         />
       )}
-      <div className="flex items-start justify-between gap-2">
-        <span
-          className={cn(
-            "text-sm font-semibold break-words",
-            active ? "text-[var(--brand)]" : "text-[var(--fg)]",
-          )}
-          dangerouslySetInnerHTML={{ __html: nameHtml }}
-        />
-        <span className="text-[10px] text-[var(--fg-muted)] whitespace-nowrap shrink-0">
-          {skill.owner}/{skill.repo}
-        </span>
+      <span
+        className={cn(
+          "block text-sm font-semibold break-words",
+          active ? "text-[var(--brand)]" : "text-[var(--fg)]",
+        )}
+        dangerouslySetInnerHTML={{ __html: nameHtml }}
+      />
+      <div className="mt-1 text-[10px] text-[var(--fg-muted)] truncate">
+        {skill.owner}/{skill.repo}
       </div>
       <p
         className="mt-1 text-xs text-[var(--fg-dim)] line-clamp-2 leading-snug"
@@ -110,3 +109,5 @@ export default function SkillListItem({
     </Link>
   );
 }
+
+export default memo(SkillListItem);

--- a/website-src/src/index.css
+++ b/website-src/src/index.css
@@ -70,3 +70,173 @@ mark.hl {
   padding: 0 2px;
   border-radius: 2px;
 }
+
+/* ─── Markdown prose (docs + changelog pages) ───────────────────────── */
+.prose-asm {
+  color: var(--fg-dim);
+  line-height: 1.65;
+  font-size: 15px;
+}
+.prose-asm h1,
+.prose-asm h2,
+.prose-asm h3,
+.prose-asm h4 {
+  color: var(--fg);
+  font-weight: 600;
+  line-height: 1.25;
+  margin-top: 2em;
+  margin-bottom: 0.5em;
+}
+.prose-asm h1 {
+  font-size: 2rem;
+  margin-top: 0;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--border);
+}
+.prose-asm h2 {
+  font-size: 1.5rem;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--border);
+}
+.prose-asm h3 {
+  font-size: 1.2rem;
+}
+.prose-asm h4 {
+  font-size: 1rem;
+}
+.prose-asm p,
+.prose-asm ul,
+.prose-asm ol,
+.prose-asm blockquote {
+  margin: 0.85em 0;
+}
+.prose-asm ul,
+.prose-asm ol {
+  padding-left: 1.5em;
+}
+.prose-asm li {
+  margin: 0.25em 0;
+}
+.prose-asm a {
+  color: var(--brand);
+  text-decoration: none;
+}
+.prose-asm a:hover {
+  text-decoration: underline;
+}
+.prose-asm code {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.9em;
+  color: var(--fg);
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+.prose-asm pre {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  padding: 12px 14px;
+  border-radius: 6px;
+  overflow-x: auto;
+  line-height: 1.5;
+  margin: 1em 0;
+}
+.prose-asm pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font-size: 0.88em;
+}
+.prose-asm blockquote {
+  border-left: 3px solid var(--brand);
+  padding: 0.25em 1em;
+  color: var(--fg-dim);
+  background: var(--brand-glow);
+  border-radius: 0 4px 4px 0;
+}
+.prose-asm hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 2em 0;
+}
+.prose-asm table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1em 0;
+  font-size: 0.92em;
+}
+.prose-asm th,
+.prose-asm td {
+  border: 1px solid var(--border);
+  padding: 6px 10px;
+  text-align: left;
+}
+.prose-asm th {
+  background: var(--bg-card);
+  color: var(--fg);
+  font-weight: 600;
+}
+.prose-asm img {
+  max-width: 100%;
+  border-radius: 6px;
+}
+.prose-asm .doc-section {
+  margin-bottom: 2rem;
+}
+.prose-asm .doc-section h2:first-child {
+  margin-top: 0;
+}
+
+/* Changelog-specific classes (ported from legacy) */
+.changelog-version {
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--brand);
+  margin-top: 2rem;
+  margin-bottom: 4px;
+}
+.changelog-version:first-child {
+  margin-top: 0.5rem;
+}
+.changelog-date {
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: var(--fg-muted);
+  margin-bottom: 12px;
+}
+.changelog-tag {
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-weight: 600;
+  margin-top: 12px;
+  margin-bottom: 6px;
+  display: inline-block;
+}
+.changelog-tag.added {
+  color: var(--brand);
+  background: var(--brand-glow);
+}
+.changelog-tag.changed {
+  color: #ffb020;
+  background: rgba(255, 176, 32, 0.12);
+}
+.changelog-tag.fixed {
+  color: #4fc3f7;
+  background: rgba(79, 195, 247, 0.12);
+}
+.changelog-tag.breaking {
+  color: #d73a49;
+  background: rgba(215, 58, 73, 0.12);
+}
+.changelog-tag.docs {
+  color: #a78bfa;
+  background: rgba(167, 139, 250, 0.12);
+}

--- a/website-src/src/main.jsx
+++ b/website-src/src/main.jsx
@@ -9,7 +9,9 @@ if (!rootEl) throw new Error("#root not found");
 
 createRoot(rootEl).render(
   <StrictMode>
-    <HashRouter>
+    <HashRouter
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
       <App />
     </HashRouter>
   </StrictMode>,

--- a/website-src/src/pages/BundlesPage.jsx
+++ b/website-src/src/pages/BundlesPage.jsx
@@ -158,6 +158,7 @@ export default function BundlesPage() {
               key={b.name}
               bundle={b}
               active={b.name === decodedName}
+              locationSearch={location.search}
             />
           ))
         )}

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useParams, Link, useLocation } from "react-router-dom";
 import { Menu, X } from "lucide-react";
-import { List } from "react-window";
+import { List, useDynamicRowHeight } from "react-window";
 import { useCatalog } from "../hooks/useCatalog.jsx";
 import { useCatalogState } from "../hooks/useCatalogState.js";
 import {
@@ -19,7 +19,10 @@ import SkillDetail from "../components/SkillDetail.jsx";
 import SidebarDrawer from "../components/SidebarDrawer.jsx";
 import { Button } from "../components/ui/button.jsx";
 
-const ROW_HEIGHT = 120;
+// Starting estimate only — actual row height is measured via
+// `useDynamicRowHeight` so dense items (many badges, long owner/repo)
+// don't get visually clipped or leave gaps.
+const DEFAULT_ROW_HEIGHT = 128;
 
 function SkillRow({
   index,
@@ -80,6 +83,13 @@ export default function CatalogPage() {
   } = useCatalogState();
 
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // Measure each rendered row so skill items with extra badges or a long
+  // owner/repo line aren't clipped. `key` changes invalidate the cache
+  // when the filtered list identity changes (search / filters applied).
+  const rowHeight = useDynamicRowHeight({
+    defaultRowHeight: DEFAULT_ROW_HEIGHT,
+  });
 
   const searchResults = useMemo(() => {
     if (!catalog || !miniSearch || !state.searchQuery.trim()) {
@@ -246,7 +256,7 @@ export default function CatalogPage() {
           <List
             rowComponent={SkillRow}
             rowCount={filtered.length}
-            rowHeight={ROW_HEIGHT}
+            rowHeight={rowHeight}
             overscanCount={4}
             rowProps={{
               skills: filtered,

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useParams, Link, useLocation } from "react-router-dom";
 import { Menu, X } from "lucide-react";
+import { List } from "react-window";
 import { useCatalog } from "../hooks/useCatalog.jsx";
 import { useCatalogState } from "../hooks/useCatalogState.js";
 import {
@@ -17,6 +18,31 @@ import SkillListItem from "../components/SkillListItem.jsx";
 import SkillDetail from "../components/SkillDetail.jsx";
 import SidebarDrawer from "../components/SidebarDrawer.jsx";
 import { Button } from "../components/ui/button.jsx";
+
+const ROW_HEIGHT = 120;
+
+function SkillRow({
+  index,
+  style,
+  skills,
+  decodedId,
+  searchQuery,
+  searchTerms,
+  locationSearch,
+}) {
+  const s = skills[index];
+  return (
+    <div style={style} className="pb-1.5">
+      <SkillListItem
+        skill={s}
+        active={s.id === decodedId}
+        searchQuery={searchQuery}
+        searchTerms={searchTerms}
+        locationSearch={locationSearch}
+      />
+    </div>
+  );
+}
 
 /**
  * Two-pane catalog view (#228). Left sidebar holds search, filters,
@@ -207,7 +233,7 @@ export default function CatalogPage() {
         </span>
       </div>
       <div
-        className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-1.5 pr-1 -mr-1"
+        className="flex-1 min-h-0 pr-1 -mr-1"
         role="list"
         aria-label="Skill results"
       >
@@ -217,15 +243,20 @@ export default function CatalogPage() {
             <p>No skills match your filters</p>
           </div>
         ) : (
-          filtered.map((s) => (
-            <SkillListItem
-              key={s.id}
-              skill={s}
-              active={s.id === decodedId}
-              searchQuery={state.searchQuery}
-              searchTerms={searchResults.terms}
-            />
-          ))
+          <List
+            rowComponent={SkillRow}
+            rowCount={filtered.length}
+            rowHeight={ROW_HEIGHT}
+            overscanCount={4}
+            rowProps={{
+              skills: filtered,
+              decodedId,
+              searchQuery: state.searchQuery,
+              searchTerms: searchResults.terms,
+              locationSearch: location.search,
+            }}
+            style={{ height: "100%" }}
+          />
         )}
       </div>
     </div>

--- a/website-src/src/pages/ChangelogPage.jsx
+++ b/website-src/src/pages/ChangelogPage.jsx
@@ -1,0 +1,1172 @@
+/**
+ * Changelog page. Ported from the legacy `renderChangelogPage()` in
+ * website/index.html.  Entries are expressed as data + JSX fragments
+ * so inline markup (code / link / strong) stays author-friendly.
+ */
+
+const REPO = "https://github.com/luongnv89/asm";
+
+function pr(n) {
+  return (
+    <a
+      href={`${REPO}/pull/${n}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >{`#${n}`}</a>
+  );
+}
+function issue(n) {
+  return (
+    <a
+      href={`${REPO}/issues/${n}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >{`#${n}`}</a>
+  );
+}
+
+const ENTRIES = [
+  {
+    version: "2.3.0",
+    date: "2026-04-21",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            Add <code>skill-best-practice</code> deterministic eval provider —
+            complements the <code>quality</code> provider with rule-based checks
+            that validate SKILL.md frontmatter, naming, and description shape (
+            {pr(197)}, {pr(198)})
+          </>,
+          <>
+            <code>asm eval</code> accepts GitHub refs and batch-evaluates
+            collections — point at a repo or collection and score every skill in
+            one command ({pr(196)})
+          </>,
+          <>
+            Scannable <code>asm list</code> output for large inventories —
+            denser, easier-to-scan rows optimised for users with hundreds of
+            installed skills ({pr(192)}, {pr(195)})
+          </>,
+          <>
+            Multi-axis filtering and search highlighting on the catalog page —
+            filter skills by multiple criteria simultaneously with matched terms
+            highlighted in results ({pr(186)})
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          "Preserve escaped HTML entities in search highlights so angle brackets and ampersands render correctly in highlighted matches",
+          <>
+            Keyboard activation on the install CTA and sort safety on unknown
+            grades ({pr(186)})
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "2.2.0",
+    date: "2026-04-20",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            Show estimated token count and <code>asm eval</code> scores on every
+            consumer surface — website cards/modal, TUI list/detail, and CLI{" "}
+            <code>inspect</code>. Token count uses a <code>words + spaces</code>{" "}
+            heuristic labelled with <code>~</code>; eval scores include overall
+            score, letter grade, per-category breakdown, and an explicit empty
+            state pointing to <code>asm eval &lt;skill&gt;</code> when data is
+            missing. Catalog payload is the single source of truth, so all 3,140
+            indexed skills carry both signals ({pr(191)}, closes {issue(187)},{" "}
+            {issue(188)})
+          </>,
+          <>
+            Refreshed Documentation page with the full <code>asm</code> command
+            reference — adds 6 missing commands (<code>import</code>,{" "}
+            <code>outdated</code>, <code>update</code>, <code>doctor</code>,{" "}
+            <code>bundle</code>, <code>config path</code>), expands
+            global-options and install-flags tables, and adds per-command
+            sections with flags and runnable examples for <code>list</code>,{" "}
+            <code>search</code>, <code>inspect</code>, <code>audit</code>,{" "}
+            <code>uninstall</code>, <code>stats</code>, <code>doctor</code>,{" "}
+            <code>bundle</code>, <code>index</code>, <code>outdated</code>/
+            <code>update</code>, <code>export</code>/<code>import</code>, and{" "}
+            <code>config</code> ({pr(190)}, closes {issue(189)})
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "2.1.0",
+    date: "2026-04-20",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            <code>heygen-com/hyperframes</code> curated-index entry — 5 new
+            skills (hyperframes, hyperframes-cli, hyperframes-registry,
+            website-to-hyperframes, gsap) for HTML-based video composition (
+            {pr(184)})
+          </>,
+          <>
+            Re-indexed <code>mattpocock/skills</code> (18 → 21 skills) (
+            {pr(183)})
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          <>
+            Skill discovery now scans 5 levels deep (was 3), catching skills
+            nested under{" "}
+            <code>plugins/&lt;group&gt;/skills/&lt;skill&gt;/SKILL.md</code>.
+            All curated repos re-indexed — catalog grew from ~1,700 to 3,135
+            skills across 24 repos ({pr(185)})
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "2.0.0",
+    date: "2026-04-19",
+    sections: [
+      {
+        tag: "breaking",
+        items: [
+          <>
+            Drop the <code>skillgrade</code> runtime provider and its bundled
+            binary — <code>asm eval &lt;skill&gt;</code> is now zero-config (no
+            external binary, API key, Docker, or <code>eval.yaml</code>). The
+            built-in <code>quality</code> provider scores every skill out of the
+            box ({pr(180)}, {pr(182)})
+          </>,
+          <>
+            Remove CLI flags <code>--runtime</code>, <code>--runtime init</code>
+            , <code>--preset</code>, <code>--provider</code>,{" "}
+            <code>--compare</code>, <code>--threshold</code>, and the{" "}
+            <code>ASM_SKILLGRADE_BIN</code> env var. CI pipelines using these
+            flags will fail on upgrade
+          </>,
+          <>
+            Remove <code>docs/skillgrade-integration.md</code>
+          </>,
+        ],
+      },
+      {
+        tag: "changed",
+        items: [
+          <>
+            Cut ~5–10 MB from the npm tarball by dropping{" "}
+            <code>skillgrade</code> from <code>dependencies</code> and{" "}
+            <code>bundledDependencies</code>
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.22.0",
+    date: "2026-04-19",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            PATH shadowing detection — <code>asm --version</code> warns when
+            multiple <code>asm</code> binaries are found on <code>PATH</code>;{" "}
+            <code>asm doctor</code> gains a new{" "}
+            <code>checkNoPathShadowing</code> check; npm postinstall warns at
+            install time; <code>install.sh</code> adds a bash-side warning
+          </>,
+          <>
+            Expanded <code>skillgrade-missing</code> error in{" "}
+            <code>asm eval</code> with a manual fallback — guides users through
+            installing Skillgrade by hand when automatic install fails
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          <>
+            Bundle <code>skillgrade</code> via <code>bundledDependencies</code>{" "}
+            — ships inside the <code>asm</code> package, always available
+            without a separate install step
+          </>,
+          <>
+            <code>asm eval --runtime init</code> auto-initialises{" "}
+            <code>eval.yaml</code> when missing; corrected misleading init hint
+            in CLI output
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.21.0",
+    date: "2026-04-19",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            <code>asm eval &lt;skill&gt;</code> scored-rubric static quality
+            lint through a new pluggable provider framework (
+            <code>quality@1.0.0</code>)
+          </>,
+          <>
+            <code>asm eval --runtime</code> runtime evaluation via{" "}
+            <a
+              href="https://github.com/mgechev/skillgrade"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              skillgrade
+            </a>{" "}
+            — LLM-judge + deterministic graders in a Docker sandbox (
+            <strong>
+              skillgrade now ships bundled with asm — zero extra install
+            </strong>
+            )
+          </>,
+          <>
+            <code>ASM_SKILLGRADE_BIN</code> env override to point at a specific
+            skillgrade binary (custom builds, PATH-installed versions, CI
+            pinning)
+          </>,
+          <>
+            <code>asm eval --runtime init</code> scaffolds an{" "}
+            <code>eval.yaml</code> for the active skill
+          </>,
+          <>
+            <code>asm eval --preset smoke|reliable|regression</code>,{" "}
+            <code>--threshold</code>, <code>--provider docker|local</code> flags
+          </>,
+          <>
+            <code>
+              asm eval --compare &lt;id&gt;@&lt;v1&gt;,&lt;id&gt;@&lt;v2&gt;
+            </code>{" "}
+            diffs two provider versions on the same skill before promoting an
+            upgrade
+          </>,
+          <>
+            <code>asm eval-providers list</code> shows registered providers,
+            versions, schema version, and required externals
+          </>,
+          <>
+            Pluggable <code>EvalProvider</code> contract with semver-range
+            resolution and versioned <code>EvalResult</code> schema (new{" "}
+            <code>src/eval/</code> module)
+          </>,
+          <>
+            Config section <code>eval.providers.*</code> in{" "}
+            <code>~/.asm/config.yml</code> for pinning provider versions and
+            runtime options
+          </>,
+          <>
+            Add <strong>Hermes</strong> as a built-in provider (18 providers
+            total) — supports <code>~/.hermes/skills/</code> and{" "}
+            <code>.hermes/skills/</code>
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          <>
+            Recognize Windows drive paths (e.g. <code>C:\</code>) as local
+            sources in <code>asm install</code>
+          </>,
+        ],
+      },
+      {
+        tag: "docs",
+        items: [
+          <>
+            Add{" "}
+            <a
+              href={`${REPO}/blob/main/docs/eval-providers.md`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <code>docs/eval-providers.md</code>
+            </a>{" "}
+            — provider model, version pinning, <code>--compare</code> workflow,
+            5-step guide to add a new provider
+          </>,
+          <>
+            Add{" "}
+            <a
+              href={`${REPO}/blob/main/docs/skillgrade-integration.md`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <code>docs/skillgrade-integration.md</code>
+            </a>{" "}
+            — install, first <code>eval.yaml</code>, presets, CI usage,
+            troubleshooting
+          </>,
+          <>
+            Document the <code>src/eval/</code> module in{" "}
+            <code>docs/ARCHITECTURE.md</code>
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.20.0",
+    date: "2026-04-12",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            Add <code>asm publish</code> command for publishing skills to the
+            ASM Registry
+          </>,
+          "Add registry-based skill resolution — install by bare name without GitHub URLs",
+          <>
+            Add <code>asm outdated</code> and <code>asm update</code> commands
+            for skill version management
+          </>,
+          <>
+            Add <code>asm doctor</code> environment health check command
+          </>,
+          <>
+            Add <code>--machine</code> flag to all commands with stable v1 JSON
+            envelope
+          </>,
+          "Add plugin marketplace skill discovery and Codex marketplace support",
+          "Add dedicated Registry page to the website with publish/install guides",
+          <>
+            Support multiple skill paths in <code>asm link</code>
+          </>,
+          <>
+            Add <code>skill_path</code> to registry manifest for multi-skill
+            repos
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          "Support commit SHA refs in skill clone for pinned installs",
+          <>
+            Create provider directory before symlinking in <code>asm link</code>
+          </>,
+          "Separate unit-tests CI job to avoid config file race condition",
+        ],
+      },
+      {
+        tag: "docs",
+        items: [
+          "Add ASM Registry publish/install section to README and website",
+          <>
+            Improve <code>asm link</code> usage examples for local skill
+            development
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.19.0",
+    date: "2026-03-28",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            Add <code>asm bundle</code> command with five subcommands (
+            <code>create</code>, <code>install</code>, <code>list</code>,{" "}
+            <code>show</code>, <code>remove</code>) for reusable skill
+            collections
+          </>,
+          "Remember user tool selection across runs — pre-checked defaults on subsequent interactive prompts",
+          <>
+            Support linking multiple skills from the same folder via{" "}
+            <code>asm link</code>
+          </>,
+          <>
+            Add <code>Imbad0202/academic-research-skills</code> to curated skill
+            index — 4 new academic workflow skills
+          </>,
+        ],
+      },
+      {
+        tag: "docs",
+        items: [
+          "Add Best Practices page to website with curated resources for skill authors",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.18.0",
+    date: "2026-03-28",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            Add <code>alirezarezvani/claude-skills</code> to curated skill index
+            — 451 new skills across engineering, marketing, product, compliance,
+            C-level advisory, and more
+          </>,
+        ],
+      },
+      {
+        tag: "docs",
+        items: [
+          "Update skill count from 2,600+ to 2,800+ across README, website, and OG image",
+          "Update Open-Source Skill Collections table with refreshed skill counts",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.17.0",
+    date: "2026-03-26",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          "Acknowledgements section to README and landing page with contributor cards, avatars, PR counts, and dependency cards",
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          "Handle Windows backslash path separators in skill name extraction",
+          "Load acknowledgements from JSON source of truth",
+          "Fix PR count mismatch and improve data sync",
+        ],
+      },
+      {
+        tag: "changed",
+        items: [
+          "Expand E2E coverage — 87 to 139 tests across Node and Bun runners",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.16.0",
+    date: "2026-03-25",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            <code>asm import</code> command for restoring skills from exported
+            JSON manifests with <code>--force</code>, <code>--scope</code>, and{" "}
+            <code>--json</code> flags
+          </>,
+          <>
+            Match count and install hints to <code>asm search</code> available
+            skills output
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          <>
+            Handle <code>--json</code> flag on empty manifest import
+          </>,
+        ],
+      },
+      {
+        tag: "changed",
+        items: ["Reorder provider list by priority and default-check agents"],
+      },
+    ],
+  },
+  {
+    version: "1.15.1",
+    date: "2026-03-25",
+    sections: [
+      {
+        tag: "added",
+        items: ["Gemini CLI and Google Antigravity as built-in providers"],
+      },
+      { tag: "docs", items: ["Update skill count from 1,700+ to 2,600+"] },
+    ],
+  },
+  {
+    version: "1.15.0",
+    date: "2026-03-24",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          "4 new skill sources added to curated index",
+          "Verified badge to skills during ingestion",
+          "Light/dark theme toggle to skill catalog",
+          "Docs page, changelog page, and version display on website",
+          "Copy buttons to docs page code blocks",
+          "Installing Skills from Local Files documentation section",
+          "Master-cai/Research-Paper-Writing-Skills to curated skill index",
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          "Website: enforce 44px touch targets and 12px min font sizes",
+          "Website: improve touch targets, font sizes, and overflow handling",
+          "Website: make catalog page fully responsive on mobile",
+          "Website: theme remaining hardcoded colors and improve contrast",
+          "Website: address theme review feedback",
+          "Verified-badge: address review feedback",
+          "Add trailing newline to .gitignore",
+          "Remove hardcoded path and fix maxdepth in skill-index-updater",
+          "Website: rebuild changelog from GitHub releases as source of truth",
+          "Website: add missing versions to changelog page",
+          "Website: address review feedback for docs/changelog pages",
+          "Installer: update picker test for deselected defaults",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.14.0",
+    date: "2026-03-24",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          "Skill catalog website with search, category filters, and one-click install commands",
+          <>
+            SEO optimization, AI bot indexing (<code>llms.txt</code>,{" "}
+            <code>robots.txt</code>), and Google Analytics
+          </>,
+          "Redesign logo as The Nexus — hub-and-spoke skill graph brand identity",
+          "GitHub star count and SKILL.md link on catalog website",
+          "Usability review improvements and Nexus logo update for catalog",
+          <>
+            <code>.skill-lock.json</code> to track installed skills with
+            integrity hashes
+          </>,
+          <>
+            Re-index existing repos with <code>compatibility</code> and{" "}
+            <code>allowedTools</code> fields
+          </>,
+          "6 new skill sources added to index",
+          "Scope selection step for global/project install",
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          "Null-skills validation bug in lock module",
+          <>
+            Git identity in <code>getCommitHash</code> test for CI compatibility
+          </>,
+          "Correct step counter in install flow",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.13.1",
+    date: "2026-03-23",
+    sections: [
+      {
+        tag: "fixed",
+        items: [
+          <>
+            Node.js v25 compatibility: resolve{" "}
+            <code>ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING</code>
+          </>,
+          <>
+            Cross-runtime TUI support: <code>bun:ffi</code> shim with real FFI
+            on Bun, no-op stubs on Node.js
+          </>,
+          "Auto re-exec with Bun for interactive TUI mode when running on Node.js",
+          <>
+            Clean <code>dist/</code> before build to prevent stale chunks
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.13.0",
+    date: "2026-03-23",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          "Parse and display all 6 SKILL.md frontmatter fields: name, description, license, compatibility, allowed-tools, metadata",
+          <>
+            <code>allowed-tools</code> risk coloring in CLI and TUI (red for
+            Bash/Write/Edit, yellow for WebFetch/WebSearch)
+          </>,
+          "Warning line for skills with high-risk tools",
+          <>
+            <code>license</code>, <code>compatibility</code>, and{" "}
+            <code>allowedTools</code> in <code>--json</code> output
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          <>
+            <code>asm index search --json</code> now includes compatibility and
+            allowedTools fields
+          </>,
+          "TUI detail overlay height accounts for warning row",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.12.0",
+    date: "2026-03-23",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          "MiniMax-AI/skills repo to curated skill index — 10 new skills",
+          "Enrich skill-index with license/creator metadata and filter flags",
+          <>
+            Extract curated skill repos into{" "}
+            <code>data/skill-index-resources.json</code>
+          </>,
+          <>
+            <code>effort</code> field in SKILL.md frontmatter
+          </>,
+          "E2E tests and multi-job CI pipeline for Node 18/20/22",
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          <>
+            Stub <code>bun:ffi</code> at build time for Node.js compatibility
+          </>,
+          <>
+            Scope unit-tests CI job to <code>src/</code> to exclude E2E tests
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.11.0",
+    date: "2026-03-21",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            Interactive checkbox picker for multi-skill install (navigate with
+            ↑/↓, toggle with Space, select all with <code>a</code>)
+          </>,
+          "Search/filter in checkbox picker for long lists",
+          "Interactive checkbox picker for provider selection during config",
+          "Support Vercel skills CLI install format",
+          "Support installing skills from local folder paths",
+          <>
+            Wave 1 provider expansion — 8 new providers, <code>$EDITOR</code>{" "}
+            config fix, creator column
+          </>,
+          'Rename user-facing "Provider" to "Tool" in CLI and TUI',
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          <>
+            Change shebang to <code>node</code> for npm global install
+            compatibility
+          </>,
+          "Skill detail TUI description overflow",
+          "Guard ingester/audit against local paths and restrict tilde expansion",
+          "Checkbox picker re-render cursor positioning",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.10.0",
+    date: "2026-03-18",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            <code>asm index</code> command with bundled pre-indexed skill data
+            for fast offline discovery
+          </>,
+          <>
+            Support nested metadata blocks in SKILL.md frontmatter (dot
+            notation: <code>metadata.version</code>)
+          </>,
+          <>
+            <code>resolveVersion()</code> helper for consistent version
+            resolution
+          </>,
+          <>
+            Updated <code>asm init</code> scaffold template with metadata block
+            format
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          "Duplicate install names in multi-skill installs",
+          <>
+            Valid JSON for <code>asm audit security --all --json</code> when no
+            skills found
+          </>,
+          <>
+            Upgrade <code>actions/checkout</code> to v5 for Node.js 20
+            deprecation
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.9.0",
+    date: "2026-03-14",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            Support GitHub subfolder URLs for <code>asm install</code> and{" "}
+            <code>asm audit security</code>
+          </>,
+          <>
+            <code>github:owner/repo#ref:path</code> shorthand syntax for
+            subfolder installs
+          </>,
+          <>
+            <code>resolveSubpath()</code> using <code>git ls-remote</code> to
+            disambiguate branches from paths
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.8.3",
+    date: "2026-03-14",
+    sections: [
+      {
+        tag: "fixed",
+        items: [
+          "Replace Unicode box-drawing characters with ASCII equivalents for terminal compatibility",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.8.2",
+    date: "2026-03-14",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          "Redesigned security audit report with compact 4-zone layout",
+          "Deduplicate matches so same file:line appears once per category",
+          "Group matches by file for compact rendering",
+          "Aggregate critical/warning/info counts in threat summary",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.8.1",
+    date: "2026-03-14",
+    sections: [
+      {
+        tag: "fixed",
+        items: [
+          "Duplicate skill removal now creates symlinks to the kept instance instead of just deleting",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.8.0",
+    date: "2026-03-14",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            <code>--transport &lt;https|ssh|auto&gt;</code> flag for private
+            GitHub repos via SSH
+          </>,
+          <>
+            <code>asm audit security</code> subcommand for scanning dangerous
+            patterns
+          </>,
+          <>
+            <code>--all</code> flag for <code>asm audit security</code> to audit
+            all installed skills
+          </>,
+          "Audit remote GitHub skills before installing",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.7.0",
+    date: "2026-03-13",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            YAML frontmatter validation for SKILL.md files using the{" "}
+            <code>yaml</code> library
+          </>,
+          <>
+            Detect and report <code>invalid-yaml</code> warnings in{" "}
+            <code>asm inspect</code> and <code>asm list</code>
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.6.2",
+    date: "2026-03-13",
+    sections: [
+      {
+        tag: "fixed",
+        items: [
+          'Suppress "fatal: not a git repository" stderr noise outside git repos',
+          "Fix 7 failing tests to match new grouped CLI output format from v1.6.0",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.6.1",
+    date: "2026-03-13",
+    sections: [
+      {
+        tag: "fixed",
+        items: [
+          <>
+            Replace Unicode bar chart characters with ASCII-safe chars in{" "}
+            <code>asm stats</code>
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.6.0",
+    date: "2026-03-13",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            Default grouped list view with colored <code>[Provider]</code>{" "}
+            badges
+          </>,
+          <>
+            <code>--flat</code> flag for list and search commands
+          </>,
+          <>
+            <code>-p/--provider</code> filter on list and search
+          </>,
+          "Stats dashboard with ASCII bar charts",
+          "Provider-specific colors throughout CLI output",
+          <>
+            Summary footer on <code>list</code> output
+          </>,
+          <>
+            Practical examples in all subcommand <code>--help</code> texts
+          </>,
+          "Actionable error hints and audit hints",
+        ],
+      },
+      {
+        tag: "changed",
+        items: [
+          <>
+            Paths shortened with <code>~</code> prefix throughout all CLI output
+          </>,
+          "Inspect output uses lighter header style with provider badges",
+          <>
+            <code>stats --json</code> omits <code>perSkillDiskBytes</code> by
+            default
+          </>,
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.5.1",
+    date: "2026-03-13",
+    sections: [
+      {
+        tag: "fixed",
+        items: [
+          "Compact batch install output with progress counter",
+          "Replace Unicode characters with ASCII-safe equivalents",
+          "Fix process hang after interactive provider selection",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.5.0",
+    date: "2026-03-13",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            <code>asm install -p all</code> to install across all enabled
+            providers
+          </>,
+          "Primary provider receives files; others get relative symlinks",
+          'Interactive provider picker includes "All providers" option',
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.4.1",
+    date: "2026-03-13",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          "Accept plain HTTPS GitHub URLs for install",
+          <>
+            Support for <code>.git</code> suffix, <code>/tree/branch</code>{" "}
+            paths, and trailing slashes
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: ["Type annotations to fix implicit any errors"],
+      },
+    ],
+  },
+  {
+    version: "1.4.0",
+    date: "2026-03-13",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            <code>asm install github:user/repo</code> command
+          </>,
+          <>
+            <code>--verbose</code> / <code>-V</code> flag for debug output
+          </>,
+          "Node.js compatibility layer, config backup, semver sort",
+          <>
+            <code>export</code>, <code>init</code>, <code>stats</code>,{" "}
+            <code>link</code> commands and skill health warnings
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: ["Pin @opentui/core to exact version 0.1.87 for stability"],
+      },
+    ],
+  },
+  {
+    version: "1.3.0",
+    date: "2026-03-11",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          "Symlink-aware duplicate detection",
+          <>
+            <code>realPath</code> field on scanned skills via{" "}
+            <code>fs.realpath()</code>
+          </>,
+        ],
+      },
+      {
+        tag: "changed",
+        items: [
+          "Audit deduplicates by resolved real path, preferring non-symlink entries",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.2.0",
+    date: "2026-03-11",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            Build step (<code>bun run build</code>) for npm distribution
+          </>,
+          "Build script with version and commit hash injection",
+          <>
+            <code>prepublishOnly</code> script for auto-build before publish
+          </>,
+        ],
+      },
+      {
+        tag: "changed",
+        items: [
+          <>
+            Bin entry points reference bundled <code>dist/</code> instead of raw
+            TypeScript
+          </>,
+        ],
+      },
+      {
+        tag: "fixed",
+        items: [
+          "Version display works in both development and production modes",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.1.0",
+    date: "2026-03-11",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          <>
+            Non-interactive CLI mode with <code>asm</code> shorthand command
+          </>,
+          <>
+            Duplicate skill audit — detect and remove duplicates across
+            providers (<code>asm audit</code>)
+          </>,
+          <>
+            JSON output support (<code>--json</code>) for CLI commands
+          </>,
+          <>
+            One-command install script (<code>curl | bash</code>)
+          </>,
+          "TUI audit overlay with two-phase workflow",
+        ],
+      },
+      {
+        tag: "changed",
+        items: ["Rebranded project to agent-skill-manager"],
+      },
+      {
+        tag: "fixed",
+        items: ["Bun global bin PATH handling and alias creation in installer"],
+      },
+    ],
+  },
+  {
+    version: "1.0.0",
+    date: "2026-03-11",
+    sections: [
+      {
+        tag: "added",
+        items: [
+          "Interactive TUI dashboard built with OpenTUI and Bun",
+          "Multi-agent support: Claude Code, Codex, OpenClaw, and generic Agents",
+          <>
+            Configurable providers via{" "}
+            <code>~/.config/agent-skill-manager/config.json</code>
+          </>,
+          "Global and project scope filtering with Tab cycling",
+          "Real-time search and sort (by name, version, location)",
+          "Detailed skill view with SKILL.md frontmatter metadata",
+          "Safe uninstall with confirmation dialog and full removal plan",
+          "In-TUI config editor — toggle providers on/off",
+          "Pre-commit hooks, GitHub Actions CI, 63 unit tests",
+        ],
+      },
+    ],
+  },
+];
+
+const VALID_TAGS = new Set(["added", "changed", "fixed", "breaking", "docs"]);
+
+function cap(s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function Entry({ version, date, sections }) {
+  const versionLabel = /^\d/.test(version) ? `v${version}` : version;
+  return (
+    <div>
+      <div className="changelog-version">{versionLabel}</div>
+      <div className="changelog-date">{date}</div>
+      {sections.map((s, i) => {
+        const tagClass = VALID_TAGS.has(s.tag) ? s.tag : "added";
+        return (
+          <div key={i}>
+            <span className={`changelog-tag ${tagClass}`}>{cap(s.tag)}</span>
+            <ul>
+              {s.items.map((item, j) => (
+                <li key={j}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function ChangelogPage() {
+  return (
+    <article className="mx-auto max-w-[820px] py-6 prose-asm">
+      <h1>Changelog</h1>
+      <p>
+        All notable changes to <code>agent-skill-manager</code>. Based on{" "}
+        <a
+          href="https://keepachangelog.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Keep a Changelog
+        </a>
+        , adhering to{" "}
+        <a href="https://semver.org/" target="_blank" rel="noopener noreferrer">
+          Semantic Versioning
+        </a>
+        .
+      </p>
+      <p>
+        <a
+          href={`${REPO}/blob/main/CHANGELOG.md`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View full changelog on GitHub →
+        </a>
+      </p>
+      {ENTRIES.map((e) => (
+        <Entry key={e.version} {...e} />
+      ))}
+    </article>
+  );
+}

--- a/website-src/src/pages/DocsPage.jsx
+++ b/website-src/src/pages/DocsPage.jsx
@@ -1,0 +1,1218 @@
+/**
+ * Documentation page. Ported from the legacy
+ * `renderDocsPage()` in website/index.html. Structure and wording are
+ * preserved; presentation relies on the shared `.prose-asm` styles.
+ */
+export default function DocsPage() {
+  return (
+    <article className="mx-auto max-w-[820px] py-6 prose-asm">
+      <h1>Documentation</h1>
+
+      <section className="doc-section">
+        <h2>Getting Started</h2>
+        <h3>Install via npm (recommended)</h3>
+        <pre>
+          <code>npm install -g agent-skill-manager</code>
+        </pre>
+        <p>
+          Requires <a href="https://bun.sh">Bun</a> ≥ 1.0.0 as the runtime.
+          Install Bun:
+        </p>
+        <pre>
+          <code>curl -fsSL https://bun.sh/install | bash</code>
+        </pre>
+        <h3>One-liner install</h3>
+        <pre>
+          <code>
+            curl -sSL
+            https://raw.githubusercontent.com/luongnv89/asm/main/install.sh |
+            bash
+          </code>
+        </pre>
+        <p>Then launch the interactive TUI:</p>
+        <pre>
+          <code>asm</code>
+        </pre>
+      </section>
+
+      <section className="doc-section">
+        <h2>CLI Command Reference</h2>
+        <p>
+          Run <code>asm &lt;command&gt; --help</code> on any command for full
+          per-command usage, options, and examples.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Command</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <Row cmd="asm" desc="Launch interactive TUI" />
+            <Row cmd="asm list" desc="List all discovered skills" />
+            <Row
+              cmd="asm search <query>"
+              desc="Search installed skills and the skill index"
+            />
+            <Row
+              cmd="asm inspect <skill-name>"
+              desc="Show detailed info for a skill"
+            />
+            <Row
+              cmd="asm install <source>"
+              desc="Install a skill from GitHub, the registry, or a local path"
+            />
+            <Row
+              cmd="asm uninstall <skill-name>"
+              desc="Remove a skill (with confirmation)"
+            />
+            <Row
+              cmd="asm init <name>"
+              desc="Scaffold a new skill with SKILL.md template"
+            />
+            <Row
+              cmd="asm link <path> [<path2> ...]"
+              desc="Symlink a local skill (or many) for live development"
+            />
+            <Row
+              cmd="asm export"
+              desc="Export skill inventory as a JSON manifest"
+            />
+            <Row
+              cmd="asm import <file>"
+              desc="Import skills from a previously exported manifest"
+            />
+            <Row
+              cmd="asm outdated"
+              desc="Show which installed skills have newer versions"
+            />
+            <Row
+              cmd="asm update [name...]"
+              desc="Update outdated skills (with security re-audit)"
+            />
+            <Row cmd="asm audit" desc="Detect duplicate skills across tools" />
+            <Row
+              cmd="asm audit security <name|source>"
+              desc="Run a security audit on an installed or remote skill"
+            />
+            <Row
+              cmd="asm publish [path]"
+              desc="Validate, audit, and submit a skill to the ASM Registry"
+            />
+            <Row
+              cmd="asm eval <skill-path>"
+              desc="Score a skill against best practices (quality lint)"
+            />
+            <Row
+              cmd="asm eval-providers list"
+              desc="List registered eval providers and versions"
+            />
+            <Row
+              cmd="asm bundle <subcommand>"
+              desc="Manage skill bundles (create, install, list, show, remove)"
+            />
+            <Row
+              cmd="asm index <subcommand>"
+              desc="Manage the skill index (ingest, search, list, remove)"
+            />
+            <Row
+              cmd="asm stats"
+              desc="Show aggregate skill metrics dashboard"
+            />
+            <Row
+              cmd="asm doctor"
+              desc="Run environment health checks and diagnostics"
+            />
+            <Row
+              cmd="asm config <subcommand>"
+              desc="Manage configuration (show, path, reset, edit)"
+            />
+          </tbody>
+        </table>
+
+        <h3>Global Options</h3>
+        <p>
+          These flags are accepted by most commands. Per-command flags are
+          listed in their own sections below.
+        </p>
+        <FlagTable
+          rows={[
+            ["-h, --help", "Show help for any command"],
+            ["-v, --version", "Print version and exit"],
+            ["--json", "Output as JSON (where supported)"],
+            ["--machine", "Stable machine-readable JSON envelope (v1)"],
+            [
+              "-s, --scope <scope>",
+              <>
+                Filter: <code>global</code>, <code>project</code>, or{" "}
+                <code>both</code> (default: both)
+              </>,
+            ],
+            [
+              "-p, --tool <name>",
+              "Target tool / provider (claude, codex, openclaw, agents, …)",
+            ],
+            [
+              "--sort <field>",
+              <>
+                Sort by: <code>name</code>, <code>version</code>, or{" "}
+                <code>location</code>
+              </>,
+            ],
+            ["--flat", "Show one row per tool instance (list, search)"],
+            ["-y, --yes", "Skip confirmation prompts"],
+            ["-f, --force", "Overwrite if target already exists"],
+            ["--no-color", "Disable ANSI colors"],
+            ["-V, --verbose", "Show debug output"],
+          ]}
+        />
+      </section>
+
+      <section className="doc-section">
+        <h2>Discovery Commands</h2>
+
+        <h3>
+          <code>asm list</code> — List installed skills
+        </h3>
+        <p>
+          By default, skills installed across multiple tools are grouped into a
+          single row with tool badges.
+        </p>
+        <FlagTable
+          rows={[
+            [
+              "--sort <field>",
+              <>
+                Sort by: <code>name</code>, <code>version</code>, or{" "}
+                <code>location</code> (default: name)
+              </>,
+            ],
+            [
+              "-s, --scope <s>",
+              <>
+                Filter: <code>global</code>, <code>project</code>, or{" "}
+                <code>both</code>
+              </>,
+            ],
+            [
+              "-p, --tool <p>",
+              "Filter by tool (claude, codex, openclaw, agents, …)",
+            ],
+            ["--flat", "Show one row per tool instance (ungrouped)"],
+            ["--json", "Output as JSON array"],
+            [
+              "--machine",
+              "Output in stable machine-readable v1 envelope format",
+            ],
+          ]}
+        />
+        <CodeBlock>{`asm list                          # List all skills (grouped)
+asm list --flat                   # One row per tool instance
+asm list -p claude                # Only Claude Code skills
+asm list -s project               # Only project-scoped skills
+asm list --sort version           # Sort by version
+asm list --json                   # Output as JSON`}</CodeBlock>
+
+        <h3>
+          <code>asm search</code> — Search installed and indexed skills
+        </h3>
+        <p>
+          Searches both installed skills and the skill index. Available skills
+          include copy-paste install commands.
+        </p>
+        <FlagTable
+          rows={[
+            [
+              "--sort <field>",
+              <>
+                Sort by: <code>name</code>, <code>version</code>, or{" "}
+                <code>location</code>
+              </>,
+            ],
+            [
+              "-s, --scope <s>",
+              <>
+                Filter: <code>global</code>, <code>project</code>, or{" "}
+                <code>both</code>
+              </>,
+            ],
+            ["-p, --tool <p>", "Filter by tool"],
+            ["--installed", "Show only installed skills"],
+            ["--available", "Show only available (not installed) skills"],
+            ["--flat", "Show one row per tool instance"],
+            ["--json", "Output as JSON array"],
+            ["--machine", "Machine-readable v1 envelope output"],
+          ]}
+        />
+        <CodeBlock>{`asm search code                   # Search installed and available
+asm search review -p claude       # Within Claude Code only
+asm search "test" --installed     # Installed skills only
+asm search "test" --available     # Available skills only
+asm search openspec --json        # Matches as JSON`}</CodeBlock>
+
+        <h3>
+          <code>asm inspect</code> — Show details for a skill
+        </h3>
+        <p>
+          Shows version, description, file count, and all provider
+          installations. The <code>&lt;skill-name&gt;</code> argument is the
+          directory name.
+        </p>
+        <FlagTable
+          rows={[
+            [
+              "-s, --scope <s>",
+              <>
+                Filter: <code>global</code>, <code>project</code>, or{" "}
+                <code>both</code>
+              </>,
+            ],
+            ["--json", "Output as JSON object"],
+          ]}
+        />
+        <CodeBlock>{`asm inspect code-review           # Show details for code-review
+asm inspect code-review --json    # Output as JSON
+asm inspect code-review -s global # Global installations only`}</CodeBlock>
+      </section>
+
+      <section className="doc-section">
+        <h2>Installing Skills from GitHub</h2>
+        <p>Install skills directly from GitHub repositories:</p>
+        <CodeBlock>{`asm install github:user/my-skill
+asm install github:user/my-skill#v1.0.0 -p claude
+asm install github:user/skills --path skills/code-review
+asm install github:user/skills --all -p claude -y
+asm install https://github.com/user/skills/tree/main/skills/code-review`}</CodeBlock>
+
+        <h3>Source Formats</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Format</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <Row
+              cmd="code-review"
+              desc="Install by name from the curated registry"
+            />
+            <Row
+              cmd="author/code-review"
+              desc="Scoped registry name (no ambiguity)"
+            />
+            <Row cmd="github:owner/repo" desc="Install from default branch" />
+            <Row cmd="github:owner/repo#ref" desc="Specific branch or tag" />
+            <Row
+              cmd="github:owner/repo#ref:path"
+              desc="Subfolder on a specific branch"
+            />
+            <Row cmd="https://github.com/owner/repo" desc="HTTPS URL" />
+            <Row
+              cmd="https://github.com/owner/repo/tree/branch/path"
+              desc="Subfolder URL (auto-detects branch)"
+            />
+            <Row
+              cmd="/abs/path/to/skill or ./relative or ~/path"
+              desc="Local folder"
+            />
+          </tbody>
+        </table>
+
+        <h3>Install Flags</h3>
+        <FlagTable
+          rows={[
+            [
+              "-p, --tool <name>",
+              <>
+                Target tool (claude, codex, openclaw, agents, …, or{" "}
+                <code>all</code> for every tool)
+              </>,
+            ],
+            [
+              "-s, --scope <scope>",
+              <>
+                Installation scope: <code>global</code> or <code>project</code>{" "}
+                (default: prompt)
+              </>,
+            ],
+            ["--name <name>", "Override skill directory name"],
+            ["--path <subdir>", "Install a specific skill from a subdirectory"],
+            [
+              "--skill <name>",
+              <>
+                Alias for <code>--path</code> (Vercel skills CLI compatibility)
+              </>,
+            ],
+            ["--all", "Install all skills found in the repo"],
+            [
+              "-m, --method <method>",
+              <>
+                Install method: <code>default</code> or <code>vercel</code>{" "}
+                (delegates to <code>npx skills add</code>)
+              </>,
+            ],
+            [
+              "-t, --transport <mode>",
+              <>
+                Transport: <code>https</code>, <code>ssh</code>, or{" "}
+                <code>auto</code> (default: auto)
+              </>,
+            ],
+            [
+              "--no-cache",
+              "Force fresh registry fetch (bypass 1-hour TTL cache)",
+            ],
+            ["-f, --force", "Overwrite if skill already exists"],
+            ["-y, --yes", "Skip confirmation prompt"],
+            ["--json", "Output result as JSON"],
+            [
+              "--machine",
+              "Machine-readable output (includes resolution source)",
+            ],
+          ]}
+        />
+      </section>
+
+      <section className="doc-section">
+        <h2>Installing Skills from Local Files</h2>
+        <p>
+          You can install skills from a local directory on your machine. The
+          directory must contain a valid <code>SKILL.md</code> file.
+        </p>
+
+        <h3>Install from a local path</h3>
+        <CodeBlock>{`asm install ./path/to/my-skill`}</CodeBlock>
+        <p>Absolute and home-relative paths are also supported:</p>
+        <CodeBlock>{`asm install /absolute/path/to/skill
+asm install ~/my-skills/awesome-skill`}</CodeBlock>
+
+        <h3>Install to a specific agent</h3>
+        <CodeBlock>{`asm install ./my-skill -p claude`}</CodeBlock>
+
+        <h3>Symlink for live development</h3>
+        <p>
+          Instead of copying, use <code>asm link</code> to create a symlink.
+          Changes to the source files are reflected immediately in the agent —
+          no reinstall needed:
+        </p>
+        <CodeBlock>{`asm link ./my-skill -p claude`}</CodeBlock>
+        <p>
+          This is the fastest iteration loop for skill development. Edit your{" "}
+          <code>SKILL.md</code>, and the agent picks up changes on the next run.
+        </p>
+
+        <h3>Local install vs link</h3>
+        <table>
+          <thead>
+            <tr>
+              <th></th>
+              <th>
+                <code>install</code>
+              </th>
+              <th>
+                <code>link</code>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Method</td>
+              <td>Copies files to agent directory</td>
+              <td>Creates a symlink</td>
+            </tr>
+            <tr>
+              <td>Live updates</td>
+              <td>No — must reinstall</td>
+              <td>Yes — changes reflected immediately</td>
+            </tr>
+            <tr>
+              <td>Best for</td>
+              <td>Final deployment</td>
+              <td>Active development</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section className="doc-section">
+        <h2>SKILL.md Specification</h2>
+        <p>
+          Every skill is a directory containing a <code>SKILL.md</code> file
+          with YAML frontmatter:
+        </p>
+        <CodeBlock>{`---
+name: my-skill
+description: "A short description of what this skill does"
+license: "MIT"
+compatibility: "Claude Code, Codex"
+allowed-tools: Bash Read Grep Glob WebFetch
+effort: medium
+metadata:
+  version: 1.0.0
+  creator: "Your Name"
+---`}</CodeBlock>
+
+        <h3>Frontmatter Fields</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>Required</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <FieldRow name="name" req="yes" desc="Unique skill identifier" />
+            <FieldRow
+              name="description"
+              req="yes"
+              desc="One-line summary shown in listings"
+            />
+            <FieldRow name="license" req="no" desc="SPDX license identifier" />
+            <FieldRow
+              name="compatibility"
+              req="no"
+              desc="Comma-separated compatible AI agents"
+            />
+            <FieldRow
+              name="allowed-tools"
+              req="no"
+              desc="Space-delimited tool names the skill uses"
+            />
+            <FieldRow
+              name="effort"
+              req="no"
+              desc="Effort level: low, medium, high, or max"
+            />
+            <FieldRow
+              name="metadata.version"
+              req="no"
+              desc="Semver version (defaults to 0.0.0)"
+            />
+            <FieldRow
+              name="metadata.creator"
+              req="no"
+              desc="Author name and optional email"
+            />
+          </tbody>
+        </table>
+      </section>
+
+      <section className="doc-section">
+        <h2>Supported Agent Tools</h2>
+        <p>
+          <code>asm</code> ships with 18 built-in providers, all enabled by
+          default:
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Tool</th>
+              <th>Global Path</th>
+              <th>Project Path</th>
+            </tr>
+          </thead>
+          <tbody>
+            <ToolRow
+              tool="Claude Code"
+              g="~/.claude/skills/"
+              p=".claude/skills/"
+            />
+            <ToolRow tool="Codex" g="~/.codex/skills/" p=".codex/skills/" />
+            <ToolRow
+              tool="OpenClaw"
+              g="~/.openclaw/skills/"
+              p=".openclaw/skills/"
+            />
+            <ToolRow tool="Agents" g="~/.agents/skills/" p=".agents/skills/" />
+            <ToolRow tool="Cursor" g="~/.cursor/rules/" p=".cursor/rules/" />
+            <ToolRow
+              tool="Windsurf"
+              g="~/.windsurf/rules/"
+              p=".windsurf/rules/"
+            />
+            <ToolRow
+              tool="Cline"
+              g="~/Documents/Cline/Rules/"
+              p=".clinerules/"
+            />
+            <ToolRow tool="Roo Code" g="~/.roo/rules/" p=".roo/rules/" />
+            <ToolRow
+              tool="Continue"
+              g="~/.continue/rules/"
+              p=".continue/rules/"
+            />
+            <ToolRow
+              tool="GitHub Copilot"
+              g="~/.github/instructions/"
+              p=".github/instructions/"
+            />
+            <ToolRow tool="Aider" g="~/.aider/skills/" p=".aider/skills/" />
+            <ToolRow
+              tool="OpenCode"
+              g="~/.config/opencode/skills/"
+              p=".opencode/skills/"
+            />
+            <ToolRow
+              tool="Zed"
+              g="~/.config/zed/prompt_overrides/"
+              p=".zed/rules/"
+            />
+            <ToolRow tool="Augment" g="~/.augment/rules/" p=".augment/rules/" />
+            <ToolRow tool="Amp" g="~/.amp/skills/" p=".amp/skills/" />
+            <ToolRow
+              tool="Gemini CLI"
+              g="~/.gemini/skills/"
+              p=".gemini/skills/"
+            />
+            <ToolRow
+              tool="Google Antigravity"
+              g="~/.antigravity/skills/"
+              p=".antigravity/skills/"
+            />
+            <ToolRow tool="Hermes" g="~/.hermes/skills/" p=".hermes/skills/" />
+          </tbody>
+        </table>
+      </section>
+
+      <section className="doc-section">
+        <h2>
+          Configuration (<code>asm config</code>)
+        </h2>
+        <p>
+          Config file is created at{" "}
+          <code>~/.config/agent-skill-manager/config.json</code> on first run
+          with 18 default providers.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Subcommand</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <Row cmd="config show" desc="Print current config as JSON" />
+            <Row cmd="config path" desc="Print the config file path" />
+            <Row
+              cmd="config edit"
+              desc={
+                <>
+                  Open the config in <code>$EDITOR</code>
+                </>
+              }
+            />
+            <Row
+              cmd="config reset"
+              desc={
+                <>
+                  Reset config to defaults (with confirmation; <code>-y</code>{" "}
+                  to skip)
+                </>
+              }
+            />
+          </tbody>
+        </table>
+        <CodeBlock>{`asm config show     # View current config
+asm config path     # Print config file path
+asm config edit     # Edit in $EDITOR
+asm config reset -y # Reset without confirmation`}</CodeBlock>
+        <p>
+          Disable a provider by setting <code>&quot;enabled&quot;: false</code>{" "}
+          in the config. Add custom skill directories via{" "}
+          <code>customPaths</code>.
+        </p>
+      </section>
+
+      <section className="doc-section">
+        <h2>Creating Your Own Skills</h2>
+        <h3>Typical workflow</h3>
+        <ol>
+          <li>
+            <strong>Scaffold</strong> — <code>asm init my-skill -p claude</code>
+          </li>
+          <li>
+            Edit your <code>SKILL.md</code>
+          </li>
+          <li>
+            <strong>Link for live testing</strong> —{" "}
+            <code>asm link ./my-skill -p claude</code>
+          </li>
+          <li>Test with your AI agent</li>
+          <li>
+            <strong>Security audit</strong> —{" "}
+            <code>asm audit security my-skill</code>
+          </li>
+          <li>
+            <strong>Verify metadata</strong> — <code>asm inspect my-skill</code>
+          </li>
+          <li>
+            <strong>Score quality</strong> — <code>asm eval ./my-skill</code>
+          </li>
+          <li>Push to GitHub</li>
+          <li>
+            <strong>Verify install flow</strong> —{" "}
+            <code>asm install github:you/my-skill</code>
+          </li>
+          <li>
+            <strong>Publish to registry</strong> —{" "}
+            <code>asm publish ./my-skill</code>
+          </li>
+        </ol>
+      </section>
+
+      <section className="doc-section">
+        <h2>
+          Evaluating Skills (<code>asm eval</code>)
+        </h2>
+        <p>
+          <code>asm eval &lt;skill&gt;</code> is zero-config: no external
+          binary, no API key, no Docker, no <code>eval.yaml</code>. The built-in{" "}
+          <code>quality@1.0.0</code> provider runs a scored rubric over
+          structure, frontmatter, clarity, and safety, and prints improvement
+          suggestions.
+        </p>
+
+        <h3>Core commands</h3>
+        <CodeBlock>{`# Score a skill on disk
+asm eval ./my-skill
+
+# List registered eval providers
+asm eval-providers list`}</CodeBlock>
+
+        <h3>Pluggable provider framework</h3>
+        <p>
+          Every evaluator implements a common <code>EvalProvider</code> contract
+          and resolves via a semver range, so new providers can be added without
+          touching the CLI.
+        </p>
+
+        <p>
+          See the full guide:{" "}
+          <a
+            href="https://github.com/luongnv89/asm/blob/main/docs/eval-providers.md"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Eval Providers
+          </a>
+          .
+        </p>
+      </section>
+
+      <section className="doc-section">
+        <h2>
+          Updating Skills (<code>asm outdated</code>, <code>asm update</code>)
+        </h2>
+
+        <h3>
+          <code>asm outdated</code>
+        </h3>
+        <p>Show which installed skills have newer versions available.</p>
+        <FlagTable
+          rows={[
+            ["--json", "Output as JSON"],
+            ["--machine", "Stable machine-readable output"],
+          ]}
+        />
+        <CodeBlock>{`asm outdated                       # Show outdated skills
+asm outdated --json                # Output as JSON`}</CodeBlock>
+
+        <h3>
+          <code>asm update [name...]</code>
+        </h3>
+        <p>
+          Update outdated skills to their latest version with security re-audit.
+          Pass one or more skill names to update only those, or omit to update
+          all outdated skills.
+        </p>
+        <FlagTable
+          rows={[
+            ["-y, --yes", "Skip confirmation prompts"],
+            ["--json", "Output as JSON"],
+            ["--machine", "Stable machine-readable output"],
+          ]}
+        />
+        <CodeBlock>{`asm update                         # Update all outdated skills
+asm update code-review             # Update a specific skill
+asm update --yes                   # Skip confirmation prompts`}</CodeBlock>
+      </section>
+
+      <section className="doc-section">
+        <h2>
+          Backup and Restore (<code>asm export</code>, <code>asm import</code>)
+        </h2>
+
+        <h3>
+          <code>asm export</code>
+        </h3>
+        <p>
+          Export skill inventory as a portable JSON manifest. Useful for backup,
+          sharing, or scripting.
+        </p>
+        <FlagTable
+          rows={[
+            [
+              "-s, --scope <s>",
+              <>
+                Filter: <code>global</code>, <code>project</code>, or{" "}
+                <code>both</code>
+              </>,
+            ],
+          ]}
+        />
+        <CodeBlock>{`asm export                        # Export all skills (stdout)
+asm export -s global              # Export global skills only
+asm export > skills.json          # Save to a file`}</CodeBlock>
+
+        <h3>
+          <code>asm import &lt;file&gt;</code>
+        </h3>
+        <p>
+          Import skills from a previously exported JSON manifest. Recreates
+          skill installations based on the manifest. Existing skills are skipped
+          unless <code>--force</code> is set.
+        </p>
+        <FlagTable
+          rows={[
+            [
+              "-s, --scope <s>",
+              <>
+                Filter: <code>global</code>, <code>project</code>, or{" "}
+                <code>both</code>
+              </>,
+            ],
+            ["-f, --force", "Overwrite existing skills"],
+            ["-y, --yes", "Skip confirmation prompt"],
+            ["--json", "Output results as JSON"],
+          ]}
+        />
+        <CodeBlock>{`asm import skills.json              # Import from manifest
+asm import skills.json --force      # Overwrite existing skills
+asm import skills.json -s global    # Import only global skills`}</CodeBlock>
+      </section>
+
+      <section className="doc-section">
+        <h2>
+          Skill Bundles (<code>asm bundle</code>)
+        </h2>
+        <p>
+          A bundle is a reusable recipe of skills for a particular workflow,
+          domain, or project setup. Create one from your installed skills, share
+          it, and install it later in another environment.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Subcommand</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <Row
+              cmd="bundle create <name>"
+              desc="Create a new bundle from installed skills (interactive)"
+            />
+            <Row
+              cmd="bundle install <name|file>"
+              desc="Install all skills from a saved bundle or bundle file"
+            />
+            <Row cmd="bundle list" desc="List all saved bundles" />
+            <Row cmd="bundle show <name|file>" desc="Show bundle details" />
+            <Row cmd="bundle remove <name>" desc="Remove a saved bundle" />
+          </tbody>
+        </table>
+        <h3>Flags</h3>
+        <FlagTable
+          rows={[
+            [
+              "-s, --scope <s>",
+              <>
+                Filter: <code>global</code>, <code>project</code>, or{" "}
+                <code>both</code>
+              </>,
+            ],
+            ["-y, --yes", "Skip confirmation prompts"],
+            ["--json", "Output as JSON"],
+          ]}
+        />
+        <CodeBlock>{`asm bundle create my-workflow       # Create from installed skills
+asm bundle install my-workflow      # Install a saved bundle
+asm bundle install ./bundle.json    # Install from a file
+asm bundle list                     # Show all saved bundles
+asm bundle show my-workflow         # Show bundle details
+asm bundle remove my-workflow       # Remove a saved bundle`}</CodeBlock>
+      </section>
+
+      <section className="doc-section">
+        <h2>
+          Skill Index (<code>asm index</code>)
+        </h2>
+        <p>
+          Manage the local skill index used by <code>asm search</code> for
+          available (not-yet-installed) skills.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Subcommand</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <Row
+              cmd="index ingest <repo>"
+              desc="Ingest a skill repository into the index"
+            />
+            <Row
+              cmd="index search <query>"
+              desc="Search indexed skills by name or description"
+            />
+            <Row cmd="index list" desc="List all indexed repositories" />
+            <Row
+              cmd="index remove <owner/repo>"
+              desc="Remove a repo from the index"
+            />
+          </tbody>
+        </table>
+        <h3>Flags</h3>
+        <FlagTable
+          rows={[
+            ["--json", "Output as JSON"],
+            [
+              "--has <field>",
+              <>
+                Only show skills that have <code>&lt;field&gt;</code> (license,
+                creator, version)
+              </>,
+            ],
+            [
+              "--missing <field>",
+              <>
+                Only show skills missing <code>&lt;field&gt;</code>
+              </>,
+            ],
+            ["-y, --yes", "Skip confirmation prompts"],
+          ]}
+        />
+        <CodeBlock>{`asm index ingest github:obra/superpowers          # Index a repo
+asm index search code review                       # Search indexed skills
+asm index search marketing --has license           # Only with license
+asm index search "" --missing creator              # Skills missing creator
+asm index list                                    # List indexed repos
+asm index remove obra/superpowers                 # Remove from index`}</CodeBlock>
+      </section>
+
+      <section className="doc-section">
+        <h2>
+          Auditing (<code>asm audit</code>)
+        </h2>
+        <p>
+          Detect duplicate skills across tools or run security audits on
+          installed and remote skills.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Subcommand</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code>audit</code> (or <code>audit duplicates</code>)
+              </td>
+              <td>Find duplicate skills (default)</td>
+            </tr>
+            <Row
+              cmd="audit security <name|source>"
+              desc="Run security audit on an installed skill or GitHub source"
+            />
+          </tbody>
+        </table>
+        <h3>Flags</h3>
+        <FlagTable
+          rows={[
+            ["--json", "Output as JSON"],
+            ["--machine", "Stable machine-readable v1 envelope output"],
+            [
+              "-y, --yes",
+              "Auto-remove duplicates, keeping one instance per group",
+            ],
+            [
+              "-s, --scope <s>",
+              <>
+                Filter: <code>global</code>, <code>project</code>, or{" "}
+                <code>both</code>
+              </>,
+            ],
+            ["--all", "(security) Audit all installed skills"],
+          ]}
+        />
+        <CodeBlock>{`asm audit                                     # Find duplicates
+asm audit -y                                  # Auto-remove duplicates
+asm audit security code-review                # Audit an installed skill
+asm audit security github:user/repo           # Audit a remote skill before install
+asm audit security --all                      # Audit all installed skills`}</CodeBlock>
+      </section>
+
+      <section className="doc-section">
+        <h2>
+          Uninstalling (<code>asm uninstall</code>)
+        </h2>
+        <p>
+          Remove a skill and its associated rule files. Shows a removal plan
+          before proceeding and asks for confirmation.
+        </p>
+        <FlagTable
+          rows={[
+            ["-y, --yes", "Skip confirmation prompt"],
+            [
+              "-s, --scope <s>",
+              <>
+                Filter: <code>global</code>, <code>project</code>, or{" "}
+                <code>both</code>
+              </>,
+            ],
+          ]}
+        />
+        <CodeBlock>{`asm uninstall code-review             # Remove with confirmation
+asm uninstall code-review -y          # Remove without confirmation
+asm uninstall code-review -s project  # Remove project copy only`}</CodeBlock>
+      </section>
+
+      <section className="doc-section">
+        <h2>
+          Stats (<code>asm stats</code>)
+        </h2>
+        <p>
+          Show aggregate skill metrics with provider distribution charts, scope
+          breakdown, disk usage, and duplicate summary.
+        </p>
+        <FlagTable
+          rows={[
+            ["--json", "Output as JSON"],
+            [
+              "-s, --scope <s>",
+              <>
+                Filter: <code>global</code>, <code>project</code>, or{" "}
+                <code>both</code>
+              </>,
+            ],
+          ]}
+        />
+        <CodeBlock>{`asm stats                         # Full dashboard
+asm stats -s global               # Global skills only
+asm stats --json                  # Output as JSON`}</CodeBlock>
+      </section>
+
+      <section className="doc-section">
+        <h2>
+          Doctor (<code>asm doctor</code>)
+        </h2>
+        <p>
+          Run environment health checks and diagnostics. Validates prerequisites
+          for using <code>asm</code> — git, GitHub CLI, Node.js, config, lock
+          file, registry, installed skills, and disk space.
+        </p>
+        <FlagTable
+          rows={[
+            ["--json", "Output as JSON"],
+            ["--machine", "Stable machine-readable v1 envelope output"],
+          ]}
+        />
+        <CodeBlock>{`asm doctor                        # Run all health checks
+asm doctor --json                 # Output as JSON
+asm doctor --machine              # Machine-readable output`}</CodeBlock>
+      </section>
+
+      <section className="doc-section">
+        <h2>ASM Registry — Install and Publish by Name</h2>
+        <p>
+          The{" "}
+          <a
+            href="https://github.com/luongnv89/asm-registry"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ASM Registry
+          </a>{" "}
+          is the curated index of community-published skills. Once listed,
+          anyone can install by name — no GitHub URL needed.
+        </p>
+
+        <h3>Install from the registry</h3>
+        <CodeBlock>{`asm install code-review
+asm install luongnv89/code-review
+asm install code-review --no-cache`}</CodeBlock>
+        <p>
+          <code>asm install</code> resolves the name against the registry index,
+          downloads the manifest, clones the pinned commit, and installs the
+          skill.
+        </p>
+
+        <h3>Publish your skill</h3>
+        <CodeBlock>{`asm publish ./my-skill`}</CodeBlock>
+        <p>
+          The publish pipeline validates your <code>SKILL.md</code>, runs a
+          security audit, generates a signed manifest with the current commit
+          SHA, and automatically opens a pull request against the registry via
+          the{" "}
+          <a
+            href="https://cli.github.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <code>gh</code> CLI
+          </a>
+          .
+        </p>
+        <CodeBlock>{`asm publish --dry-run ./my-skill   # preview manifest, no PR
+asm publish --force ./my-skill    # override security warnings
+asm publish --yes ./my-skill      # skip confirmation (CI)`}</CodeBlock>
+
+        <h3>Publish flags</h3>
+        <FlagTable
+          rows={[
+            ["--dry-run", "Preview the manifest without creating a PR"],
+            ["--force", "Override warning-level security findings"],
+            ["--yes", "Skip the confirmation prompt"],
+            ["--machine", "Output as a machine-readable JSON envelope"],
+          ]}
+        />
+
+        <h3>How registry resolution works</h3>
+        <ol>
+          <li>
+            <code>asm install code-review</code> fetches the registry index
+            (cached 1 hour)
+          </li>
+          <li>
+            Finds the manifest for <code>code-review</code> — including pinned{" "}
+            <code>commit</code> and <code>skill_path</code>
+          </li>
+          <li>
+            Clones the repo at that exact commit and navigates to the skill
+            subdirectory
+          </li>
+          <li>
+            Installs as if you ran{" "}
+            <code>asm install github:author/repo#commit:path</code>
+          </li>
+        </ol>
+        <p>
+          If multiple authors publish the same name, <code>asm</code> shows a
+          disambiguation prompt. Use a scoped name (<code>author/skill</code>)
+          to skip it.
+        </p>
+      </section>
+
+      <section className="doc-section">
+        <h2>TUI Keyboard Shortcuts</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <KeyRow k="↑/↓ or j/k" a="Navigate skill list" />
+            <KeyRow k="Enter" a="View skill details" />
+            <KeyRow k="d" a="Uninstall selected skill" />
+            <KeyRow k="/" a="Search / filter skills" />
+            <KeyRow k="Esc" a="Back / clear filter / close dialog" />
+            <KeyRow k="Tab" a="Cycle scope: Global → Project → Both" />
+            <KeyRow k="s" a="Cycle sort: Name → Version → Location" />
+            <KeyRow k="r" a="Refresh / rescan skills" />
+            <KeyRow k="c" a="Open configuration" />
+            <KeyRow k="a" a="Audit duplicates" />
+            <KeyRow k="q" a="Quit" />
+          </tbody>
+        </table>
+      </section>
+    </article>
+  );
+}
+
+function Row({ cmd, desc }) {
+  return (
+    <tr>
+      <td>
+        <code>{cmd}</code>
+      </td>
+      <td>{desc}</td>
+    </tr>
+  );
+}
+
+function FlagTable({ rows }) {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Flag</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(([flag, desc]) => (
+          <tr key={flag}>
+            <td>
+              <code>{flag}</code>
+            </td>
+            <td>{desc}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function FieldRow({ name, req, desc }) {
+  return (
+    <tr>
+      <td>
+        <code>{name}</code>
+      </td>
+      <td>{req}</td>
+      <td>{desc}</td>
+    </tr>
+  );
+}
+
+function ToolRow({ tool, g, p }) {
+  return (
+    <tr>
+      <td>{tool}</td>
+      <td>
+        <code>{g}</code>
+      </td>
+      <td>
+        <code>{p}</code>
+      </td>
+    </tr>
+  );
+}
+
+function KeyRow({ k, a }) {
+  return (
+    <tr>
+      <td>
+        <code>{k}</code>
+      </td>
+      <td>{a}</td>
+    </tr>
+  );
+}
+
+function CodeBlock({ children }) {
+  return (
+    <pre>
+      <code>{children}</code>
+    </pre>
+  );
+}


### PR DESCRIPTION
## Summary
- **Header**: restore Docs / Changelog links (point at the repo README and CHANGELOG.md), a version pill sourced from the loaded catalog, and a GitHub link with star count when available. Also moves `owner/repo` out of the `SkillListItem` header row so long skill names get the full width and stop wrapping into 3–4 lines.
- **Performance**: the sidebar was rendering all 6,783 `<SkillListItem>` nodes, which caused ~10s click latency. Profiling showed React committed in ~22ms — the rest was browser layout / style recalc across the full list whenever the `active` class flipped. Memoize `SkillListItem` / `BundleListItem`, hoist `useLocation` up to the page, and replace the flat `.map()` with a `react-window` `<List>` so only the visible rows (+4 overscan) live in the DOM. Selection now feels instant.
- **Repo URL**: update GitHub URLs from `luongnv89/agent-skill-manager` → `luongnv89/asm` (the repo rename) in Header, Footer, `package.json` (homepage / repository / bugs), and two source comments. The npm package name itself is unchanged.

## Test plan
- [x] `npm run lint:site` passes
- [x] `npm run test:site` passes (19/19) — added a no-op `ResizeObserver` stub because `react-window` v2 subscribes to one on mount and jsdom doesn't ship it
- [x] `npm run build:site` succeeds
- [x] Manually verified locally: clicking any skill swaps the detail pane instantly instead of taking ~10s; nav shows logo / Skills / Bundles / Docs / Changelog / version / GitHub; scrolling the sidebar list renders new rows smoothly