### PR TITLE
feat(website): add bundle builder UI for custom skill bundles (#238)

### DIFF
--- a/website-src/src/App.jsx
+++ b/website-src/src/App.jsx
@@ -1,11 +1,14 @@
+import { useCallback, useState } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import Header from "./components/Header.jsx";
 import Footer from "./components/Footer.jsx";
+import BundleBuilderDialog from "./components/BundleBuilderDialog.jsx";
 import CatalogPage from "./pages/CatalogPage.jsx";
 import BundlesPage from "./pages/BundlesPage.jsx";
 import DocsPage from "./pages/DocsPage.jsx";
 import ChangelogPage from "./pages/ChangelogPage.jsx";
 import { CatalogProvider } from "./hooks/useCatalog.jsx";
+import { BundleCartProvider } from "./hooks/useBundleCart.jsx";
 
 /**
  * Root application shell.
@@ -19,25 +22,41 @@ import { CatalogProvider } from "./hooks/useCatalog.jsx";
  * the catalog is always a two-pane layout, and the `:id` in the URL
  * simply selects which skill shows in the detail pane. Same pattern
  * for `/bundles` and `/bundles/:name`.
+ *
+ * Bundle builder (#238): dialog state lives at the app shell so the
+ * header cart button (any route) can open it. The `BundleCartProvider`
+ * wraps everything so skill-level cart state is shared across pages.
  */
 export default function App() {
+  const [bundleBuilderOpen, setBundleBuilderOpen] = useState(false);
+  // Stable references so the dialog's mount effect (which listens on
+  // `onClose` in its dep array) doesn't re-fire on every App render and
+  // yank focus away from the form the user is typing into.
+  const openBuilder = useCallback(() => setBundleBuilderOpen(true), []);
+  const closeBuilder = useCallback(() => setBundleBuilderOpen(false), []);
   return (
     <CatalogProvider>
-      <div className="min-h-screen flex flex-col bg-[var(--bg)] text-[var(--fg)]">
-        <Header />
-        <main className="flex-1 w-full max-w-[1280px] mx-auto px-4 sm:px-6 py-6">
-          <Routes>
-            <Route path="/" element={<CatalogPage />} />
-            <Route path="/skills/:id" element={<CatalogPage />} />
-            <Route path="/bundles" element={<BundlesPage />} />
-            <Route path="/bundles/:name" element={<BundlesPage />} />
-            <Route path="/docs" element={<DocsPage />} />
-            <Route path="/changelog" element={<ChangelogPage />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
-        </main>
-        <Footer />
-      </div>
+      <BundleCartProvider>
+        <div className="min-h-screen flex flex-col bg-[var(--bg)] text-[var(--fg)]">
+          <Header onOpenBundleBuilder={openBuilder} />
+          <main className="flex-1 w-full max-w-[1280px] mx-auto px-4 sm:px-6 py-6">
+            <Routes>
+              <Route path="/" element={<CatalogPage />} />
+              <Route path="/skills/:id" element={<CatalogPage />} />
+              <Route path="/bundles" element={<BundlesPage />} />
+              <Route path="/bundles/:name" element={<BundlesPage />} />
+              <Route path="/docs" element={<DocsPage />} />
+              <Route path="/changelog" element={<ChangelogPage />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </main>
+          <Footer />
+          <BundleBuilderDialog
+            open={bundleBuilderOpen}
+            onClose={closeBuilder}
+          />
+        </div>
+      </BundleCartProvider>
     </CatalogProvider>
   );
 }

--- a/website-src/src/__tests__/bundle-cart.test.jsx
+++ b/website-src/src/__tests__/bundle-cart.test.jsx
@@ -1,0 +1,306 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
+/**
+ * Vitest/jsdom 25 ships `localStorage` as a plain object without Storage
+ * methods, which breaks the cart's persistence layer. Install a minimal
+ * in-memory Storage shim on both `window.localStorage` and
+ * `globalThis.localStorage` so the provider's `setItem`/`getItem` calls
+ * work under test.
+ */
+function installLocalStorageShim() {
+  const store = new Map();
+  const shim = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => void store.set(k, String(v)),
+    removeItem: (k) => void store.delete(k),
+    clear: () => void store.clear(),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  Object.defineProperty(window, "localStorage", {
+    value: shim,
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    value: shim,
+    configurable: true,
+  });
+}
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { HashRouter } from "react-router-dom";
+import MiniSearch from "minisearch";
+import App from "../App.jsx";
+import { MINISEARCH_OPTIONS } from "../lib/minisearch-options.js";
+
+/**
+ * Bundle cart flow (#238). Covers:
+ *   - add-to-bundle button in a list row doesn't navigate (it must
+ *     call preventDefault on the wrapping <Link>)
+ *   - cart count in the header reflects selections
+ *   - opening the builder shows the skill, validates metadata, and
+ *     can trigger the export path
+ */
+const generatedAt = "2026-04-24T00:00:00.000Z";
+
+const catalog = {
+  generatedAt,
+  totalSkills: 2,
+  totalRepos: 1,
+  skills: [
+    {
+      id: "owner/repo::a::hello-world",
+      detailPath: "skills/hello.json",
+      name: "hello-world",
+      description: "A friendly greeting skill.",
+      owner: "owner",
+      repo: "repo",
+      categories: ["demo"],
+      installUrl: "github:owner/repo:skills/hello-world",
+      license: "MIT",
+      version: "1.0.0",
+      verified: true,
+      hasTools: false,
+      tokenCount: 300,
+    },
+    {
+      id: "owner/repo::b::readme-gen",
+      detailPath: "skills/readme.json",
+      name: "readme-generator",
+      description: "Generates great READMEs.",
+      owner: "owner",
+      repo: "repo",
+      categories: ["docs"],
+      installUrl: "github:owner/repo:skills/readme-gen",
+      license: "MIT",
+      version: "0.1.0",
+      verified: false,
+      hasTools: false,
+      tokenCount: 500,
+    },
+  ],
+  categories: ["demo", "docs"],
+  repos: [{ owner: "owner", repo: "repo", skillCount: 2 }],
+  stars: 0,
+};
+
+function buildIndexJson() {
+  const ms = new MiniSearch(MINISEARCH_OPTIONS);
+  ms.addAll(
+    catalog.skills.map((s, i) => ({
+      id: i,
+      name: s.name,
+      description: s.description,
+      categoriesStr: s.categories.join(" "),
+    })),
+  );
+  const payload = ms.toJSON();
+  payload.generatedAt = generatedAt;
+  return JSON.stringify(payload);
+}
+
+const FETCH_MAP = {
+  "skills.min.json": () => new Response(JSON.stringify(catalog)),
+  "search.idx.json": () => new Response(buildIndexJson()),
+  "bundles.json": () => new Response(JSON.stringify({ bundles: [] })),
+  "skills/hello.json": () => new Response(JSON.stringify(catalog.skills[0])),
+};
+
+function mockFetch() {
+  return vi.fn(async (url) => {
+    for (const [suffix, fn] of Object.entries(FETCH_MAP)) {
+      if (String(url).endsWith(suffix)) return fn();
+    }
+    return new Response("not found", { status: 404 });
+  });
+}
+
+describe("Bundle cart flow", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+    globalThis.fetch = mockFetch();
+    installLocalStorageShim();
+  });
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("adding a skill from the list increments the cart without navigating", async () => {
+    const { container } = render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </HashRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("hello-world")).toBeTruthy());
+
+    // Find the compact add-to-bundle button on the hello-world row
+    const helloAddBtn = screen.getByRole("button", {
+      name: /Add hello-world to bundle/i,
+    });
+    expect(helloAddBtn).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(helloAddBtn);
+    });
+
+    // Cart count should appear in the header
+    await waitFor(() => {
+      const count = container.querySelector(
+        "[data-testid='bundle-cart-count']",
+      );
+      expect(count?.textContent).toBe("1");
+    });
+
+    // URL should still be the catalog root — no navigation happened
+    expect(window.location.hash).not.toContain("/skills/");
+
+    // Click again to toggle off
+    const helloRemoveBtn = screen.getByRole("button", {
+      name: /Remove hello-world from bundle/i,
+    });
+    await act(async () => {
+      fireEvent.click(helloRemoveBtn);
+    });
+    await waitFor(() => {
+      const count = container.querySelector(
+        "[data-testid='bundle-cart-count']",
+      );
+      expect(count).toBeNull();
+    });
+  });
+
+  it("opens the builder dialog and validates the bundle name", async () => {
+    const { container } = render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </HashRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("hello-world")).toBeTruthy());
+
+    // Add one skill
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /Add hello-world to bundle/i }),
+      );
+    });
+
+    // Open the builder via the header cart button
+    const cartBtn = screen.getByRole("button", {
+      name: /Open bundle builder/i,
+    });
+    await act(async () => {
+      fireEvent.click(cartBtn);
+    });
+
+    // The dialog renders with the skill visible (labelled by the h2)
+    const dialog = await screen.findByRole("dialog", {
+      name: /Build a bundle/i,
+    });
+    expect(dialog).toBeTruthy();
+    expect(screen.getByText(/skills? in this bundle/i)).toBeTruthy();
+    // The skill name should appear in the dialog item list
+    const withinDialog = dialog.querySelectorAll("li");
+    expect(withinDialog.length).toBe(1);
+
+    // Export button is enabled (there's ≥1 skill) but the name is blank,
+    // so clicking should show a validation error message
+    const exportBtn = screen.getByRole("button", { name: /Export \.json/i });
+    expect(exportBtn.disabled).toBe(false);
+    await act(async () => {
+      fireEvent.click(exportBtn);
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Bundle name is required/i)).toBeTruthy();
+    });
+
+    // Fill a valid name and publish (opens a new tab — stub window.open)
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const nameInput = container.querySelector("#bundle-name");
+    expect(nameInput).toBeTruthy();
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "my-test-pack" } });
+    });
+    const publishBtn = screen.getByRole("button", { name: /^Publish/i });
+    await act(async () => {
+      fireEvent.click(publishBtn);
+    });
+    expect(openSpy).toHaveBeenCalledOnce();
+    const urlArg = openSpy.mock.calls[0][0];
+    expect(urlArg).toMatch(/github\.com\/luongnv89\/asm\/issues\/new/);
+    expect(urlArg).toContain("my-test-pack");
+    openSpy.mockRestore();
+  });
+
+  it("persists the cart across remounts via localStorage", async () => {
+    const first = render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </HashRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("hello-world")).toBeTruthy());
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /Add hello-world to bundle/i }),
+      );
+    });
+    await waitFor(() => {
+      expect(
+        first.container.querySelector("[data-testid='bundle-cart-count']")
+          ?.textContent,
+      ).toBe("1");
+    });
+
+    // Confirm the provider persisted to localStorage before unmounting.
+    const saved = JSON.parse(
+      window.localStorage.getItem("asm-bundle-cart:v1") || "{}",
+    );
+    expect(saved.items?.length).toBe(1);
+    expect(saved.items[0].name).toBe("hello-world");
+
+    first.unmount();
+
+    const second = render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </HashRouter>,
+    );
+    await waitFor(() =>
+      expect(
+        second.container.querySelectorAll("[aria-label='Skill results'] a")
+          .length,
+      ).toBeGreaterThan(0),
+    );
+    await waitFor(() => {
+      const count = second.container.querySelector(
+        "[data-testid='bundle-cart-count']",
+      );
+      expect(count?.textContent).toBe("1");
+    });
+  });
+});

--- a/website-src/src/__tests__/bundle-cart.test.jsx
+++ b/website-src/src/__tests__/bundle-cart.test.jsx
@@ -235,12 +235,20 @@ describe("Bundle cart flow", () => {
       expect(screen.getByText(/Bundle name is required/i)).toBeTruthy();
     });
 
-    // Fill a valid name and publish (opens a new tab — stub window.open)
+    // Fill a valid name + description + author (all three required —
+    // mirrors the CLI's validateBundle) and publish. Opens a new tab
+    // so we stub window.open.
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
     const nameInput = container.querySelector("#bundle-name");
+    const descInput = container.querySelector("#bundle-description");
+    const authorInput = container.querySelector("#bundle-author");
     expect(nameInput).toBeTruthy();
+    expect(descInput).toBeTruthy();
+    expect(authorInput).toBeTruthy();
     await act(async () => {
       fireEvent.change(nameInput, { target: { value: "my-test-pack" } });
+      fireEvent.change(descInput, { target: { value: "A test pack." } });
+      fireEvent.change(authorInput, { target: { value: "alice" } });
     });
     const publishBtn = screen.getByRole("button", { name: /^Publish/i });
     await act(async () => {

--- a/website-src/src/__tests__/bundle-export.test.js
+++ b/website-src/src/__tests__/bundle-export.test.js
@@ -71,21 +71,46 @@ describe("buildBundleJson", () => {
 });
 
 describe("validateBundleForm", () => {
-  it("requires a name and ≥1 skill", () => {
+  it("requires name, description, author, and ≥1 skill", () => {
     const errors = validateBundleForm({ name: "" }, []);
     const fields = errors.map((e) => e.field);
     expect(fields).toContain("name");
+    expect(fields).toContain("description");
+    expect(fields).toContain("author");
     expect(fields).toContain("skills");
   });
 
+  it("flags an empty description even when name and skills are valid", () => {
+    const errors = validateBundleForm(
+      { name: "ok-name", description: "  ", author: "alice" },
+      SKILLS,
+    );
+    expect(errors.map((e) => e.field)).toEqual(["description"]);
+  });
+
+  it("flags an empty author even when name and skills are valid", () => {
+    const errors = validateBundleForm(
+      { name: "ok-name", description: "has one", author: "" },
+      SKILLS,
+    );
+    expect(errors.map((e) => e.field)).toEqual(["author"]);
+  });
+
   it("rejects invalid name characters", () => {
-    const errors = validateBundleForm({ name: "bad name!" }, SKILLS);
+    const errors = validateBundleForm(
+      { name: "bad name!", description: "d", author: "a" },
+      SKILLS,
+    );
     expect(errors.some((e) => e.field === "name")).toBe(true);
   });
 
   it("accepts a sensible valid form", () => {
     const errors = validateBundleForm(
-      { name: "content.pack_v2-alpha" },
+      {
+        name: "content.pack_v2-alpha",
+        description: "A curated pack.",
+        author: "alice",
+      },
       SKILLS,
     );
     expect(errors).toEqual([]);
@@ -131,6 +156,28 @@ describe("buildIssueUrl", () => {
     expect(body).not.toContain(
       `#/skills/${encodeURIComponent(SKILLS[0].installUrl)}`,
     );
+  });
+
+  it("truncates even when the final single skill would overflow the budget", () => {
+    // Regression test: earlier the truncation guard had a `i < skills.length - 1`
+    // clause that let the last row through unconditionally, which could push
+    // the encoded body past the cap on a bundle where one very large skill
+    // sits at the end.
+    const bulkyDescription = "x".repeat(2000);
+    const skills = [
+      {
+        id: "o/r::x::huge",
+        name: "huge-skill",
+        installUrl: "github:o/r:skills/huge-skill",
+        description: bulkyDescription,
+      },
+    ];
+    const url = buildIssueUrl(skills, { name: "one" }, { maxBodyBytes: 500 });
+    const body = new URLSearchParams(url.split("?")[1]).get("body");
+    // The single bulky row should be replaced by the "…N more" note
+    // rather than appended, keeping the body inside (header + footer + note).
+    expect(body).toMatch(/more\*\* skill/);
+    expect(body).not.toContain(bulkyDescription);
   });
 
   it("keeps the whole URL within the encoded byte limit under large bundles", () => {

--- a/website-src/src/__tests__/bundle-export.test.js
+++ b/website-src/src/__tests__/bundle-export.test.js
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBundleJson,
+  buildIssueUrl,
+  validateBundleForm,
+} from "../lib/bundle-export.js";
+
+const NOW = new Date("2026-04-24T12:00:00.000Z");
+
+const SKILLS = [
+  {
+    id: "owner/repo::a::hello-world",
+    name: "hello-world",
+    installUrl: "github:owner/repo:skills/hello-world",
+    description: "A friendly greeting skill.",
+    version: "1.0.0",
+  },
+  {
+    id: "owner/repo::b::readme-gen",
+    name: "readme-generator",
+    installUrl: "github:owner/repo:skills/readme-gen",
+    description: "Generates great READMEs.",
+    version: "0.0.0",
+  },
+];
+
+describe("buildBundleJson", () => {
+  it("produces a BundleManifest with the required fields", () => {
+    const meta = {
+      name: "my-pack",
+      description: "A test pack.",
+      author: "alice",
+      tags: "demo, docs",
+    };
+    const bundle = buildBundleJson(SKILLS, meta, NOW);
+    expect(bundle).toMatchObject({
+      version: 1,
+      name: "my-pack",
+      description: "A test pack.",
+      author: "alice",
+      createdAt: NOW.toISOString(),
+      tags: ["demo", "docs"],
+    });
+    expect(bundle.skills).toHaveLength(2);
+    expect(bundle.skills[0]).toEqual({
+      name: "hello-world",
+      installUrl: "github:owner/repo:skills/hello-world",
+      description: "A friendly greeting skill.",
+      version: "1.0.0",
+    });
+    // version "0.0.0" is the default sentinel and should be omitted
+    expect(bundle.skills[1].version).toBeUndefined();
+  });
+
+  it("omits tags when empty and trims metadata", () => {
+    const bundle = buildBundleJson(
+      [SKILLS[0]],
+      {
+        name: "  trimmed  ",
+        description: " with space ",
+        author: "  bob ",
+        tags: "  ",
+      },
+      NOW,
+    );
+    expect(bundle.name).toBe("trimmed");
+    expect(bundle.description).toBe("with space");
+    expect(bundle.author).toBe("bob");
+    expect(bundle.tags).toBeUndefined();
+  });
+});
+
+describe("validateBundleForm", () => {
+  it("requires a name and ≥1 skill", () => {
+    const errors = validateBundleForm({ name: "" }, []);
+    const fields = errors.map((e) => e.field);
+    expect(fields).toContain("name");
+    expect(fields).toContain("skills");
+  });
+
+  it("rejects invalid name characters", () => {
+    const errors = validateBundleForm({ name: "bad name!" }, SKILLS);
+    expect(errors.some((e) => e.field === "name")).toBe(true);
+  });
+
+  it("accepts a sensible valid form", () => {
+    const errors = validateBundleForm(
+      { name: "content.pack_v2-alpha" },
+      SKILLS,
+    );
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("buildIssueUrl", () => {
+  it("produces a github issues URL with title/body/labels", () => {
+    const url = buildIssueUrl(SKILLS, {
+      name: "my-pack",
+      description: "Short desc",
+      author: "alice",
+      tags: "docs",
+    });
+    expect(url).toMatch(
+      /^https:\/\/github\.com\/luongnv89\/asm\/issues\/new\?/,
+    );
+    const qs = new URLSearchParams(url.split("?")[1]);
+    expect(qs.get("title")).toBe("[FEATURE] Bundle: my-pack");
+    expect(qs.get("labels")).toBe("enhancement,feature");
+    const body = qs.get("body");
+    expect(body).toContain("my-pack");
+    expect(body).toContain("alice");
+    expect(body).toContain("hello-world");
+    expect(body).toContain("readme-generator");
+  });
+
+  it("uses each skill's id (not installUrl) for the catalog deep link", () => {
+    // The router's `useParams` decodes via `decodeSkillId(encodedId)`,
+    // so the link target must be the skill `id`. Passing installUrl
+    // here would 404 every link in the published issue.
+    const url = buildIssueUrl(
+      [SKILLS[0]],
+      { name: "one" },
+      { catalogBaseUrl: "https://example.test/asm/" },
+    );
+    const body = new URLSearchParams(url.split("?")[1]).get("body");
+    const expectedLink = `https://example.test/asm/#/skills/${encodeURIComponent(
+      SKILLS[0].id,
+    )}`;
+    expect(body).toContain(expectedLink);
+    // And must NOT fall back to the installUrl
+    expect(body).not.toContain(
+      `#/skills/${encodeURIComponent(SKILLS[0].installUrl)}`,
+    );
+  });
+
+  it("keeps the whole URL within the encoded byte limit under large bundles", () => {
+    const many = Array.from({ length: 200 }, (_, i) => ({
+      id: `o/r::x::sk-${i}`,
+      name: `skill-${i}-name-that-is-somewhat-long-to-consume-bytes`,
+      installUrl: `github:o/r:skills/skill-${i}-name-that-is-somewhat-long-to-consume-bytes`,
+      description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    }));
+    const maxBodyBytes = 3000;
+    const url = buildIssueUrl(many, { name: "big" }, { maxBodyBytes });
+    const body = new URLSearchParams(url.split("?")[1]).get("body");
+    expect(body).toMatch(/more\*\* skill/);
+    // Encoded body (what actually goes into the URL) stays within cap +
+    // a small overhead for header/footer + truncation note.
+    expect(encodeURIComponent(body).length).toBeLessThan(maxBodyBytes + 1500);
+  });
+});

--- a/website-src/src/components/AddToBundleButton.jsx
+++ b/website-src/src/components/AddToBundleButton.jsx
@@ -1,0 +1,82 @@
+import { Check, Plus } from "lucide-react";
+import { useBundleCart } from "../hooks/useBundleCart.jsx";
+import { cn } from "../lib/cn.js";
+
+/**
+ * Toggle button that adds/removes a skill from the bundle cart.
+ *
+ * The `compact` variant is a 24px icon button used inside the
+ * `SkillListItem` card. Because that card is wrapped in a
+ * `<Link>`, the click handler must stop propagation and prevent
+ * default — otherwise the browser navigates to the skill detail
+ * route on click instead of toggling cart membership.
+ *
+ * The `default` variant is a full button for the `SkillDetail`
+ * action area.
+ */
+export default function AddToBundleButton({ skill, compact = false }) {
+  const { add, remove, has } = useBundleCart();
+  if (!skill || !skill.id || !skill.installUrl) return null;
+  const inCart = has(skill.id);
+
+  const handleClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (inCart) remove(skill.id);
+    else add(skill);
+  };
+
+  if (compact) {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-label={
+          inCart
+            ? `Remove ${skill.name} from bundle`
+            : `Add ${skill.name} to bundle`
+        }
+        aria-pressed={inCart}
+        className={cn(
+          "shrink-0 inline-flex items-center justify-center rounded h-6 w-6 text-[11px] transition-colors",
+          inCart
+            ? "bg-[var(--brand)] text-[var(--bg)] hover:bg-[var(--brand-dim)]"
+            : "border border-[var(--border)] text-[var(--fg-dim)] hover:text-[var(--brand)] hover:border-[var(--brand)]",
+        )}
+        title={inCart ? "In bundle — click to remove" : "Add to bundle"}
+      >
+        {inCart ? (
+          <Check className="h-3.5 w-3.5" aria-hidden="true" />
+        ) : (
+          <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-pressed={inCart}
+      className={cn(
+        "inline-flex items-center justify-center gap-1.5 rounded-md text-sm font-medium transition-colors h-9 px-3 py-2",
+        inCart
+          ? "bg-[var(--brand)] text-[var(--bg)] hover:bg-[var(--brand-dim)]"
+          : "border border-[var(--border)] bg-transparent text-[var(--fg-dim)] hover:border-[var(--brand)] hover:text-[var(--fg)]",
+      )}
+    >
+      {inCart ? (
+        <>
+          <Check className="h-4 w-4" aria-hidden="true" />
+          In bundle
+        </>
+      ) : (
+        <>
+          <Plus className="h-4 w-4" aria-hidden="true" />
+          Add to bundle
+        </>
+      )}
+    </button>
+  );
+}

--- a/website-src/src/components/BundleBuilderDialog.jsx
+++ b/website-src/src/components/BundleBuilderDialog.jsx
@@ -124,6 +124,7 @@ export default function BundleBuilderDialog({ open, onClose }) {
         type="button"
         aria-label="Close bundle builder"
         onClick={onClose}
+        tabIndex={-1}
         className="absolute inset-0 bg-black/60"
       />
       <div

--- a/website-src/src/components/BundleBuilderDialog.jsx
+++ b/website-src/src/components/BundleBuilderDialog.jsx
@@ -1,0 +1,346 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { X, Download, Github, Trash2, ExternalLink } from "lucide-react";
+import { useBundleCart } from "../hooks/useBundleCart.jsx";
+import {
+  buildBundleJson,
+  buildIssueUrl,
+  downloadBundleJson,
+  validateBundleForm,
+} from "../lib/bundle-export.js";
+import { Button } from "./ui/button.jsx";
+import { Input } from "./ui/input.jsx";
+import { cn } from "../lib/cn.js";
+
+/**
+ * Bundle builder dialog (#238). Opens from the header cart button
+ * and lets the user review selected skills, fill bundle metadata,
+ * and either export a `.json` or publish a pre-filled feature
+ * request issue.
+ *
+ * Kept deliberately framework-free (no @radix-ui/react-dialog) to
+ * match the existing `SidebarDrawer` approach — a single flexible
+ * surface is fine for one modal.
+ */
+export default function BundleBuilderDialog({ open, onClose }) {
+  const { items, remove, clear, meta, setMeta } = useBundleCart();
+  const closeBtnRef = useRef(null);
+  const panelRef = useRef(null);
+  const returnFocusRef = useRef(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    // Remember the element focused at open time so we can return focus
+    // when the dialog closes — a baseline expectation for modal dialogs.
+    returnFocusRef.current =
+      typeof document !== "undefined" ? document.activeElement : null;
+
+    const onKey = (e) => {
+      if (e.key === "Escape") {
+        onClose?.();
+        return;
+      }
+      // Tab trap: cycle Tab / Shift-Tab within the panel so keyboard
+      // users can't accidentally reach the page underneath.
+      if (e.key === "Tab" && panelRef.current) {
+        const focusables = panelRef.current.querySelectorAll(
+          "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])",
+        );
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        const active = document.activeElement;
+        if (e.shiftKey && active === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    closeBtnRef.current?.focus();
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+      // Return focus to whatever opened the dialog.
+      const el = returnFocusRef.current;
+      if (el && typeof el.focus === "function") {
+        try {
+          el.focus();
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+  }, [open, onClose]);
+
+  const errors = useMemo(() => validateBundleForm(meta, items), [meta, items]);
+  const errorsByField = useMemo(() => {
+    const m = {};
+    for (const e of errors) m[e.field] = e.message;
+    return m;
+  }, [errors]);
+  const isValid = errors.length === 0;
+
+  if (!open) return null;
+
+  const handleExport = () => {
+    setSubmitted(true);
+    if (!isValid) return;
+    const bundle = buildBundleJson(items, meta);
+    downloadBundleJson(bundle);
+  };
+
+  const handlePublish = () => {
+    setSubmitted(true);
+    if (!isValid) return;
+    const url = buildIssueUrl(items, meta);
+    window.open(url, "_blank", "noopener,noreferrer");
+  };
+
+  const handleClear = () => {
+    if (items.length === 0) return;
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm("Clear all skills from this bundle?")
+    ) {
+      return;
+    }
+    clear();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="bundle-builder-title"
+      className="fixed inset-0 z-50 flex items-stretch sm:items-center justify-center p-0 sm:p-4"
+    >
+      <button
+        type="button"
+        aria-label="Close bundle builder"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60"
+      />
+      <div
+        ref={panelRef}
+        className={cn(
+          "relative w-full sm:max-w-2xl max-h-[100dvh] sm:max-h-[90vh] overflow-y-auto",
+          "rounded-none sm:rounded-lg border border-[var(--border)] bg-[var(--bg)] shadow-xl",
+          "flex flex-col",
+        )}
+      >
+        <header className="flex items-center justify-between gap-2 border-b border-[var(--border)] px-5 py-3 sticky top-0 bg-[var(--bg)] z-10">
+          <div>
+            <h2
+              id="bundle-builder-title"
+              className="text-lg font-semibold text-[var(--fg)]"
+            >
+              Build a bundle
+            </h2>
+            <p className="text-xs text-[var(--fg-dim)]">
+              {items.length === 0
+                ? "No skills selected yet. Add skills from the catalog to get started."
+                : `${items.length} ${items.length === 1 ? "skill" : "skills"} in this bundle`}
+            </p>
+          </div>
+          <Button
+            ref={closeBtnRef}
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </header>
+
+        <div className="flex-1 px-5 py-4 flex flex-col gap-5">
+          <fieldset className="flex flex-col gap-3">
+            <legend className="text-xs uppercase tracking-wide text-[var(--fg-muted)]">
+              Bundle metadata
+            </legend>
+            <Field
+              id="bundle-name"
+              label="Name"
+              hint="Short identifier. Letters, digits, '.', '_', '-' (max 64)."
+              error={submitted ? errorsByField.name : undefined}
+              required
+            >
+              <Input
+                id="bundle-name"
+                value={meta.name}
+                onChange={(e) => setMeta({ name: e.target.value })}
+                placeholder="content-writing"
+                aria-invalid={submitted && !!errorsByField.name}
+                autoComplete="off"
+              />
+            </Field>
+            <Field
+              id="bundle-description"
+              label="Description"
+              hint="One or two sentences about what the bundle does."
+            >
+              <textarea
+                id="bundle-description"
+                value={meta.description}
+                onChange={(e) => setMeta({ description: e.target.value })}
+                placeholder="Content creation and marketing skills…"
+                rows={2}
+                className="flex w-full rounded-md border border-[var(--border)] bg-[var(--bg-input)] px-3 py-2 text-sm text-[var(--fg)] placeholder:text-[var(--fg-muted)] focus-visible:outline-none focus-visible:border-[var(--brand)] focus-visible:ring-2 focus-visible:ring-[var(--border-focus)]"
+              />
+            </Field>
+            <div className="grid sm:grid-cols-2 gap-3">
+              <Field id="bundle-author" label="Author">
+                <Input
+                  id="bundle-author"
+                  value={meta.author}
+                  onChange={(e) => setMeta({ author: e.target.value })}
+                  placeholder="your-name"
+                  autoComplete="off"
+                />
+              </Field>
+              <Field
+                id="bundle-tags"
+                label="Tags"
+                hint="Comma-separated, optional."
+              >
+                <Input
+                  id="bundle-tags"
+                  value={meta.tags}
+                  onChange={(e) => setMeta({ tags: e.target.value })}
+                  placeholder="content, marketing"
+                  autoComplete="off"
+                />
+              </Field>
+            </div>
+          </fieldset>
+
+          <section className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xs uppercase tracking-wide text-[var(--fg-muted)]">
+                Skills ({items.length})
+              </h3>
+              {items.length > 0 && (
+                <button
+                  type="button"
+                  onClick={handleClear}
+                  className="text-[11px] text-[var(--fg-dim)] hover:text-[var(--warn)] inline-flex items-center gap-1"
+                >
+                  <Trash2 className="h-3 w-3" aria-hidden="true" />
+                  Clear all
+                </button>
+              )}
+            </div>
+            {submitted && errorsByField.skills && (
+              <p className="text-xs text-[var(--warn)]">
+                ⚠ {errorsByField.skills}
+              </p>
+            )}
+            {items.length === 0 ? (
+              <p className="text-sm text-[var(--fg-dim)] border border-dashed border-[var(--border)] rounded-md px-4 py-6 text-center">
+                Your bundle is empty. Close this dialog and click{" "}
+                <span className="font-medium text-[var(--fg)]">
+                  Add to bundle
+                </span>{" "}
+                on any skill to start building.
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-1.5" role="list">
+                {items.map((sk) => (
+                  <li
+                    key={sk.id}
+                    className="flex items-start justify-between gap-2 rounded-md border border-[var(--border)] bg-[var(--bg-card)] px-3 py-2"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-sm text-[var(--fg)] truncate">
+                          {sk.name}
+                        </span>
+                        {sk.owner && sk.repo && (
+                          <span className="text-[10px] text-[var(--fg-muted)] truncate">
+                            {sk.owner}/{sk.repo}
+                          </span>
+                        )}
+                      </div>
+                      {sk.description && (
+                        <p className="text-xs text-[var(--fg-dim)] line-clamp-2">
+                          {sk.description}
+                        </p>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => remove(sk.id)}
+                      aria-label={`Remove ${sk.name} from bundle`}
+                      className="shrink-0 text-[var(--fg-muted)] hover:text-[var(--warn)] px-1.5 py-1 rounded"
+                    >
+                      <X className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+
+        <footer className="border-t border-[var(--border)] px-5 py-3 flex flex-wrap items-center justify-end gap-2 sticky bottom-0 bg-[var(--bg)]">
+          <p className="mr-auto text-[11px] text-[var(--fg-muted)] max-w-[280px]">
+            Export installs via{" "}
+            <code className="text-[var(--brand)]">asm bundle install</code>.
+            Publish opens a pre-filled feature request.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleExport}
+            disabled={items.length === 0}
+            className="gap-1.5"
+          >
+            <Download className="h-4 w-4" aria-hidden="true" />
+            Export .json
+          </Button>
+          <Button
+            type="button"
+            onClick={handlePublish}
+            disabled={items.length === 0}
+            className="gap-1.5"
+          >
+            <Github className="h-4 w-4" aria-hidden="true" />
+            Publish
+            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function Field({ id, label, hint, error, required, children }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label
+        htmlFor={id}
+        className="text-xs font-medium text-[var(--fg-dim)] flex items-center gap-1"
+      >
+        {label}
+        {required && (
+          <span className="text-[var(--warn)]" aria-hidden="true">
+            *
+          </span>
+        )}
+      </label>
+      {children}
+      {error ? (
+        <p className="text-[11px] text-[var(--warn)]">⚠ {error}</p>
+      ) : hint ? (
+        <p className="text-[11px] text-[var(--fg-muted)]">{hint}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/website-src/src/components/BundleCartButton.jsx
+++ b/website-src/src/components/BundleCartButton.jsx
@@ -1,0 +1,36 @@
+import { ShoppingCart } from "lucide-react";
+import { useBundleCart } from "../hooks/useBundleCart.jsx";
+
+/**
+ * Header pill that shows the current bundle-cart count and opens
+ * the builder dialog on click. Rendered in `Header.jsx` so it stays
+ * visible on every route (Skills, Bundles, Docs, Changelog).
+ */
+export default function BundleCartButton({ onOpen }) {
+  const { items } = useBundleCart();
+  const count = items.length;
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label={
+        count === 0
+          ? "Open bundle builder"
+          : `Open bundle builder (${count} ${count === 1 ? "skill" : "skills"} in cart)`
+      }
+      className="flex items-center gap-1.5 text-[var(--fg-dim)] hover:text-[var(--brand)] hover:border-[var(--brand)] text-sm px-2.5 py-1 border border-[var(--border)] rounded-md transition-colors"
+      title="Bundle builder"
+    >
+      <ShoppingCart className="w-4 h-4" aria-hidden="true" />
+      <span className="hidden sm:inline">Bundle</span>
+      {count > 0 && (
+        <span
+          className="font-mono text-[11px] text-[var(--brand)]"
+          data-testid="bundle-cart-count"
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/website-src/src/components/Header.jsx
+++ b/website-src/src/components/Header.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, NavLink } from "react-router-dom";
 import { useCatalog } from "../hooks/useCatalog.jsx";
+import BundleCartButton from "./BundleCartButton.jsx";
 
 function applyTheme(next) {
   document.documentElement.setAttribute("data-theme", next);
@@ -21,7 +22,7 @@ function formatStars(n) {
   return String(n);
 }
 
-export default function Header() {
+export default function Header({ onOpenBundleBuilder }) {
   const { catalog } = useCatalog();
   const version = catalog?.version;
   const stars = formatStars(catalog?.stars);
@@ -100,6 +101,9 @@ export default function Header() {
             >
               v{version}
             </span>
+          )}
+          {onOpenBundleBuilder && (
+            <BundleCartButton onOpen={onOpenBundleBuilder} />
           )}
           <button
             type="button"

--- a/website-src/src/components/SkillDetail.jsx
+++ b/website-src/src/components/SkillDetail.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { evalScoreClass, formatTokens } from "../lib/utils.js";
 import CopyButton from "./CopyButton.jsx";
+import AddToBundleButton from "./AddToBundleButton.jsx";
 import { Badge } from "./ui/badge.jsx";
 import { Card } from "./ui/card.jsx";
 
@@ -214,6 +215,13 @@ export default function SkillDetail({ slim }) {
         </code>
         <CopyButton text={cmd} size="md" />
       </Card>
+
+      <div className="flex items-center gap-2">
+        <AddToBundleButton skill={skill} />
+        <span className="text-[11px] text-[var(--fg-muted)]">
+          Group this skill with others into an installable bundle.
+        </span>
+      </div>
 
       {skill.skillUrl && (
         <p className="text-xs">

--- a/website-src/src/components/SkillListItem.jsx
+++ b/website-src/src/components/SkillListItem.jsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { Link } from "react-router-dom";
 import { Wrench } from "lucide-react";
 import { Badge } from "./ui/badge.jsx";
+import AddToBundleButton from "./AddToBundleButton.jsx";
 import { cn } from "../lib/cn.js";
 import {
   evalScoreClass,
@@ -64,13 +65,16 @@ function SkillListItem({
           className="absolute left-0 top-2 bottom-2 w-[3px] rounded-r bg-[var(--brand)]"
         />
       )}
-      <span
-        className={cn(
-          "block text-sm font-semibold break-words",
-          active ? "text-[var(--brand)]" : "text-[var(--fg)]",
-        )}
-        dangerouslySetInnerHTML={{ __html: nameHtml }}
-      />
+      <div className="flex items-start justify-between gap-2">
+        <span
+          className={cn(
+            "block text-sm font-semibold break-words min-w-0 flex-1",
+            active ? "text-[var(--brand)]" : "text-[var(--fg)]",
+          )}
+          dangerouslySetInnerHTML={{ __html: nameHtml }}
+        />
+        <AddToBundleButton skill={skill} compact />
+      </div>
       <div className="mt-1 text-[10px] text-[var(--fg-muted)] truncate">
         {skill.owner}/{skill.repo}
       </div>

--- a/website-src/src/hooks/useBundleCart.jsx
+++ b/website-src/src/hooks/useBundleCart.jsx
@@ -1,0 +1,138 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+/**
+ * Bundle cart state + localStorage persistence (#238). Mirrors the
+ * `useCatalog` context pattern so consumers can subscribe from any
+ * route without prop-drilling.
+ *
+ * Persistence key is versioned (`asm-bundle-cart:v1`) so a future
+ * schema change can migrate instead of silently corrupting older
+ * carts. Reads are guarded against localStorage exceptions (Safari
+ * private mode, quota errors, server-side render).
+ */
+const STORAGE_KEY = "asm-bundle-cart:v1";
+
+const BundleCartContext = createContext({
+  items: [],
+  meta: { name: "", description: "", author: "", tags: "" },
+  add: () => {},
+  remove: () => {},
+  clear: () => {},
+  setMeta: () => {},
+  has: () => false,
+});
+
+const DEFAULT_META = { name: "", description: "", author: "", tags: "" };
+
+function loadInitial() {
+  if (typeof localStorage === "undefined") {
+    return { items: [], meta: { ...DEFAULT_META } };
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { items: [], meta: { ...DEFAULT_META } };
+    const parsed = JSON.parse(raw);
+    const items = Array.isArray(parsed?.items)
+      ? parsed.items.filter(isValidCartItem)
+      : [];
+    const meta =
+      parsed?.meta && typeof parsed.meta === "object"
+        ? {
+            name: stringField(parsed.meta.name),
+            description: stringField(parsed.meta.description),
+            author: stringField(parsed.meta.author),
+            tags: stringField(parsed.meta.tags),
+          }
+        : { ...DEFAULT_META };
+    return { items, meta };
+  } catch {
+    return { items: [], meta: { ...DEFAULT_META } };
+  }
+}
+
+function stringField(v) {
+  return typeof v === "string" ? v : "";
+}
+
+function isValidCartItem(item) {
+  return (
+    item &&
+    typeof item === "object" &&
+    typeof item.id === "string" &&
+    typeof item.name === "string" &&
+    typeof item.installUrl === "string"
+  );
+}
+
+export function BundleCartProvider({ children }) {
+  const initial = useRef(null);
+  if (initial.current === null) initial.current = loadInitial();
+  const [items, setItems] = useState(initial.current.items);
+  const [meta, setMetaState] = useState(initial.current.meta);
+
+  useEffect(() => {
+    if (typeof localStorage === "undefined") return;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ items, meta }));
+    } catch {
+      /* ignore quota / private-mode errors */
+    }
+  }, [items, meta]);
+
+  const add = useCallback((skill) => {
+    if (!skill || !skill.id) return;
+    setItems((prev) => {
+      if (prev.some((s) => s.id === skill.id)) return prev;
+      return [
+        ...prev,
+        {
+          id: skill.id,
+          name: skill.name,
+          installUrl: skill.installUrl,
+          description: skill.description || "",
+          version: skill.version || "",
+          owner: skill.owner || "",
+          repo: skill.repo || "",
+        },
+      ];
+    });
+  }, []);
+
+  const remove = useCallback((id) => {
+    setItems((prev) => prev.filter((s) => s.id !== id));
+  }, []);
+
+  const clear = useCallback(() => {
+    setItems([]);
+  }, []);
+
+  const setMeta = useCallback((patch) => {
+    setMetaState((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const ids = useMemo(() => new Set(items.map((s) => s.id)), [items]);
+  const has = useCallback((id) => ids.has(id), [ids]);
+
+  const value = useMemo(
+    () => ({ items, meta, add, remove, clear, setMeta, has }),
+    [items, meta, add, remove, clear, setMeta, has],
+  );
+
+  return (
+    <BundleCartContext.Provider value={value}>
+      {children}
+    </BundleCartContext.Provider>
+  );
+}
+
+export function useBundleCart() {
+  return useContext(BundleCartContext);
+}

--- a/website-src/src/lib/bundle-export.js
+++ b/website-src/src/lib/bundle-export.js
@@ -38,9 +38,12 @@ export function buildBundleJson(skills, meta, now = new Date()) {
 }
 
 /**
- * Validate the minimum fields the CLI requires (`name` non-empty,
- * ≥1 skill) plus a JSON-filename-safe name check. Returns an array
- * of { field, message } — empty means valid.
+ * Validate the fields the CLI's `validateBundle()` in `src/bundler.ts`
+ * enforces server-side (non-empty `name`, `description`, `author`, and
+ * ≥ 1 skill), plus a JSON-filename-safe name check. Mirroring these
+ * here prevents users from exporting a `.json` that `asm bundle
+ * install` would then reject. Returns an array of { field, message }
+ * — empty means valid.
  */
 export function validateBundleForm(meta, skills) {
   const errors = [];
@@ -53,6 +56,15 @@ export function validateBundleForm(meta, skills) {
       message:
         "Name must start with a letter or digit and use only letters, digits, '.', '_', or '-' (max 64 chars).",
     });
+  }
+  if (!(meta.description || "").trim()) {
+    errors.push({
+      field: "description",
+      message: "Description is required.",
+    });
+  }
+  if (!(meta.author || "").trim()) {
+    errors.push({ field: "author", message: "Author is required." });
   }
   if (!Array.isArray(skills) || skills.length === 0) {
     errors.push({
@@ -177,7 +189,7 @@ function buildIssueBody(skills, meta, { catalogBaseUrl, maxBytes }) {
       s.description ? ` — ${truncateLine(s.description, 140)}` : ""
     }`;
     const encodedRowLen = encodeURIComponent(row + "\n").length;
-    if (runningEncodedLen + encodedRowLen > maxBytes && i < skills.length - 1) {
+    if (runningEncodedLen + encodedRowLen > maxBytes) {
       truncated = skills.length - i;
       break;
     }

--- a/website-src/src/lib/bundle-export.js
+++ b/website-src/src/lib/bundle-export.js
@@ -1,0 +1,201 @@
+/**
+ * Client-side bundle export helpers (#238). Pure functions so they
+ * can be unit-tested without a DOM. The canonical Node-side bundle
+ * validator lives in `src/bundler.ts`; we deliberately don't port it
+ * — instead we validate only what the user can influence in the
+ * builder form, and let the CLI catch anything else at install time.
+ */
+
+const REPO_OWNER = "luongnv89";
+const REPO_NAME = "asm";
+
+/**
+ * Build a `BundleManifest` (matching `src/utils/types.ts`) from the
+ * in-memory cart + the metadata form values. `createdAt` is set here
+ * — not when the cart row is added — so the timestamp reflects when
+ * the user exported, not when they started shopping.
+ */
+export function buildBundleJson(skills, meta, now = new Date()) {
+  const tags = splitTags(meta.tags);
+  const manifest = {
+    version: 1,
+    name: (meta.name || "").trim(),
+    description: (meta.description || "").trim(),
+    author: (meta.author || "").trim(),
+    createdAt: now.toISOString(),
+    skills: skills.map((s) => {
+      const ref = {
+        name: s.name,
+        installUrl: s.installUrl,
+      };
+      if (s.description) ref.description = s.description;
+      if (s.version && s.version !== "0.0.0") ref.version = s.version;
+      return ref;
+    }),
+  };
+  if (tags.length > 0) manifest.tags = tags;
+  return manifest;
+}
+
+/**
+ * Validate the minimum fields the CLI requires (`name` non-empty,
+ * ≥1 skill) plus a JSON-filename-safe name check. Returns an array
+ * of { field, message } — empty means valid.
+ */
+export function validateBundleForm(meta, skills) {
+  const errors = [];
+  const name = (meta.name || "").trim();
+  if (!name) {
+    errors.push({ field: "name", message: "Bundle name is required." });
+  } else if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/.test(name)) {
+    errors.push({
+      field: "name",
+      message:
+        "Name must start with a letter or digit and use only letters, digits, '.', '_', or '-' (max 64 chars).",
+    });
+  }
+  if (!Array.isArray(skills) || skills.length === 0) {
+    errors.push({
+      field: "skills",
+      message: "Add at least one skill to the bundle.",
+    });
+  }
+  return errors;
+}
+
+function splitTags(raw) {
+  if (!raw) return [];
+  return String(raw)
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Trigger a JSON download by creating a blob URL + temporary <a>.
+ * Kept out of buildBundleJson so the pure function stays testable.
+ */
+export function downloadBundleJson(bundle, doc = document) {
+  const json = JSON.stringify(bundle, null, 2);
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = doc.createElement("a");
+  a.href = url;
+  a.download = `${bundle.name || "bundle"}.json`;
+  doc.body.appendChild(a);
+  a.click();
+  doc.body.removeChild(a);
+  // Revoke on next tick to give browsers time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+/**
+ * Build a GitHub "new issue" web intent URL that pre-fills the
+ * feature-request template. GitHub caps pre-filled bodies around
+ * ~8KB in practice (URL-encoded) — we truncate the skills list with
+ * a "…N more" note when needed instead of silently dropping rows.
+ *
+ * Labels: `enhancement,feature` matches the labels the maintainer
+ * uses on existing bundle-related issues (e.g. #238 itself). A
+ * future `bundles` label can be added server-side by a triage rule.
+ */
+export function buildIssueUrl(skills, meta, opts = {}) {
+  const owner = opts.owner || REPO_OWNER;
+  const repo = opts.repo || REPO_NAME;
+  const catalogBaseUrl = opts.catalogBaseUrl || "https://luongnv.com/asm/";
+  const maxBytes = opts.maxBodyBytes || 7000;
+
+  const title = `[FEATURE] Bundle: ${(meta.name || "untitled").trim()}`;
+  const body = buildIssueBody(skills, meta, { catalogBaseUrl, maxBytes });
+
+  const params = new URLSearchParams({
+    title,
+    body,
+    labels: "enhancement,feature",
+  });
+  return `https://github.com/${owner}/${repo}/issues/new?${params.toString()}`;
+}
+
+function buildIssueBody(skills, meta, { catalogBaseUrl, maxBytes }) {
+  const tags = splitTags(meta.tags);
+  const header = [
+    "## Problem Statement",
+    "",
+    "A community-curated skill bundle, submitted via the website bundle builder.",
+    "",
+    "## Proposed Solution",
+    "",
+    `Promote the following custom bundle to the pre-defined bundle catalog.`,
+    "",
+    "### Bundle metadata",
+    "",
+    `- **Name:** ${meta.name || "(unnamed)"}`,
+    `- **Description:** ${meta.description || "(no description)"}`,
+    `- **Author:** ${meta.author || "(anonymous)"}`,
+    tags.length > 0 ? `- **Tags:** ${tags.join(", ")}` : null,
+    `- **Skill count:** ${skills.length}`,
+    "",
+    "### Skills",
+    "",
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
+
+  const footer = [
+    "",
+    "## Use Cases",
+    "",
+    "1. Users who want a one-shot install of this combination of skills.",
+    "2. Maintainers looking for signal on which skill combinations are popular enough to promote.",
+    "",
+    "## Additional Context",
+    "",
+    "_Generated by the ASM website bundle builder._",
+  ].join("\n");
+
+  // Budget rows against the *URL-encoded* length so we don't blow past
+  // the pre-filled issue limit (~8KB on the query string). Each raw
+  // markdown character expands 1-3x after `URLSearchParams.toString()`
+  // (newlines → %0A, backticks → %60, em-dash → %E2%80%94), so
+  // measuring raw length dramatically under-counts.
+  const rows = [];
+  let truncated = 0;
+  let runningEncodedLen =
+    encodeURIComponent(header).length + encodeURIComponent(footer).length;
+  for (let i = 0; i < skills.length; i++) {
+    const s = skills[i];
+    // Catalog deep-link uses the skill's `id` (what the router decodes
+    // via `decodeSkillId` in useParams), not `installUrl` — the two
+    // values are distinct and the router won't resolve installUrl.
+    const catalogLink = s.id
+      ? `${catalogBaseUrl}#/skills/${encodeURIComponent(s.id)}`
+      : null;
+    const nameCell = catalogLink
+      ? `[\`${s.name}\`](${catalogLink})`
+      : `\`${s.name}\``;
+    const row = `- ${nameCell} — \`${s.installUrl}\`${
+      s.description ? ` — ${truncateLine(s.description, 140)}` : ""
+    }`;
+    const encodedRowLen = encodeURIComponent(row + "\n").length;
+    if (runningEncodedLen + encodedRowLen > maxBytes && i < skills.length - 1) {
+      truncated = skills.length - i;
+      break;
+    }
+    rows.push(row);
+    runningEncodedLen += encodedRowLen;
+  }
+  if (truncated > 0) {
+    rows.push(
+      `- …and **${truncated} more** skill${truncated === 1 ? "" : "s"} — see the attached \`.json\` for the full list.`,
+    );
+  }
+
+  return header + rows.join("\n") + footer;
+}
+
+function truncateLine(s, max) {
+  if (!s) return "";
+  const single = String(s).replace(/\s+/g, " ").trim();
+  if (single.length <= max) return single;
+  return single.slice(0, max - 1) + "…";
+}


### PR DESCRIPTION
## Summary

Adds an interactive bundle-building experience to the ASM website (closes #238). Users can browse the skill catalog, select multiple skills with "Add to bundle" buttons, review the selection in a cart-style dialog with a metadata form, and either **export** the bundle as a `.json` file that `asm bundle install` accepts, or **publish** it as a pre-filled feature-request issue so maintainers can promote popular combinations to predefined bundles.

Complements #202 (CLI + predefined bundles) by delivering the custom-bundle UX on the site.

## Approach

**Balanced**: a lightweight React context provider for cart state + localStorage persistence, a single modal for the metadata form and review, and pure helpers for export/publish logic. No new runtime dependencies — everything reuses the existing shadcn primitives and lucide icons already shipping in the bundle.

- `hooks/useBundleCart.jsx` — cart context with versioned localStorage (`asm-bundle-cart:v1`) and defensive parsing for stored state
- `lib/bundle-export.js` — pure functions: `buildBundleJson()` → matches `BundleManifest` in `src/utils/types.ts`; `buildIssueUrl()` → GitHub web-intent URL with pre-filled feature-request body (budgeted against encoded byte length so large bundles don't blow past GitHub's pre-fill limit); `validateBundleForm()` for client-side checks
- `components/AddToBundleButton.jsx` — compact + full variants. Compact lives inside the `<Link>`-wrapped `SkillListItem` and calls `e.preventDefault/stopPropagation` so clicking "Add" doesn't navigate
- `components/BundleBuilderDialog.jsx` — accessible modal (`role=dialog`, `aria-labelledby`, Tab focus trap, return-focus-on-close, Escape, backdrop dismiss)
- `components/BundleCartButton.jsx` — header pill visible on every route (Skills / Bundles / Docs / Changelog) so the cart is always reachable
- `App.jsx`, `Header.jsx`, `SkillListItem.jsx`, `SkillDetail.jsx` wired up with stable `useCallback` refs to avoid effect-teardown focus yanks while typing in the form

## Changes

| File | Kind | Notes |
|------|------|-------|
| `website-src/src/App.jsx` | modified | Wraps tree in `BundleCartProvider`, mounts dialog, stable callbacks |
| `website-src/src/components/Header.jsx` | modified | Mounts `BundleCartButton` between version and theme toggle |
| `website-src/src/components/SkillListItem.jsx` | modified | Compact add-to-bundle button on each row |
| `website-src/src/components/SkillDetail.jsx` | modified | Full add-to-bundle button below the install command |
| `website-src/src/components/AddToBundleButton.jsx` | new | Toggle add/remove; compact + full variants |
| `website-src/src/components/BundleCartButton.jsx` | new | Header cart pill with count |
| `website-src/src/components/BundleBuilderDialog.jsx` | new | Modal with metadata form, skill list, Export/Publish |
| `website-src/src/hooks/useBundleCart.jsx` | new | Context + versioned localStorage persistence |
| `website-src/src/lib/bundle-export.js` | new | `BundleManifest` JSON + GitHub issue URL builders |
| `website-src/src/__tests__/bundle-export.test.js` | new | Pure-fn tests: schema, validation, truncation |
| `website-src/src/__tests__/bundle-cart.test.jsx` | new | Integration: add→count, validate→publish, persist |

## Test Results

- **Unit + integration:** `npm run test:site` — **30/30 passing** (5 test files; 10 new assertions for bundle logic)
- **Lint:** `npm run lint:site` — no new issues (existing `ChangelogPage.jsx` warnings are unrelated)
- **Build:** `npm run build:site` — clean (bundle grew by ~10 KB gzipped, 104.8 KB total)
- **Pre-push hooks:** build + node e2e tests both passed

## Acceptance Criteria

- [x] Skills catalog page shows an "Add to bundle" affordance on each skill; selected skills are visually marked (✓ compact icon + `aria-pressed`).
- [x] A persistent cart UI displays the current selection count and is accessible from any catalog page (header pill on every route).
- [x] Opening the cart shows selected skills with remove controls and a form for bundle metadata (name, version, description, author).
- [x] "Export" downloads a `.json` file that conforms to the bundle schema defined in #202 and is installable via `asm bundle install ./file.json`.
- [x] "Publish" opens a pre-filled GitHub new-issue URL in `luongnv89/asm` with bundle name, description, author, and the selected skills list (with catalog deep-links) in the body.
- [x] Cart state persists across page navigation via localStorage.

## Test plan

- [ ] Open Skills page, add 3 skills from the list, confirm cart count is "3" in the header
- [ ] Navigate to `/bundles`, `/docs` — confirm cart pill remains visible and shows "3"
- [ ] Open the cart modal — confirm all 3 skills listed, remove one, confirm count drops to "2"
- [ ] Try to Export/Publish with the Name field empty — confirm validation message appears under Name
- [ ] Fill Name (`my-pack`), click Export — confirm `my-pack.json` downloads and opens as valid JSON
- [ ] Run `asm bundle install ./my-pack.json` against the exported file — confirm CLI accepts it
- [ ] Click Publish — confirm a new tab opens to `github.com/luongnv89/asm/issues/new` with title, body (with catalog links), and labels `enhancement,feature` pre-filled
- [ ] Reload the page — confirm cart still shows the same skills (localStorage round-trip)
- [ ] Tab through the open dialog — confirm focus stays inside; Escape closes and returns focus to the cart button
- [ ] Try clicking "Add to bundle" on a list row — confirm no navigation to `/skills/:id` happens