### PR TITLE
fix(website): label distinguishing install path when skill name collides (#241)

### DIFF
--- a/website-src/src/__tests__/filter-sort.test.js
+++ b/website-src/src/__tests__/filter-sort.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyFilters,
   anyFilterActive,
+  buildNameCollisionKeys,
   defaultSort,
 } from "../lib/filter-sort.js";
 import { emptyFacetState } from "../lib/facets.js";
@@ -147,6 +148,69 @@ describe("applyFilters", () => {
     ]);
     const out = applyFilters(skills, state, { scoreById });
     expect(out.map((s) => s.id)).toEqual(["gamma", "beta"]);
+  });
+});
+
+describe("buildNameCollisionKeys (issue #241)", () => {
+  it("returns an empty set when every (owner, repo, name) is unique", () => {
+    const skills = [
+      mk({ id: "1", name: "a", owner: "o", repo: "r1" }),
+      mk({ id: "2", name: "a", owner: "o", repo: "r2" }),
+      mk({ id: "3", name: "b", owner: "o", repo: "r1" }),
+    ];
+    expect(buildNameCollisionKeys(skills).size).toBe(0);
+  });
+
+  it("flags only the (owner, repo, name) tuples that collide", () => {
+    const skills = [
+      // Two entries sharing owner/repo/name — a plugin-bundle variant
+      mk({ id: "1", name: "dup", owner: "o", repo: "r" }),
+      mk({ id: "2", name: "dup", owner: "o", repo: "r" }),
+      // Same name under a different repo — NOT a collision
+      mk({ id: "3", name: "dup", owner: "o", repo: "other" }),
+      // Unrelated unique entry
+      mk({ id: "4", name: "solo", owner: "o", repo: "r" }),
+    ];
+    const keys = buildNameCollisionKeys(skills);
+    expect(keys.has("o/r::dup")).toBe(true);
+    expect(keys.has("o/other::dup")).toBe(false);
+    expect(keys.has("o/r::solo")).toBe(false);
+    expect(keys.size).toBe(1);
+  });
+
+  it("handles the reported sickn33 case (3 install paths, same skill)", () => {
+    const skills = [
+      mk({
+        id: "a",
+        name: "00-andruia-consultant",
+        owner: "sickn33",
+        repo: "antigravity-awesome-skills",
+      }),
+      mk({
+        id: "b",
+        name: "00-andruia-consultant",
+        owner: "sickn33",
+        repo: "antigravity-awesome-skills",
+      }),
+      mk({
+        id: "c",
+        name: "00-andruia-consultant",
+        owner: "sickn33",
+        repo: "antigravity-awesome-skills",
+      }),
+    ];
+    const keys = buildNameCollisionKeys(skills);
+    expect(keys.size).toBe(1);
+    expect(
+      keys.has("sickn33/antigravity-awesome-skills::00-andruia-consultant"),
+    ).toBe(true);
+  });
+
+  it("returns a fresh Set (not a shared reference)", () => {
+    const skills = [mk({ id: "1", name: "x" })];
+    expect(buildNameCollisionKeys(skills)).not.toBe(
+      buildNameCollisionKeys(skills),
+    );
   });
 });
 

--- a/website-src/src/__tests__/skill-list-item.test.jsx
+++ b/website-src/src/__tests__/skill-list-item.test.jsx
@@ -1,0 +1,101 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { HashRouter } from "react-router-dom";
+import SkillListItem from "../components/SkillListItem.jsx";
+
+/**
+ * Regression tests for issue #241 — when multiple install paths share a
+ * (owner, repo, name) tuple (plugin-bundle layouts) the list rows used to
+ * look identical. Rendering `hasNameCollision` must surface the
+ * distinguishing relPath so the user can tell the siblings apart.
+ */
+
+const baseSkill = {
+  id: "sickn33/antigravity-awesome-skills::plugins/antigravity-awesome-skills-claude/skills/00-andruia-consultant::00-andruia-consultant",
+  name: "00-andruia-consultant",
+  description: "Arquitecto de Soluciones Principal.",
+  owner: "sickn33",
+  repo: "antigravity-awesome-skills",
+  categories: ["general"],
+  installUrl:
+    "github:sickn33/antigravity-awesome-skills:plugins/antigravity-awesome-skills-claude/skills/00-andruia-consultant",
+  license: "",
+  version: "0.0.0",
+  verified: true,
+  hasTools: false,
+};
+
+function renderItem(props) {
+  return render(
+    <HashRouter
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <SkillListItem
+        skill={baseSkill}
+        active={false}
+        searchQuery=""
+        searchTerms={null}
+        locationSearch=""
+        {...props}
+      />
+    </HashRouter>,
+  );
+}
+
+describe("SkillListItem — name collision labeling (issue #241)", () => {
+  afterEach(() => cleanup());
+
+  it("does not render the install path when there is no collision", () => {
+    renderItem({ hasNameCollision: false });
+    expect(
+      screen.queryByText(/plugins\/antigravity-awesome-skills-claude/),
+    ).toBeNull();
+  });
+
+  it("renders the distinguishing install path when hasNameCollision is true", () => {
+    renderItem({ hasNameCollision: true });
+    expect(
+      screen.getByText(
+        "plugins/antigravity-awesome-skills-claude/skills/00-andruia-consultant",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("yields a different rendered path for each sibling in a collision group", () => {
+    const { unmount } = renderItem({ hasNameCollision: true });
+    expect(
+      screen.getByText(
+        "plugins/antigravity-awesome-skills-claude/skills/00-andruia-consultant",
+      ),
+    ).toBeTruthy();
+    unmount();
+
+    const sibling = {
+      ...baseSkill,
+      id: "sickn33/antigravity-awesome-skills::skills/00-andruia-consultant::00-andruia-consultant",
+      installUrl:
+        "github:sickn33/antigravity-awesome-skills:skills/00-andruia-consultant",
+    };
+    render(
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <SkillListItem
+          skill={sibling}
+          active={false}
+          searchQuery=""
+          searchTerms={null}
+          locationSearch=""
+          hasNameCollision={true}
+        />
+      </HashRouter>,
+    );
+    expect(screen.getByText("skills/00-andruia-consultant")).toBeTruthy();
+    expect(
+      screen.queryByText(
+        "plugins/antigravity-awesome-skills-claude/skills/00-andruia-consultant",
+      ),
+    ).toBeNull();
+  });
+});

--- a/website-src/src/__tests__/utils.test.js
+++ b/website-src/src/__tests__/utils.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { skillRelPath } from "../lib/utils.js";
+
+describe("skillRelPath (issue #241)", () => {
+  it("extracts the in-repo path from a standard installUrl", () => {
+    expect(skillRelPath("github:owner/repo:skills/foo")).toBe("skills/foo");
+  });
+
+  it("preserves slashes for nested plugin-bundle paths", () => {
+    expect(
+      skillRelPath(
+        "github:sickn33/antigravity-awesome-skills:plugins/antigravity-awesome-skills-claude/skills/00-andruia-consultant",
+      ),
+    ).toBe(
+      "plugins/antigravity-awesome-skills-claude/skills/00-andruia-consultant",
+    );
+  });
+
+  it("returns empty string when there is no path segment", () => {
+    expect(skillRelPath("github:owner/repo")).toBe("");
+  });
+
+  it("returns empty string for falsy or non-string input", () => {
+    expect(skillRelPath("")).toBe("");
+    expect(skillRelPath(null)).toBe("");
+    expect(skillRelPath(undefined)).toBe("");
+    expect(skillRelPath(123)).toBe("");
+  });
+});

--- a/website-src/src/components/SkillListItem.jsx
+++ b/website-src/src/components/SkillListItem.jsx
@@ -9,6 +9,7 @@ import {
   formatTokens,
   highlightMatches,
   encodeSkillId,
+  skillRelPath,
 } from "../lib/utils.js";
 
 /**
@@ -28,6 +29,7 @@ function SkillListItem({
   searchQuery,
   searchTerms,
   locationSearch,
+  hasNameCollision,
 }) {
   const nameHtml = highlightMatches(skill.name, searchQuery, searchTerms);
   const descHtml = highlightMatches(
@@ -44,6 +46,10 @@ function SkillListItem({
   const evalTone = skill.evalSummary
     ? evalScoreClass(skill.evalSummary.overallScore)
     : null;
+  // When the same name appears at multiple install paths inside one repo
+  // (plugin-bundle variants — issue #241) surface the distinguishing
+  // relPath so the row is no longer visually identical to its siblings.
+  const collisionPath = hasNameCollision ? skillRelPath(skill.installUrl) : "";
 
   return (
     <Link
@@ -78,6 +84,14 @@ function SkillListItem({
       <div className="mt-1 text-[10px] text-[var(--fg-muted)] truncate">
         {skill.owner}/{skill.repo}
       </div>
+      {collisionPath && (
+        <div
+          className="text-[10px] text-[var(--fg-muted)] truncate font-mono"
+          title={"Install path: " + collisionPath}
+        >
+          {collisionPath}
+        </div>
+      )}
       <p
         className="mt-1 text-xs text-[var(--fg-dim)] line-clamp-2 leading-snug"
         dangerouslySetInnerHTML={{ __html: descHtml }}

--- a/website-src/src/lib/filter-sort.js
+++ b/website-src/src/lib/filter-sort.js
@@ -126,6 +126,30 @@ export function applyFilters(skills, state, options = {}) {
   return results;
 }
 
+/**
+ * Build the set of `owner/repo::name` keys that collide — i.e. the same
+ * skill name exists at more than one install path within a single repo
+ * (plugin-bundle layouts do this). Consumers use this to decide whether
+ * to surface the distinguishing sub-path on a list row so two otherwise
+ * identical-looking cards don't look like accidental duplicates
+ * (issue #241).
+ *
+ * @param {object[]} skills Slim skill rows.
+ * @returns {Set<string>}
+ */
+export function buildNameCollisionKeys(skills) {
+  const counts = new Map();
+  for (const s of skills) {
+    const key = s.owner + "/" + s.repo + "::" + s.name;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const collisions = new Set();
+  for (const [key, n] of counts) {
+    if (n > 1) collisions.add(key);
+  }
+  return collisions;
+}
+
 export function anyFilterActive(state) {
   if (state.searchQuery && state.searchQuery.trim()) return true;
   if (state.activeCategories.size > 0) return true;

--- a/website-src/src/lib/utils.js
+++ b/website-src/src/lib/utils.js
@@ -27,6 +27,19 @@ export function skillSource(s) {
   return "community";
 }
 
+// Extract the in-repo relPath from an installUrl formatted as
+// `github:owner/repo:relPath`. Returns an empty string when the URL has no
+// path segment (top-level SKILL.md in the repo root).
+export function skillRelPath(installUrl) {
+  if (!installUrl || typeof installUrl !== "string") return "";
+  const idx = installUrl.indexOf(":");
+  if (idx === -1) return "";
+  const rest = installUrl.slice(idx + 1);
+  const idx2 = rest.indexOf(":");
+  if (idx2 === -1) return "";
+  return rest.slice(idx2 + 1);
+}
+
 // Format an estimated token count as "~N tokens" / "~1.2k tokens" /
 // "~12k tokens". Mirrors src/utils/token-count.ts:formatTokenCount so the
 // website + CLI agree.

--- a/website-src/src/pages/CatalogPage.jsx
+++ b/website-src/src/pages/CatalogPage.jsx
@@ -7,6 +7,7 @@ import { useCatalogState } from "../hooks/useCatalogState.js";
 import {
   applyFilters,
   anyFilterActive,
+  buildNameCollisionKeys,
   defaultSort,
 } from "../lib/filter-sort.js";
 import { computeFacetCounts } from "../lib/facets.js";
@@ -32,8 +33,12 @@ function SkillRow({
   searchQuery,
   searchTerms,
   locationSearch,
+  collisionKeys,
 }) {
   const s = skills[index];
+  const hasCollision =
+    !!collisionKeys &&
+    collisionKeys.has(s.owner + "/" + s.repo + "::" + s.name);
   return (
     <div style={style} className="pb-1.5">
       <SkillListItem
@@ -42,6 +47,7 @@ function SkillRow({
         searchQuery={searchQuery}
         searchTerms={searchTerms}
         locationSearch={locationSearch}
+        hasNameCollision={hasCollision}
       />
     </div>
   );
@@ -118,6 +124,18 @@ export default function CatalogPage() {
 
   const facetCounts = useMemo(
     () => (catalog ? computeFacetCounts(catalog.skills) : null),
+    [catalog],
+  );
+
+  // A skill name may appear at multiple install paths within a single repo
+  // (plugin-bundle layouts ship the same skill under several relPaths — see
+  // build-catalog.ts and issue #241). The data layer preserves every install
+  // target on purpose so each has a distinct `installUrl`, but with identical
+  // name/owner/repo/description/badges the list rows look like duplicates to
+  // a casual reader. The collision set lets `SkillListItem` surface the
+  // distinguishing sub-path on those rows only, keeping the common case clean.
+  const collisionKeys = useMemo(
+    () => (catalog ? buildNameCollisionKeys(catalog.skills) : null),
     [catalog],
   );
 
@@ -264,6 +282,7 @@ export default function CatalogPage() {
               searchQuery: state.searchQuery,
               searchTerms: searchResults.terms,
               locationSearch: location.search,
+              collisionKeys,
             }}
             style={{ height: "100%" }}
           />


### PR DESCRIPTION
## Summary

Closes #241. Plugin-bundle repos ship the same skill name at several install paths — the data layer preserves every target on purpose (#201) so each has a distinct `installUrl`, but the list rendered identical-looking cards because name, owner/repo, description, and badges all matched. Users saw the same skill 3× with no way to tell the rows apart (the reporter showed `00-andruia-consultant` from `sickn33/antigravity-awesome-skills` appearing three times).

## Approach

Fix at the UI layer only — leave the data layer invariants from issue #201 intact:

- Added `buildNameCollisionKeys(skills)` in `filter-sort.js` — returns `Set<"owner/repo::name">` for tuples with >1 entry (1,862 such groups exist in the current catalog).
- `CatalogPage` computes it once via `useMemo` over `catalog.skills` (cheap O(n), does not rebuild on keystroke).
- Passed down as `hasNameCollision` to each `SkillListItem`.
- When true, `SkillListItem` renders the `relPath` (extracted via new `skillRelPath(installUrl)` helper) as a muted sub-label beneath `owner/repo`. Non-colliding rows are unchanged.

## Changes

| File | Change |
|------|--------|
| `website-src/src/lib/utils.js` | + `skillRelPath(installUrl)` helper |
| `website-src/src/lib/filter-sort.js` | + `buildNameCollisionKeys(skills)` helper |
| `website-src/src/pages/CatalogPage.jsx` | Compute collision set, thread through row props |
| `website-src/src/components/SkillListItem.jsx` | Render sub-label when colliding |
| `website-src/src/__tests__/utils.test.js` | **new** — 4 tests for `skillRelPath` |
| `website-src/src/__tests__/filter-sort.test.js` | +4 tests for `buildNameCollisionKeys` |
| `website-src/src/__tests__/skill-list-item.test.jsx` | **new** — 3 jsdom tests for collision labeling |

## Test Results

- `npm run test:site` — 44/44 pass (7 files, +3 new tests)
- `npm run test:e2e` — 156/156 pass, including the `build-verification.test.ts` dedup suite from #201
- `npm test` (src unit) — 1614/1614 pass
- `npm run typecheck` — clean
- `npm run build && npm run build:site` — success
- Visually verified at http://localhost:5173/#/?q=00-andruia on both mobile (375×812) and desktop (1280×800) — the three previously-identical rows now display distinguishing install paths.

## Acceptance Criteria

- [x] Reproduce the duplicate-skill behavior — 1,862 `(owner, repo, name)` tuples have >1 entry in the catalog; `00-andruia-consultant` has 3 (three identical rows confirmed visually).
- [x] Determine source of duplication — **UI rendering layer**: data layer intentionally preserves variants per #201, but `SkillListItem` did not surface any distinguishing info.
- [x] Same skill/source pair appears only once unless explicitly labeled — all 3 rows now carry their `relPath` label.
- [x] Regression check — new tests in `filter-sort.test.js`, `utils.test.js`, and `skill-list-item.test.jsx`. Existing data-layer regression tests from #201 remain green.
- [x] Validated on mobile-width UI (375×812, via drawer) — sub-label renders identically.

## Test plan

- [ ] Reviewer pulls the branch and runs `npm run dev:site`
- [ ] Navigate to `/#/?q=00-andruia` — confirm 3 rows show distinguishing paths beneath `owner/repo`
- [ ] Confirm a skill with a unique `(owner, repo, name)` (e.g. search `readme-generator`) shows NO sub-label
- [ ] Resize to 375px mobile, open the drawer, repeat both checks