### PR TITLE
feat(eval): accept author as canonical frontmatter field (creator kept as alias)

### DIFF
--- a/src/eval/providers/quality/v1/fixtures/missing-frontmatter.json
+++ b/src/eval/providers/quality/v1/fixtures/missing-frontmatter.json
@@ -76,7 +76,7 @@
           "Missing required field: name.",
           "Missing required field: description.",
           "Missing or default version.",
-          "Missing `creator`.",
+          "Missing `author`.",
           "Missing `license`.",
           "Body has meaningful content.",
           "Body uses markdown headings."
@@ -86,7 +86,7 @@
           "Add `name:` to frontmatter (use the skill directory name).",
           "Add a one-line `description:` to frontmatter.",
           "Set `metadata.version` (or top-level `version`) using semver (e.g. 0.1.0).",
-          "Add a `creator` field so users know who authored and maintains the skill.",
+          "Add an `author` field so users know who authored and maintains the skill.",
           "Add a `license` field (e.g. `license: MIT`)."
         ]
       },

--- a/src/evaluator.test.ts
+++ b/src/evaluator.test.ts
@@ -398,20 +398,37 @@ describe("buildFixPlan", () => {
     );
   });
 
-  it("adds creator from gitAuthor option when absent", () => {
+  it("adds author from gitAuthor option when absent", () => {
     const plan = buildFixPlan(
       "---\nname: x\ndescription: do a thing\n---\n\nbody\n",
       { gitAuthor: "Jane Doe" },
     );
-    expect(plan.newContent).toContain("creator: Jane Doe");
-    expect(plan.applied.some((a) => a.id === "add-missing-creator")).toBe(true);
+    expect(plan.newContent).toContain("author: Jane Doe");
+    expect(plan.applied.some((a) => a.id === "add-missing-author")).toBe(true);
   });
 
-  it("skips creator when no gitAuthor is provided", () => {
+  it("skips author when no gitAuthor is provided", () => {
     const plan = buildFixPlan(
       "---\nname: x\ndescription: do a thing\n---\n\nbody\n",
     );
-    expect(plan.skipped.some((s) => s.id === "add-missing-creator")).toBe(true);
+    expect(plan.skipped.some((s) => s.id === "add-missing-author")).toBe(true);
+  });
+
+  it("accepts legacy `creator:` as an alias and does not re-add author", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\ncreator: Legacy Author\n---\n\nbody\n",
+      { gitAuthor: "Jane Doe" },
+    );
+    expect(plan.newContent).not.toContain("author: Jane Doe");
+    expect(plan.applied.some((a) => a.id === "add-missing-author")).toBe(false);
+  });
+
+  it("accepts `metadata.author` as canonical", () => {
+    const plan = buildFixPlan(
+      "---\nname: x\ndescription: do a thing\nmetadata:\n  author: Jane Doe\n---\n\nbody\n",
+      { gitAuthor: "Git Name" },
+    );
+    expect(plan.applied.some((a) => a.id === "add-missing-author")).toBe(false);
   });
 
   it("infers effort from line count when missing", () => {
@@ -505,7 +522,7 @@ describe("applyFix", () => {
     expect(r.backupPath).toBe(join(dir, "SKILL.md.bak"));
     const after = await readFile(join(dir, "SKILL.md"), "utf-8");
     expect(after).toContain("version: 0.1.0");
-    expect(after).toContain("creator: Alice");
+    expect(after).toContain("author: Alice");
     const backup = await readFile(r.backupPath!, "utf-8");
     expect(backup).toBe(original);
   });
@@ -528,7 +545,7 @@ describe("applyFix", () => {
     );
     const r = await applyFix(dir, { dryRun: false, gitAuthor: "Bob" });
     expect(r.report.frontmatter.version).toBe("0.1.0");
-    expect(r.report.frontmatter.creator).toBe("Bob");
+    expect(r.report.frontmatter.author).toBe("Bob");
   });
 });
 

--- a/src/evaluator.test.ts
+++ b/src/evaluator.test.ts
@@ -221,6 +221,32 @@ describe("evaluateSkillContent", () => {
     ).toBe(true);
   });
 
+  it("awards authorship point for legacy creator-only skills", () => {
+    const report = evaluateSkillContent({
+      content:
+        "---\nname: x\ndescription: Do a thing when triggered.\nversion: 1.0.0\nlicense: MIT\ncreator: Legacy Author\n---\nbody\n",
+      skillPath: "/virtual/x",
+      skillMdPath: "/virtual/x/SKILL.md",
+    });
+    const structure = report.categories.find((c) => c.id === "structure")!;
+    expect(structure.findings.some((f) => /Missing.*author/i.test(f))).toBe(
+      false,
+    );
+  });
+
+  it("awards authorship point for metadata.author skills", () => {
+    const report = evaluateSkillContent({
+      content:
+        "---\nname: x\ndescription: Do a thing when triggered.\nversion: 1.0.0\nlicense: MIT\nmetadata:\n  author: Jane Doe\n---\nbody\n",
+      skillPath: "/virtual/x",
+      skillMdPath: "/virtual/x/SKILL.md",
+    });
+    const structure = report.categories.find((c) => c.id === "structure")!;
+    expect(structure.findings.some((f) => /Missing.*author/i.test(f))).toBe(
+      false,
+    );
+  });
+
   it("produces up to 3 top suggestions", () => {
     const report = evaluateSkillContent({
       content: POOR_SKILL,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -15,12 +15,14 @@
  *   7. Naming & conventions       — naming conventions, imperative mood, consistent labels
  *
  * Also provides `--fix` / `--fix --dry-run` auto-fix for deterministic
- * frontmatter issues (ordering, version default, creator from git, effort
+ * frontmatter issues (ordering, version default, author from git, effort
  * inference from size, trailing whitespace, CRLF normalization).
  *
  * Schema mapping notes (see also /docs/ARCHITECTURE.md + README "SKILL.md Format"):
  *   - Issue wording     → codebase convention
- *   - `author`          → `creator` (or `metadata.creator`)
+ *   - `author` is the canonical authorship field (top-level or `metadata.author`);
+ *     `creator` is accepted as a legacy alias for backwards compatibility and
+ *     resolves identically. The auto-fixer emits `author:` going forward.
  *   - top-level `version` → `metadata.version` (preferred) with `version` fallback
  *   - `XS/S/M/L/XL`     → `low/medium/high/max`
  *   - `type`            → not a recognized frontmatter field; ignored by the
@@ -111,12 +113,19 @@ export interface FixResult {
 export const ROOT_README_SUGGESTION =
   "Relocate `README.md` out of the skill root so SKILL.md remains the sole top-level document (e.g., move it to `docs/README.md`).";
 
-/** Canonical frontmatter key ordering used by the auto-fixer. */
+/** Canonical frontmatter key ordering used by the auto-fixer.
+ *
+ *  `author` is the canonical authorship field; `creator` is kept in the list
+ *  so legacy skills that still declare it are reordered correctly rather than
+ *  sinking to the bottom of the frontmatter. New skills scaffolded by the
+ *  auto-fixer receive `author:`.
+ */
 export const CANONICAL_FIELD_ORDER = [
   "name",
   "description",
   "version",
   "license",
+  "author",
   "creator",
   "compatibility",
   "allowed-tools",
@@ -365,12 +374,16 @@ function scoreStructure(
     );
   }
 
-  const hasCreator = Boolean(fm.creator || fm["metadata.creator"]);
-  if (hasCreator) score += 1;
+  // `author` is canonical; `creator` is accepted as a legacy alias so existing
+  // skills keep their score during the field rename transition.
+  const hasAuthor = Boolean(
+    fm.author || fm["metadata.author"] || fm.creator || fm["metadata.creator"],
+  );
+  if (hasAuthor) score += 1;
   else {
-    findings.push("Missing `creator`.");
+    findings.push("Missing `author`.");
     suggestions.push(
-      "Add a `creator` field so users know who authored and maintains the skill.",
+      "Add an `author` field so users know who authored and maintains the skill.",
     );
   }
 
@@ -1065,7 +1078,8 @@ export async function evaluateSkill(
  *
  * Only low-risk, deterministic edits are applied:
  *   - Add missing `version` as `0.1.0`
- *   - Add missing `creator` from git `user.name` if available
+ *   - Add missing `author` from git `user.name` if available (legacy
+ *     `creator:` is accepted and left in place — not rewritten)
  *   - Infer `effort` from body line count (low/medium/high/max)
  *   - Normalise trailing whitespace and CRLF line endings
  *   - Ensure a blank line between `---` and body
@@ -1231,21 +1245,26 @@ export function buildFixPlan(
     });
   }
 
-  // 2) Add missing creator from git config user.name (if provided).
-  const hasCreator = Boolean(fm.creator || fm["metadata.creator"]);
-  if (!hasCreator) {
+  // 2) Add missing author from git config user.name (if provided).
+  //    `creator` is still accepted as a legacy alias, so a skill that declares
+  //    only `creator:` is considered complete and the auto-fixer leaves it
+  //    alone. New skills get `author:` written.
+  const hasAuthor = Boolean(
+    fm.author || fm["metadata.author"] || fm.creator || fm["metadata.creator"],
+  );
+  if (!hasAuthor) {
     const gitAuthor = options.gitAuthor?.trim();
     if (gitAuthor) {
-      fmStr = appendFrontmatterKey(fmStr, "creator", gitAuthor);
+      fmStr = appendFrontmatterKey(fmStr, "author", gitAuthor);
       applied.push({
-        id: "add-missing-creator",
-        description: `Add \`creator: ${gitAuthor}\` from git config.`,
+        id: "add-missing-author",
+        description: `Add \`author: ${gitAuthor}\` from git config.`,
       });
     } else {
       skipped.push({
-        id: "add-missing-creator",
+        id: "add-missing-author",
         description:
-          "Missing `creator` — no git user.name found to fill in safely.",
+          "Missing `author` — no git user.name found to fill in safely.",
       });
     }
   }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1089,7 +1089,9 @@ export async function evaluateSkill(
  * they're returned in `skipped`.
  */
 export interface BuildFixPlanOptions {
-  /** Optional git author string to use when `creator` is missing. */
+  /** Optional git author string to use when no authorship field
+   *  (`author`, `metadata.author`, or the legacy `creator` aliases) is
+   *  present. The fixer writes `author:` going forward. */
   gitAuthor?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- `asm eval` now treats `author` (top-level or `metadata.author`) as the canonical authorship field.
- Legacy `creator:` is kept as an accepted alias — existing skills in the wild keep their score, no migration needed.
- The autofixer writes `author:` going forward; `creator:` entries are left in place.

## Changes
- `src/evaluator.ts` — `hasCreator` → `hasAuthor` check considers all four resolutions: `author`, `metadata.author`, `creator`, `metadata.creator`. Autofixer emits `author:`. Wording in findings/suggestions references `author`. `CANONICAL_FIELD_ORDER` includes both keys so reordering still works for legacy skills.
- `src/evaluator.test.ts` — existing `creator`-based tests flipped to the new `author` output; added tests covering the `creator:` alias path, `metadata.author` resolution, and direct `scoreStructure` coverage for legacy skills.
- `src/eval/providers/quality/v1/fixtures/missing-frontmatter.json` — snapshot wording updated to match new finding copy.
- JSDoc on `BuildFixPlanOptions.gitAuthor` updated to reflect the new canonical field.

## Test plan
- [x] `npx vitest run src/evaluator.test.ts` — 76/76 pass
- [x] `npx vitest run src/` — 1618/1618 pass
- [x] Dogfood: `asm eval skills/skill-auto-improver` (legacy `creator:`) → 100/100, unchanged
- [x] Dogfood: `asm eval skills/skill-upstream-pr` (new `metadata.author:`) → 97/100, unchanged
- [x] Pre-commit hooks (prettier + typecheck + unit tests) pass
- [x] Pre-push hooks (build + e2e) pass
- [ ] Check CI green on the pushed branch

## Note
Branch was originally bundled with the `skill-upstream-pr` addition; that has been split out to #244. This PR now only contains the evaluator rename.