### PR TITLE
fix(install): treat path-shaped inputs that exist as local paths (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `asm eval` `skill-best-practice` provider (v1.0.0 → v1.1.0) — align with the latest `skill-creator` standard (v1.7.1): add `xhigh` to the effort enum, warn when descriptions exceed the 250-char runtime budget (truncation chops the negative-trigger clause), require `metadata.version` (semver-formatted), warn when `metadata.author` is missing, and require frontmatter `name` to match the parent directory ([#246](https://github.com/luongnv89/asm/issues/246)) — @luongnv89
 
+### Bug Fixes
+
+- `asm install` now treats `skills/x-skill` and `./skills/x-skill` identically — when the input contains a path separator and resolves to an existing directory in the current working directory, it is treated as a local path rather than dispatched to the registry as a scoped name ([#249](https://github.com/luongnv89/asm/issues/249)) — @luongnv89
+
 ## v2.5.0 — 2026-04-24
 
 ### Features

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import {
 import {
   parseSource,
   isLocalPath,
+  isExistingLocalDir,
   sanitizeName,
   checkGitAvailable,
   cloneToTemp,
@@ -1785,6 +1786,13 @@ async function cmdInstall(args: ParsedArgs) {
   process.on("SIGTERM", cleanup);
 
   try {
+    // Disambiguate path-shaped inputs that look like scoped names: if
+    // `<cwd>/<sourceStr>` is an existing directory, treat it as a local path
+    // (matches the `./` prefixed form). See issue #249.
+    if (!isLocalPath(sourceStr) && (await isExistingLocalDir(sourceStr))) {
+      sourceStr = `./${sourceStr}`;
+    }
+
     // Step 0: Registry resolution for bare/scoped names
     if (isBareOrScopedName(sourceStr)) {
       console.info(

--- a/src/installer.test.ts
+++ b/src/installer.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "os";
 import {
   parseSource,
   isLocalPath,
+  isExistingLocalDir,
   parseLocalSource,
   resolveSubpath,
   sanitizeName,
@@ -1439,6 +1440,56 @@ describe("parseSource with local paths", () => {
     const result = parseSource("https://github.com/owner/repo");
     expect(result.isLocal).toBeUndefined();
     expect(result.owner).toBe("owner");
+  });
+});
+
+// ─── isExistingLocalDir tests ──────────────────────────────────────────────
+
+describe("isExistingLocalDir", () => {
+  let tempDir: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-test-existing-dir-"));
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("returns true when path-shaped input exists as directory in cwd", async () => {
+    await mkdir(join(tempDir, "skills", "x-skill"), { recursive: true });
+    expect(await isExistingLocalDir("skills/x-skill")).toBe(true);
+  });
+
+  test("returns false for bare names without separator", async () => {
+    // Even if a directory matching the bare name exists, do not classify it
+    // as a local path — bare names belong to the registry.
+    await mkdir(join(tempDir, "code-review"), { recursive: true });
+    expect(await isExistingLocalDir("code-review")).toBe(false);
+  });
+
+  test("returns false for path-shaped input that does not exist", async () => {
+    expect(await isExistingLocalDir("skills/missing")).toBe(false);
+    expect(await isExistingLocalDir("author/typo")).toBe(false);
+  });
+
+  test("returns false when path resolves to a file, not a directory", async () => {
+    await mkdir(join(tempDir, "skills"), { recursive: true });
+    await writeFile(join(tempDir, "skills", "not-a-dir"), "");
+    expect(await isExistingLocalDir("skills/not-a-dir")).toBe(false);
+  });
+
+  test("returns true for backslash-separated path (Windows-style)", async () => {
+    await mkdir(join(tempDir, "skills", "x-skill"), { recursive: true });
+    // Whether the OS resolves a backslash separator depends on the platform,
+    // but the helper must at least attempt the check (i.e. not bail on the
+    // separator gate).
+    const result = await isExistingLocalDir("skills\\x-skill");
+    expect(typeof result).toBe("boolean");
   });
 });
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -63,6 +63,29 @@ export function isLocalPath(input: string): boolean {
   );
 }
 
+/**
+ * Filesystem-aware disambiguator for path-shaped inputs that are not yet
+ * classified as local by `isLocalPath`.
+ *
+ * Inputs like `skills/x-skill` are syntactically indistinguishable from
+ * registry-scoped names like `author/skill`. Both have exactly one `/` and
+ * pass `isBareOrScopedName`. Resolve the ambiguity by checking the working
+ * directory: if `<cwd>/<input>` exists and is a directory, treat it as a
+ * local path; otherwise let the registry resolver handle it.
+ *
+ * Returns false for inputs without a path separator (a bare name like
+ * `code-review` is never local even if a `code-review/` directory exists).
+ */
+export async function isExistingLocalDir(input: string): Promise<boolean> {
+  if (!input.includes("/") && !input.includes("\\")) return false;
+  try {
+    const s = await stat(resolve(input));
+    return s.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 export function parseLocalSource(input: string): ParsedSource {
   let absPath: string;
   if (input === "~") {


### PR DESCRIPTION
## Summary

Closes #249.

`asm install skills/x-skill` previously failed because `isBareOrScopedName("skills/x-skill")` returned `true` (the input matches the `author/name` scoped-name pattern), routing the input to the registry rather than treating it as a local path. Both `skills/x-skill` and `./skills/x-skill` are valid relative paths in shell/filesystem semantics and should behave identically.

## Approach

The fix is **purely additive** — pure classifiers `isLocalPath` and `isBareOrScopedName` are unchanged because `skills/x-skill` (intended as a local path) and `author/skill` (intended as a registry-scoped name) are syntactically identical; only filesystem state can disambiguate them.

- New `installer.ts:isExistingLocalDir(input)` — async helper that returns true iff the input contains a path separator AND `path.resolve(input)` exists and is a directory.
- In `cli.ts:cmdInstall`, before the `isBareOrScopedName` registry-dispatch branch, if the input isn't already classified as local by `isLocalPath` AND `isExistingLocalDir(input)` is true, prepend `./` so `parseSource` correctly classifies it as local. The existing local-path codepath is reused unchanged.

The path-separator gate (`includes('/')`) inside the helper preserves existing registry behavior for bare names like `code-review` — even if a same-named directory exists in cwd, bare names still go to the registry.

## Decision Record

- **Why not modify `isLocalPath`?** It is a pure pattern-based classifier consumed by `parseSource`. Making it return `true` for any string with `/` would misclassify `github:owner/repo`.
- **Why not modify `isBareOrScopedName`?** Same disambiguation problem — only filesystem state distinguishes `skills/x-skill` from `author/skill`.
- **Why fs-stat in `cmdInstall` instead of pushing the check into a helper?** Other commands (`cmdLink`, `cmdImport`, `cmdPublish`) already call `path.resolve()` directly and were never affected; only the install codepath has the registry-vs-local fork.
- **`stat` vs `lstat`?** Follow symlinks — mirrors what `./skills/x-skill` would do.

## Changes

| File | Change |
|------|--------|
| `src/installer.ts` | Add exported async `isExistingLocalDir` helper |
| `src/cli.ts` | Import helper; add disambiguator before `isBareOrScopedName` branch in `cmdInstall` |
| `src/installer.test.ts` | 5 unit tests for `isExistingLocalDir` |
| `CHANGELOG.md` | Bug Fixes entry under Unreleased |

## Test plan

- [x] `npx vitest run` — all 1789 tests pass across 53 files
- [x] `npx tsc --noEmit` — clean
- [x] Pre-push hook (build + e2e) — passed
- [x] Manual smoke test in `/tmp` fixture:
  - [x] `asm install skills/x-skill` (existing dir) → `local: /private/tmp/.../skills/x-skill` ✓
  - [x] `asm install ./skills/x-skill` → same path ✓ (no regression)
  - [x] `asm install skills/nonexistent` → falls through to registry ✓ (preserved behavior)

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| Running asm command with `skills/x-skill` resolves identically to `./skills/x-skill` | ✓ verified |
| Both forms produce identical command output and exit status | ✓ verified |
| Fix covers all asm subcommands accepting path/skill arguments | ✓ — only `cmdInstall` was affected; `cmdLink`/`cmdImport`/`cmdPublish`/`cmdEval` already call `path.resolve()` directly and worked before |
| Absolute paths and `./`, `../` continue to work without regression | ✓ verified, full unit suite green |