### PR TITLE
chore(security): add local-first security baseline and CI mirror

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,71 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Mirrors scripts/security_check.py, the same runner invoked by the local
+# pre-commit `security-check` hook. Failure parity with local: any HIGH or
+# CRITICAL finding fails the job.
+
+permissions:
+  contents: read
+
+jobs:
+  local-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION=8.30.0
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Install trivy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget gnupg
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(. /etc/os-release && echo "$VERSION_CODENAME") main" \
+            | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install -y trivy
+          trivy --version
+
+      - name: Cache trivy vulnerability DB
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/trivy
+          key: trivy-db-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            trivy-db-${{ runner.os }}-
+
+      - name: Warm trivy vulnerability DB
+        run: trivy fs --download-db-only .
+
+      - name: Install semgrep
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install semgrep
+          semgrep --version
+
+      - name: Run local security checks
+        run: python3 scripts/security_check.py
+
+      - name: Upload security reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-reports
+          path: |
+            security/security-report.json
+            security/security-report.md

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,11 +41,15 @@ jobs:
           sudo apt-get install -y trivy
           trivy --version
 
+      - name: Compute trivy cache week stamp
+        id: trivy-cache-key
+        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Cache trivy vulnerability DB
         uses: actions/cache@v4
         with:
           path: ~/.cache/trivy
-          key: trivy-db-${{ runner.os }}-${{ github.run_id }}
+          key: trivy-db-${{ runner.os }}-${{ steps.trivy-cache-key.outputs.week }}
           restore-keys: |
             trivy-db-${{ runner.os }}-
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,11 @@ competitor-analysis.md
 
 # skill-auto-improver iteration artifacts (baseline + per-iter eval JSON + report)
 .asm-improver/
+
+# Local security runner reports (regenerated each run)
+security/security-report.json
+security/security-report.md
+
+# Backups created by /security-setup
+.pre-commit-config.yaml.bak
+SECURITY.md.bak

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+title = "asm gitleaks config"
+
+# Extend the default gitleaks ruleset.
+[extend]
+useDefault = true
+
+# Allowlist test fixtures that intentionally embed fake API keys to verify
+# ASM's own credential-leak detection. These are not real secrets and live
+# only inside test files.
+[allowlist]
+description = "Test fixtures containing fake credentials used to exercise ASM's security auditor / verifier."
+paths = [
+  '''^src/verifier\.test\.ts$''',
+  '''^src/security-auditor\.test\.ts$''',
+  '''^src/installer\.test\.ts$''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,14 @@ repos:
 
   - repo: local
     hooks:
+      # ── Security ────────────────────────────────────────────────────────────
+      - id: security-check
+        name: local security hardening check
+        entry: python3 scripts/security_check.py
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
       # ── Commit stage ────────────────────────────────────────────────────────
       - id: prettier
         name: prettier

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,3 +41,68 @@ When contributing to this project:
 - Use environment variables for sensitive configuration
 - Follow secure coding practices
 - Report any security concerns immediately
+
+## Local Security Checks
+
+This repository runs local-first security checks through pre-commit. The
+runner at `scripts/security_check.py` invokes the tools listed in
+`security/security-tools.json`, writes a JSON + Markdown report under
+`security/`, and exits non-zero on `HIGH` or `CRITICAL` findings.
+
+### Selected Tools
+
+| Category        | Tool                        | Why selected                                                       | Runtime network    |
+| --------------- | --------------------------- | ------------------------------------------------------------------ | ------------------ |
+| Secrets         | gitleaks                    | Single binary, scans repo content fully offline                    | No                 |
+| Dependencies    | trivy `fs --skip-db-update` | Reads `package-lock.json` against locally warmed vuln DB           | No (DB pre-warmed) |
+| Static analysis | semgrep                     | Local rules under `security/semgrep-rules.yml` (no registry fetch) | No                 |
+
+### Run Locally
+
+```bash
+# Direct invocation
+python3 scripts/security_check.py
+
+# Through pre-commit
+pre-commit run security-check --all-files
+```
+
+Reports land at `security/security-report.json` and `security/security-report.md`.
+
+### Warm the Vulnerability Database
+
+The trivy hook uses `--skip-db-update`, so the DB must be warmed once and
+periodically refreshed:
+
+```bash
+trivy fs --download-db-only .
+```
+
+### Explicit Bypass
+
+Bypass is discouraged. When necessary, run the runner directly with `--force`,
+type the literal `YES` at the prompt, then commit with `--no-verify`.
+`pre-commit` closes hook stdin, so the prompt cannot be answered from inside
+`git commit`.
+
+```bash
+SECURITY_CHECK_ARGS=--force python3 scripts/security_check.py
+# Type YES at the prompt, then:
+git commit --no-verify
+```
+
+Record every bypass below (date, reason, link to the recorded report) so the
+override is auditable.
+
+#### Bypass Log
+
+_None recorded._
+
+### CI Mirror
+
+`.github/workflows/security.yml` runs the same `scripts/security_check.py`
+on `push` to `main` and on every `pull_request`. The workflow installs
+`gitleaks`, `trivy`, and `semgrep`, caches the trivy vulnerability database
+between runs, and uploads `security/security-report.{json,md}` as the
+`security-reports` artifact. Failure parity with the local hook: any
+`HIGH` or `CRITICAL` finding fails the job.

--- a/scripts/security_check.py
+++ b/scripts/security_check.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Local security summary runner for the security-setup skill.
+
+Copy this file into a target repository at scripts/security_check.py.
+It intentionally uses only the Python standard library and external security
+tools selected by security/security-tools.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"]
+DEFAULT_TIMEOUT_SECONDS = 120
+DEFAULT_CONFIG = {
+    "fail_on": ["CRITICAL", "HIGH"],
+    "checks": [
+        {
+            "name": "gitleaks",
+            "category": "secrets",
+            "required": True,
+            "command": [
+                "gitleaks",
+                "detect",
+                "--source",
+                ".",
+                "--redact",
+                "--report-format",
+                "json",
+                "--report-path",
+                "{output}",
+            ],
+        },
+        {
+            "name": "trivy",
+            "category": "dependencies",
+            "required": True,
+            "command": [
+                "trivy",
+                "fs",
+                "--scanners",
+                "vuln",
+                "--skip-db-update",
+                "--format",
+                "json",
+                "--exit-code",
+                "0",
+                ".",
+            ],
+        },
+        {
+            "name": "semgrep",
+            "category": "static",
+            "required": True,
+            "command": [
+                "semgrep",
+                "--config",
+                "security/semgrep-rules.yml",
+                "--json",
+                "--error",
+                ".",
+            ],
+        },
+    ],
+}
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    if path.exists():
+        return json.loads(path.read_text())
+    return DEFAULT_CONFIG
+
+
+def command_exists(command: list[str]) -> bool:
+    return bool(command and shutil.which(command[0]))
+
+
+def materialize_command(command: list[str], output: Path) -> list[str]:
+    return [part.replace("{output}", str(output)) for part in command]
+
+
+def run_check(check: dict[str, Any], tmpdir: Path) -> dict[str, Any]:
+    output = tmpdir / f"{check['name']}.json"
+    command = materialize_command(check["command"], output)
+    result: dict[str, Any] = {
+        "name": check["name"],
+        "category": check.get("category", "other"),
+        "required": bool(check.get("required", False)),
+        "command": command,
+        "returncode": None,
+        "stdout": "",
+        "stderr": "",
+        "raw_output": None,
+        "findings": [],
+    }
+
+    if not command_exists(command):
+        result["tool_error"] = f"Missing tool: {command[0]}"
+        return result
+
+    timeout = int(check.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS))
+    try:
+        proc = subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        result["tool_error"] = f"Tool timed out after {timeout}s: {' '.join(command)}"
+        result["stdout"] = (exc.stdout or "").strip() if isinstance(exc.stdout, str) else ""
+        result["stderr"] = (exc.stderr or "").strip() if isinstance(exc.stderr, str) else ""
+        return result
+    result["returncode"] = proc.returncode
+    result["stdout"] = proc.stdout.strip()
+    result["stderr"] = proc.stderr.strip()
+
+    try:
+        raw = read_json_output(output, proc.stdout)
+    except JsonOutputError as exc:
+        result["raw_output"] = None
+        result["tool_error"] = str(exc)
+        return result
+    result["raw_output"] = raw
+    result["findings"] = parse_findings(check["name"], check.get("category", "other"), raw)
+
+    if not has_parser(check["name"]):
+        result["tool_error"] = (
+            f"No parser registered for tool {check['name']!r}; findings cannot be extracted. "
+            "Add a parser in scripts/security_check.py or use a supported tool name "
+            f"({', '.join(sorted(PARSERS))})."
+        )
+        return result
+
+    if proc.returncode not in (0, 1) and not result["findings"]:
+        result["tool_error"] = result["stderr"] or result["stdout"] or "Tool failed"
+
+    return result
+
+
+class JsonOutputError(Exception):
+    """Raised when a tool's report file or stdout exists but is not valid JSON."""
+
+
+def read_json_output(output_path: Path, stdout: str) -> Any:
+    try:
+        if output_path.exists():
+            text = output_path.read_text()
+            if text.strip():
+                return json.loads(text)
+        if stdout.strip().startswith(("{", "[")):
+            return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise JsonOutputError(f"malformed JSON output: {exc}") from exc
+    except OSError as exc:
+        raise JsonOutputError(f"failed to read report file: {exc}") from exc
+    return None
+
+
+def finding(
+    category: str,
+    severity: str,
+    tool: str,
+    title: str,
+    path: str = "",
+    hint: str = "",
+) -> dict[str, str]:
+    return {
+        "category": category,
+        "severity": normalize_severity(severity),
+        "tool": tool,
+        "title": title,
+        "path": path,
+        "hint": hint,
+    }
+
+
+def normalize_severity(value: str | None) -> str:
+    if not value:
+        return "INFO"
+    value = str(value).upper()
+    if value == "ERROR":
+        return "HIGH"
+    if value == "WARNING":
+        return "MEDIUM"
+    if value in SEVERITY_ORDER:
+        return value
+    return "INFO"
+
+
+def parse_findings(tool: str, category: str, raw: Any) -> list[dict[str, str]]:
+    if raw is None:
+        return []
+    parser = PARSERS.get(tool)
+    if parser is None:
+        return []
+    return parser(raw, category, tool)
+
+
+def has_parser(tool: str) -> bool:
+    return tool in PARSERS
+
+
+def parse_gitleaks(raw: Any, category: str, tool: str) -> list[dict[str, str]]:
+    findings = []
+    for item in raw if isinstance(raw, list) else []:
+        title = item.get("Description") or item.get("RuleID") or "Potential secret"
+        path = item.get("File") or ""
+        hint = "Rotate exposed credential and remove it from git history if committed."
+        findings.append(finding(category, "HIGH", tool, title, path, hint))
+    return findings
+
+
+def parse_trivy(raw: Any, category: str, tool: str) -> list[dict[str, str]]:
+    findings = []
+    for result in raw.get("Results", []) if isinstance(raw, dict) else []:
+        target = result.get("Target", "")
+        for vuln in result.get("Vulnerabilities", []) or []:
+            title = f"{vuln.get('VulnerabilityID', 'Vulnerability')} in {vuln.get('PkgName', 'package')}"
+            fixed = vuln.get("FixedVersion")
+            hint = f"Upgrade to {fixed}." if fixed else "Review advisory and upgrade or pin a safe version."
+            findings.append(finding(category, vuln.get("Severity", "INFO"), tool, title, target, hint))
+    return findings
+
+
+def parse_semgrep(raw: Any, category: str, tool: str) -> list[dict[str, str]]:
+    findings = []
+    for item in raw.get("results", []) if isinstance(raw, dict) else []:
+        extra = item.get("extra", {})
+        check_id = item.get("check_id", "semgrep finding")
+        path = item.get("path", "")
+        title = extra.get("message") or check_id
+        findings.append(finding(category, extra.get("severity", "INFO"), tool, title, path, "Review the matching code and apply the rule guidance."))
+    return findings
+
+
+def parse_bandit(raw: Any, category: str, tool: str) -> list[dict[str, str]]:
+    findings = []
+    for item in raw.get("results", []) if isinstance(raw, dict) else []:
+        title = item.get("issue_text") or item.get("test_id") or "Bandit finding"
+        path = item.get("filename", "")
+        findings.append(finding(category, item.get("issue_severity", "INFO"), tool, title, path, "Follow Bandit remediation guidance."))
+    return findings
+
+
+def parse_cargo_audit(raw: Any, category: str, tool: str) -> list[dict[str, str]]:
+    findings = []
+    vulns = raw.get("vulnerabilities", {}) if isinstance(raw, dict) else {}
+    for item in vulns.get("list", []) or []:
+        advisory = item.get("advisory", {})
+        package = item.get("package", {})
+        title = f"{advisory.get('id', 'Advisory')} in {package.get('name', 'crate')}"
+        severity = advisory.get("severity") or "HIGH"
+        findings.append(
+            finding(
+                category,
+                severity,
+                tool,
+                title,
+                "Cargo.lock",
+                "Update the affected crate or apply the advisory workaround.",
+            )
+        )
+    return findings
+
+
+PARSERS = {
+    "gitleaks": parse_gitleaks,
+    "trivy": parse_trivy,
+    "semgrep": parse_semgrep,
+    "bandit": parse_bandit,
+    "cargo-audit": parse_cargo_audit,
+}
+
+
+def add_tool_error_findings(results: list[dict[str, Any]], no_fail_on_missing_tools: bool) -> None:
+    for result in results:
+        error = result.get("tool_error")
+        if not error:
+            continue
+        severity = "INFO" if no_fail_on_missing_tools and "Missing tool:" in error else "HIGH"
+        result["findings"].append(
+            finding(
+                "tool-errors",
+                severity,
+                result["name"],
+                error,
+                "",
+                "Install the selected tool or mark it optional in security/security-tools.json.",
+            )
+        )
+
+
+def summarize(results: list[dict[str, Any]]) -> tuple[list[dict[str, str]], dict[str, Any]]:
+    findings = [item for result in results for item in result["findings"]]
+    severity_counts = Counter(item["severity"] for item in findings)
+    category_counts = Counter(item["category"] for item in findings)
+    return findings, {
+        "checks_run": len(results),
+        "finding_count": len(findings),
+        "severity_counts": dict(severity_counts),
+        "category_counts": dict(category_counts),
+    }
+
+
+def write_reports(json_path: Path, md_path: Path, payload: dict[str, Any]) -> None:
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    md_path.write_text(render_markdown(payload))
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    summary = payload["summary"]
+    lines = [
+        "# Security Check Report",
+        "",
+        f"Generated: {payload['generated_at']}",
+        "",
+        "## Summary",
+        "",
+        f"- Checks run: {summary['checks_run']}",
+        f"- Findings: {summary['finding_count']}",
+        f"- Severity: {format_counter(summary['severity_counts'])}",
+        f"- Categories: {format_counter(summary['category_counts'])}",
+        "",
+        "## Findings",
+        "",
+    ]
+    if not payload["findings"]:
+        lines.append("No findings.")
+    for item in payload["findings"]:
+        path = f" ({item['path']})" if item.get("path") else ""
+        lines.append(f"- **{item['severity']}** [{item['category']}/{item['tool']}] {item['title']}{path}")
+        if item.get("hint"):
+            lines.append(f"  - Hint: {item['hint']}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_counter(counter: dict[str, int]) -> str:
+    if not counter:
+        return "none"
+    ordered = []
+    for key in SEVERITY_ORDER:
+        if key in counter:
+            ordered.append(f"{key}={counter[key]}")
+    for key in sorted(set(counter) - set(SEVERITY_ORDER)):
+        ordered.append(f"{key}={counter[key]}")
+    return ", ".join(ordered)
+
+
+def print_summary(payload: dict[str, Any], json_path: Path, md_path: Path) -> None:
+    summary = payload["summary"]
+    print("Security Check Summary")
+    print("======================")
+    print(f"Checks run: {summary['checks_run']}")
+    print(f"Findings: {summary['finding_count']}")
+    print(f"Severity: {format_counter(summary['severity_counts'])}")
+    print(f"Categories: {format_counter(summary['category_counts'])}")
+    print(f"JSON report: {json_path}")
+    print(f"Markdown report: {md_path}")
+    if payload["findings"]:
+        print("\nTop findings:")
+        for item in payload["findings"][:10]:
+            path = f" ({item['path']})" if item.get("path") else ""
+            print(f"- {item['severity']} [{item['category']}/{item['tool']}] {item['title']}{path}")
+            if item.get("hint"):
+                print(f"  Hint: {item['hint']}")
+
+
+def should_fail(findings: list[dict[str, str]], fail_on: list[str]) -> bool:
+    fail_set = {normalize_severity(item) for item in fail_on}
+    return any(item["severity"] in fail_set for item in findings)
+
+
+def maybe_force_override(force: bool) -> bool:
+    if not force:
+        return False
+    if not sys.stdin.isatty():
+        print(
+            "Refusing --force in a non-interactive context. Run from a terminal and type YES.",
+            file=sys.stderr,
+        )
+        return False
+    try:
+        answer = input("Type YES to override security checks and force-push: ")
+    except EOFError:
+        print("No confirmation received; bypass denied.", file=sys.stderr)
+        return False
+    return answer == "YES"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run local security checks and print a summary report.")
+    parser.add_argument("--config", default="security/security-tools.json", help="Path to tool config JSON.")
+    parser.add_argument("--output", default="security/security-report.json", help="Path for JSON report.")
+    parser.add_argument("--markdown", default="security/security-report.md", help="Path for Markdown report.")
+    parser.add_argument("--force", action="store_true", help="Allow explicit YES-confirmed bypass when findings would fail.")
+    parser.add_argument("--no-fail-on-missing-tools", action="store_true", help="Treat missing tools as info for first-run verification.")
+    extra = os.environ.get("SECURITY_CHECK_ARGS", "").strip()
+    argv = sys.argv[1:] + (shlex.split(extra, posix=os.name != "nt") if extra else [])
+    args = parser.parse_args(argv)
+
+    config = load_config(Path(args.config))
+    with tempfile.TemporaryDirectory(prefix="security-check-") as tmp:
+        results = [run_check(check, Path(tmp)) for check in config.get("checks", [])]
+
+    add_tool_error_findings(results, args.no_fail_on_missing_tools)
+    findings, summary = summarize(results)
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "summary": summary,
+        "findings": findings,
+        "checks": results,
+    }
+
+    output_path = Path(args.output)
+    markdown_path = Path(args.markdown)
+    write_reports(output_path, markdown_path, payload)
+    print_summary(payload, output_path, markdown_path)
+
+    if should_fail(findings, config.get("fail_on", ["CRITICAL", "HIGH"])):
+        if maybe_force_override(args.force):
+            print("Override accepted. Security findings remain in the report.")
+            return 0
+        print("Security checks failed. Fix findings or rerun with --force and type YES to override.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/security_check.py
+++ b/scripts/security_check.py
@@ -145,7 +145,7 @@ def run_check(check: dict[str, Any], tmpdir: Path) -> dict[str, Any]:
         )
         return result
 
-    if proc.returncode not in (0, 1) and not result["findings"]:
+    if proc.returncode not in (0, 1):
         result["tool_error"] = result["stderr"] or result["stdout"] or "Tool failed"
 
     return result

--- a/security/security-tools.json
+++ b/security/security-tools.json
@@ -1,0 +1,55 @@
+{
+  "fail_on": ["CRITICAL", "HIGH"],
+  "checks": [
+    {
+      "name": "gitleaks",
+      "category": "secrets",
+      "required": true,
+      "command": [
+        "gitleaks",
+        "detect",
+        "--source",
+        ".",
+        "--config",
+        ".gitleaks.toml",
+        "--redact",
+        "--report-format",
+        "json",
+        "--report-path",
+        "{output}"
+      ]
+    },
+    {
+      "name": "trivy",
+      "category": "dependencies",
+      "required": true,
+      "command": [
+        "trivy",
+        "fs",
+        "--scanners",
+        "vuln",
+        "--skip-db-update",
+        "--skip-dirs",
+        ".opencode,.claude,.agents,.gstack,.gitissue,.asm-improver,node_modules,dist,website,coverage",
+        "--format",
+        "json",
+        "--exit-code",
+        "0",
+        "."
+      ]
+    },
+    {
+      "name": "semgrep",
+      "category": "static",
+      "required": true,
+      "command": [
+        "semgrep",
+        "--config",
+        "security/semgrep-rules.yml",
+        "--json",
+        "--error",
+        "."
+      ]
+    }
+  ]
+}

--- a/security/semgrep-rules.yml
+++ b/security/semgrep-rules.yml
@@ -1,0 +1,32 @@
+rules:
+  - id: javascript-eval
+    languages: [javascript, typescript]
+    severity: ERROR
+    message: Avoid eval-like execution of dynamic strings.
+    metadata:
+      cwe: "CWE-95"
+      owasp: "A03:2021-Injection"
+    pattern-either:
+      - pattern: eval(...)
+      - pattern: new Function(...)
+
+  - id: hardcoded-debug-mode
+    languages: [javascript, typescript]
+    severity: WARNING
+    message: Hard-coded debug mode can expose internals in production.
+    metadata:
+      cwe: "CWE-489"
+    pattern-either:
+      - pattern: DEBUG = true
+      - pattern: debug = true
+
+  - id: child-process-shell-true
+    languages: [javascript, typescript]
+    severity: ERROR
+    message: Avoid spawning a shell with dynamic input; pass args as array instead.
+    metadata:
+      cwe: "CWE-78"
+      owasp: "A03:2021-Injection"
+    pattern-either:
+      - pattern: child_process.exec($CMD, ...)
+      - pattern: require('child_process').exec($CMD, ...)

--- a/security/semgrep-rules.yml
+++ b/security/semgrep-rules.yml
@@ -27,6 +27,9 @@ rules:
     metadata:
       cwe: "CWE-78"
       owasp: "A03:2021-Injection"
-    pattern-either:
-      - pattern: child_process.exec($CMD, ...)
-      - pattern: require('child_process').exec($CMD, ...)
+    patterns:
+      - pattern-either:
+          - pattern: child_process.exec($CMD, ...)
+          - pattern: require('child_process').exec($CMD, ...)
+      - pattern-not: child_process.exec("...", ...)
+      - pattern-not: require('child_process').exec("...", ...)


### PR DESCRIPTION
## Summary

- Adds a pre-commit `security-check` hook backed by **gitleaks** (secrets), **trivy** (dependencies), and **semgrep** (static analysis), all running offline at hook time. Exits non-zero on `HIGH`/`CRITICAL` findings.
- Mirrors the same `scripts/security_check.py` runner in `.github/workflows/security.yml` on `push` to `main` and `pull_request`. Caches the trivy vuln DB across runs and uploads `security-reports` (JSON + Markdown) as a build artifact.
- Allowlists 3 test files (`src/{verifier,security-auditor,installer}.test.ts`) that intentionally embed fake API keys to exercise ASM's own credential-leak detection.

## Files

| File | Change |
|---|---|
| `.pre-commit-config.yaml` | Adds `security-check` local hook before existing prettier/typecheck/test stages |
| `scripts/security_check.py` | New stdlib-only runner; reads `security/security-tools.json`, writes JSON + Markdown reports |
| `security/security-tools.json` | Tool list and commands (with `--skip-dirs` for gitignored dev-tooling dirs and `--config .gitleaks.toml`) |
| `security/semgrep-rules.yml` | Local rules: `eval`, hardcoded debug, `child_process.exec` with shell strings |
| `.gitleaks.toml` | Extends gitleaks defaults; allowlists test fixture files |
| `SECURITY.md` | New "Local Security Checks" section (tools table, run commands, bypass policy, bypass log) |
| `.github/workflows/security.yml` | Free-tier GitHub Actions mirror of the local runner |
| `.gitignore` | Ignores generated reports + `.bak` backups |

## Bypass policy

Bypass requires running the runner directly with `SECURITY_CHECK_ARGS=--force`, typing `YES` at the prompt, then `git commit --no-verify`. Documented in `SECURITY.md`. The pre-commit harness closes hook stdin so the prompt cannot be answered from inside `git commit` — this is intentional.

## Test plan

- [x] `python3 scripts/security_check.py` exits 0 with 0 findings on a clean tree
- [x] `pre-commit run security-check --all-files` passes
- [x] All existing pre-commit hooks (prettier, typecheck, unit-tests, build, e2e) still pass
- [x] `security/security-report.json` parses as valid JSON with a top-level `summary` object
- [x] `.github/workflows/security.yml` parses as valid YAML
- [ ] First CI run on this PR exercises the workflow on GitHub's runners
- [ ] Confirm the `security-reports` artifact appears in the workflow run

## Notes

- No SARIF upload — the skill keeps the summary report only; easy to add later via `github/codeql-action/upload-sarif` if you want findings in the Security tab.
- Trivy vuln DB is cached in `~/.cache/trivy` keyed by `runner.os` + `github.run_id`; first run downloads the DB, subsequent runs reuse it.