### PR TITLE
feat(index): index 2 new skill sources - warpdotdev/oz-skills and entireio/skills

### DIFF
--- a/.codex/skills/skill-index-updater
+++ b/.codex/skills/skill-index-updater
@@ -1,0 +1,1 @@
+../../.agents/skills/skill-index-updater

--- a/.gemini/skills/skill-index-updater
+++ b/.gemini/skills/skill-index-updater
@@ -1,0 +1,1 @@
+../../.agents/skills/skill-index-updater

--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -261,6 +261,24 @@
       "description": "A collection of AI agent skills focused on resume optimization, job applications, and career development",
       "maintainer": "@Paramchoudhary",
       "enabled": true
+    },
+    {
+      "source": "github:warpdotdev/oz-skills",
+      "url": "https://github.com/warpdotdev/oz-skills",
+      "owner": "warpdotdev",
+      "repo": "oz-skills",
+      "description": "A curated collection of reusable Agent Skills for Warp AI agents and Oz",
+      "maintainer": "@warpdotdev",
+      "enabled": true
+    },
+    {
+      "source": "github:entireio/skills",
+      "url": "https://github.com/entireio/skills",
+      "owner": "entireio",
+      "repo": "skills",
+      "description": "Cross-agent skills that help coding agents use Entire context from Checkpoints, sessions, and git history to search past work, explain code, and hand off sessions.",
+      "maintainer": "@entireio",
+      "enabled": true
     }
   ]
 }

--- a/data/skill-index/Affitor_affiliate-skills.json
+++ b/data/skill-index/Affitor_affiliate-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Affitor/affiliate-skills.git",
   "owner": "Affitor",
   "repo": "affiliate-skills",
-  "updatedAt": "2026-04-30T23:05:12.281Z",
+  "updatedAt": "2026-05-05T23:45:25.089Z",
   "skillCount": 53,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.162Z",
+        "evaluatedAt": "2026-05-05T23:45:24.937Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.162Z",
+          "evaluatedAt": "2026-05-05T23:45:24.938Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.162Z",
+          "evaluatedAt": "2026-05-05T23:45:24.938Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.164Z",
+        "evaluatedAt": "2026-05-05T23:45:24.940Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.164Z",
+          "evaluatedAt": "2026-05-05T23:45:24.940Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.164Z",
+          "evaluatedAt": "2026-05-05T23:45:24.940Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.167Z",
+        "evaluatedAt": "2026-05-05T23:45:24.943Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.167Z",
+          "evaluatedAt": "2026-05-05T23:45:24.943Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.167Z",
+          "evaluatedAt": "2026-05-05T23:45:24.943Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.169Z",
+        "evaluatedAt": "2026-05-05T23:45:24.946Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.169Z",
+          "evaluatedAt": "2026-05-05T23:45:24.946Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.169Z",
+          "evaluatedAt": "2026-05-05T23:45:24.946Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.171Z",
+        "evaluatedAt": "2026-05-05T23:45:24.948Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.171Z",
+          "evaluatedAt": "2026-05-05T23:45:24.948Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.171Z",
+          "evaluatedAt": "2026-05-05T23:45:24.948Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.173Z",
+        "evaluatedAt": "2026-05-05T23:45:24.950Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.173Z",
+          "evaluatedAt": "2026-05-05T23:45:24.950Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.173Z",
+          "evaluatedAt": "2026-05-05T23:45:24.950Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.175Z",
+        "evaluatedAt": "2026-05-05T23:45:24.953Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.175Z",
+          "evaluatedAt": "2026-05-05T23:45:24.953Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.175Z",
+          "evaluatedAt": "2026-05-05T23:45:24.953Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.178Z",
+        "evaluatedAt": "2026-05-05T23:45:24.956Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.178Z",
+          "evaluatedAt": "2026-05-05T23:45:24.956Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.178Z",
+          "evaluatedAt": "2026-05-05T23:45:24.956Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.181Z",
+        "evaluatedAt": "2026-05-05T23:45:24.959Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.181Z",
+          "evaluatedAt": "2026-05-05T23:45:24.960Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.181Z",
+          "evaluatedAt": "2026-05-05T23:45:24.960Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.183Z",
+        "evaluatedAt": "2026-05-05T23:45:24.962Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.183Z",
+          "evaluatedAt": "2026-05-05T23:45:24.962Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.183Z",
+          "evaluatedAt": "2026-05-05T23:45:24.962Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.186Z",
+        "evaluatedAt": "2026-05-05T23:45:24.965Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.186Z",
+          "evaluatedAt": "2026-05-05T23:45:24.965Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.186Z",
+          "evaluatedAt": "2026-05-05T23:45:24.965Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.188Z",
+        "evaluatedAt": "2026-05-05T23:45:24.968Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.188Z",
+          "evaluatedAt": "2026-05-05T23:45:24.968Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.188Z",
+          "evaluatedAt": "2026-05-05T23:45:24.968Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.190Z",
+        "evaluatedAt": "2026-05-05T23:45:24.970Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.190Z",
+          "evaluatedAt": "2026-05-05T23:45:24.970Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.190Z",
+          "evaluatedAt": "2026-05-05T23:45:24.970Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.192Z",
+        "evaluatedAt": "2026-05-05T23:45:24.973Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.192Z",
+          "evaluatedAt": "2026-05-05T23:45:24.973Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.192Z",
+          "evaluatedAt": "2026-05-05T23:45:24.973Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.194Z",
+        "evaluatedAt": "2026-05-05T23:45:24.975Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.195Z",
+          "evaluatedAt": "2026-05-05T23:45:24.975Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.195Z",
+          "evaluatedAt": "2026-05-05T23:45:24.975Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.197Z",
+        "evaluatedAt": "2026-05-05T23:45:24.978Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.197Z",
+          "evaluatedAt": "2026-05-05T23:45:24.978Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.197Z",
+          "evaluatedAt": "2026-05-05T23:45:24.978Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.199Z",
+        "evaluatedAt": "2026-05-05T23:45:24.982Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.199Z",
+          "evaluatedAt": "2026-05-05T23:45:24.983Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.199Z",
+          "evaluatedAt": "2026-05-05T23:45:24.983Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.201Z",
+        "evaluatedAt": "2026-05-05T23:45:24.985Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.201Z",
+          "evaluatedAt": "2026-05-05T23:45:24.985Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.201Z",
+          "evaluatedAt": "2026-05-05T23:45:24.985Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.203Z",
+        "evaluatedAt": "2026-05-05T23:45:24.988Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.203Z",
+          "evaluatedAt": "2026-05-05T23:45:24.988Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.203Z",
+          "evaluatedAt": "2026-05-05T23:45:24.988Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.206Z",
+        "evaluatedAt": "2026-05-05T23:45:24.990Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.206Z",
+          "evaluatedAt": "2026-05-05T23:45:24.990Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.206Z",
+          "evaluatedAt": "2026-05-05T23:45:24.990Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.208Z",
+        "evaluatedAt": "2026-05-05T23:45:24.995Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.208Z",
+          "evaluatedAt": "2026-05-05T23:45:24.995Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.208Z",
+          "evaluatedAt": "2026-05-05T23:45:24.995Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.210Z",
+        "evaluatedAt": "2026-05-05T23:45:24.998Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.210Z",
+          "evaluatedAt": "2026-05-05T23:45:24.998Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.210Z",
+          "evaluatedAt": "2026-05-05T23:45:24.998Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -3078,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.212Z",
+        "evaluatedAt": "2026-05-05T23:45:25.000Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -3133,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.212Z",
+          "evaluatedAt": "2026-05-05T23:45:25.000Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3151,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.212Z",
+          "evaluatedAt": "2026-05-05T23:45:25.000Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -3215,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.214Z",
+        "evaluatedAt": "2026-05-05T23:45:25.003Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -3270,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.214Z",
+          "evaluatedAt": "2026-05-05T23:45:25.003Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -3288,7 +3288,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.214Z",
+          "evaluatedAt": "2026-05-05T23:45:25.003Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -3352,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.217Z",
+        "evaluatedAt": "2026-05-05T23:45:25.007Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -3407,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.217Z",
+          "evaluatedAt": "2026-05-05T23:45:25.007Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3425,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.217Z",
+          "evaluatedAt": "2026-05-05T23:45:25.007Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -3489,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.219Z",
+        "evaluatedAt": "2026-05-05T23:45:25.009Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -3544,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.219Z",
+          "evaluatedAt": "2026-05-05T23:45:25.009Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -3562,7 +3562,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.219Z",
+          "evaluatedAt": "2026-05-05T23:45:25.009Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -3626,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.221Z",
+        "evaluatedAt": "2026-05-05T23:45:25.012Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -3681,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.221Z",
+          "evaluatedAt": "2026-05-05T23:45:25.012Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -3699,7 +3699,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.221Z",
+          "evaluatedAt": "2026-05-05T23:45:25.012Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -3763,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.223Z",
+        "evaluatedAt": "2026-05-05T23:45:25.016Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -3818,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.223Z",
+          "evaluatedAt": "2026-05-05T23:45:25.016Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3836,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.223Z",
+          "evaluatedAt": "2026-05-05T23:45:25.016Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -3900,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.226Z",
+        "evaluatedAt": "2026-05-05T23:45:25.019Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -3955,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.226Z",
+          "evaluatedAt": "2026-05-05T23:45:25.019Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -3973,7 +3973,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.226Z",
+          "evaluatedAt": "2026-05-05T23:45:25.019Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -4037,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.229Z",
+        "evaluatedAt": "2026-05-05T23:45:25.023Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -4092,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.229Z",
+          "evaluatedAt": "2026-05-05T23:45:25.023Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -4110,7 +4110,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.229Z",
+          "evaluatedAt": "2026-05-05T23:45:25.023Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -4174,7 +4174,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.231Z",
+        "evaluatedAt": "2026-05-05T23:45:25.026Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -4229,7 +4229,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.231Z",
+          "evaluatedAt": "2026-05-05T23:45:25.026Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -4247,7 +4247,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.231Z",
+          "evaluatedAt": "2026-05-05T23:45:25.026Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -4311,7 +4311,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.233Z",
+        "evaluatedAt": "2026-05-05T23:45:25.028Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -4366,7 +4366,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.233Z",
+          "evaluatedAt": "2026-05-05T23:45:25.028Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -4384,7 +4384,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.233Z",
+          "evaluatedAt": "2026-05-05T23:45:25.028Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -4448,7 +4448,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.235Z",
+        "evaluatedAt": "2026-05-05T23:45:25.030Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -4503,7 +4503,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.235Z",
+          "evaluatedAt": "2026-05-05T23:45:25.030Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -4521,7 +4521,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.235Z",
+          "evaluatedAt": "2026-05-05T23:45:25.030Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -4585,7 +4585,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.237Z",
+        "evaluatedAt": "2026-05-05T23:45:25.032Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -4640,7 +4640,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.237Z",
+          "evaluatedAt": "2026-05-05T23:45:25.032Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -4658,7 +4658,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.237Z",
+          "evaluatedAt": "2026-05-05T23:45:25.032Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -4722,7 +4722,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.239Z",
+        "evaluatedAt": "2026-05-05T23:45:25.035Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -4777,7 +4777,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.239Z",
+          "evaluatedAt": "2026-05-05T23:45:25.035Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -4795,7 +4795,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.239Z",
+          "evaluatedAt": "2026-05-05T23:45:25.035Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -4859,7 +4859,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.241Z",
+        "evaluatedAt": "2026-05-05T23:45:25.037Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -4914,7 +4914,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.241Z",
+          "evaluatedAt": "2026-05-05T23:45:25.037Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -4932,7 +4932,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.241Z",
+          "evaluatedAt": "2026-05-05T23:45:25.037Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -4996,7 +4996,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.243Z",
+        "evaluatedAt": "2026-05-05T23:45:25.039Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -5051,7 +5051,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.243Z",
+          "evaluatedAt": "2026-05-05T23:45:25.040Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -5069,7 +5069,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.243Z",
+          "evaluatedAt": "2026-05-05T23:45:25.040Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -5133,7 +5133,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.245Z",
+        "evaluatedAt": "2026-05-05T23:45:25.042Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -5188,7 +5188,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.245Z",
+          "evaluatedAt": "2026-05-05T23:45:25.042Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -5206,7 +5206,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.245Z",
+          "evaluatedAt": "2026-05-05T23:45:25.042Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -5270,7 +5270,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.247Z",
+        "evaluatedAt": "2026-05-05T23:45:25.044Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -5325,7 +5325,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.247Z",
+          "evaluatedAt": "2026-05-05T23:45:25.044Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -5343,7 +5343,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.247Z",
+          "evaluatedAt": "2026-05-05T23:45:25.044Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -5407,7 +5407,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.249Z",
+        "evaluatedAt": "2026-05-05T23:45:25.047Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -5462,7 +5462,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.249Z",
+          "evaluatedAt": "2026-05-05T23:45:25.047Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -5480,7 +5480,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.249Z",
+          "evaluatedAt": "2026-05-05T23:45:25.047Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -5544,7 +5544,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.251Z",
+        "evaluatedAt": "2026-05-05T23:45:25.049Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -5599,7 +5599,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.251Z",
+          "evaluatedAt": "2026-05-05T23:45:25.049Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -5617,7 +5617,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.251Z",
+          "evaluatedAt": "2026-05-05T23:45:25.049Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -5681,7 +5681,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.253Z",
+        "evaluatedAt": "2026-05-05T23:45:25.052Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -5736,7 +5736,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.253Z",
+          "evaluatedAt": "2026-05-05T23:45:25.052Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -5754,7 +5754,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.253Z",
+          "evaluatedAt": "2026-05-05T23:45:25.052Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -5818,7 +5818,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.255Z",
+        "evaluatedAt": "2026-05-05T23:45:25.054Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -5873,7 +5873,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.255Z",
+          "evaluatedAt": "2026-05-05T23:45:25.054Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -5891,7 +5891,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.255Z",
+          "evaluatedAt": "2026-05-05T23:45:25.054Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -5955,7 +5955,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.257Z",
+        "evaluatedAt": "2026-05-05T23:45:25.057Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -6010,7 +6010,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.257Z",
+          "evaluatedAt": "2026-05-05T23:45:25.057Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -6028,7 +6028,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.257Z",
+          "evaluatedAt": "2026-05-05T23:45:25.057Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -6092,7 +6092,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.260Z",
+        "evaluatedAt": "2026-05-05T23:45:25.060Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -6147,7 +6147,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.260Z",
+          "evaluatedAt": "2026-05-05T23:45:25.061Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -6165,7 +6165,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.260Z",
+          "evaluatedAt": "2026-05-05T23:45:25.061Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -6229,7 +6229,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.262Z",
+        "evaluatedAt": "2026-05-05T23:45:25.064Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -6284,7 +6284,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.262Z",
+          "evaluatedAt": "2026-05-05T23:45:25.064Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -6302,7 +6302,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.262Z",
+          "evaluatedAt": "2026-05-05T23:45:25.064Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -6366,7 +6366,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.265Z",
+        "evaluatedAt": "2026-05-05T23:45:25.067Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -6421,7 +6421,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.265Z",
+          "evaluatedAt": "2026-05-05T23:45:25.067Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -6439,7 +6439,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.265Z",
+          "evaluatedAt": "2026-05-05T23:45:25.067Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -6503,7 +6503,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.267Z",
+        "evaluatedAt": "2026-05-05T23:45:25.071Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -6558,7 +6558,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.267Z",
+          "evaluatedAt": "2026-05-05T23:45:25.071Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -6576,7 +6576,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.267Z",
+          "evaluatedAt": "2026-05-05T23:45:25.071Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -6640,7 +6640,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.270Z",
+        "evaluatedAt": "2026-05-05T23:45:25.074Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -6695,7 +6695,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.270Z",
+          "evaluatedAt": "2026-05-05T23:45:25.074Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -6713,7 +6713,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.270Z",
+          "evaluatedAt": "2026-05-05T23:45:25.074Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -6777,7 +6777,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.272Z",
+        "evaluatedAt": "2026-05-05T23:45:25.077Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -6832,7 +6832,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.272Z",
+          "evaluatedAt": "2026-05-05T23:45:25.077Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -6850,7 +6850,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.272Z",
+          "evaluatedAt": "2026-05-05T23:45:25.077Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -6914,7 +6914,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.275Z",
+        "evaluatedAt": "2026-05-05T23:45:25.080Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -6969,7 +6969,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.275Z",
+          "evaluatedAt": "2026-05-05T23:45:25.080Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -6987,7 +6987,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.275Z",
+          "evaluatedAt": "2026-05-05T23:45:25.080Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -7051,7 +7051,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.278Z",
+        "evaluatedAt": "2026-05-05T23:45:25.084Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -7106,7 +7106,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.278Z",
+          "evaluatedAt": "2026-05-05T23:45:25.084Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -7124,7 +7124,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.278Z",
+          "evaluatedAt": "2026-05-05T23:45:25.084Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -7188,7 +7188,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:12.280Z",
+        "evaluatedAt": "2026-05-05T23:45:25.088Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -7243,7 +7243,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.280Z",
+          "evaluatedAt": "2026-05-05T23:45:25.088Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -7261,7 +7261,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:12.280Z",
+          "evaluatedAt": "2026-05-05T23:45:25.088Z",
           "evaluatedVersion": "1.0"
         }
       }

--- a/data/skill-index/Eronred_aso-skills.json
+++ b/data/skill-index/Eronred_aso-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Eronred/aso-skills.git",
   "owner": "Eronred",
   "repo": "aso-skills",
-  "updatedAt": "2026-04-30T23:05:16.141Z",
+  "updatedAt": "2026-05-05T23:45:29.065Z",
   "skillCount": 30,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.099Z",
+        "evaluatedAt": "2026-05-05T23:45:29.021Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.099Z",
+          "evaluatedAt": "2026-05-05T23:45:29.021Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.099Z",
+          "evaluatedAt": "2026-05-05T23:45:29.021Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.100Z",
+        "evaluatedAt": "2026-05-05T23:45:29.023Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.100Z",
+          "evaluatedAt": "2026-05-05T23:45:29.023Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.100Z",
+          "evaluatedAt": "2026-05-05T23:45:29.023Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.102Z",
+        "evaluatedAt": "2026-05-05T23:45:29.025Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.102Z",
+          "evaluatedAt": "2026-05-05T23:45:29.025Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.102Z",
+          "evaluatedAt": "2026-05-05T23:45:29.025Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.103Z",
+        "evaluatedAt": "2026-05-05T23:45:29.027Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.103Z",
+          "evaluatedAt": "2026-05-05T23:45:29.027Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.103Z",
+          "evaluatedAt": "2026-05-05T23:45:29.027Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.105Z",
+        "evaluatedAt": "2026-05-05T23:45:29.029Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.105Z",
+          "evaluatedAt": "2026-05-05T23:45:29.029Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.105Z",
+          "evaluatedAt": "2026-05-05T23:45:29.029Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.106Z",
+        "evaluatedAt": "2026-05-05T23:45:29.030Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.106Z",
+          "evaluatedAt": "2026-05-05T23:45:29.030Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.106Z",
+          "evaluatedAt": "2026-05-05T23:45:29.030Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.107Z",
+        "evaluatedAt": "2026-05-05T23:45:29.032Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.107Z",
+          "evaluatedAt": "2026-05-05T23:45:29.032Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.107Z",
+          "evaluatedAt": "2026-05-05T23:45:29.032Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.108Z",
+        "evaluatedAt": "2026-05-05T23:45:29.033Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.108Z",
+          "evaluatedAt": "2026-05-05T23:45:29.033Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.108Z",
+          "evaluatedAt": "2026-05-05T23:45:29.033Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.110Z",
+        "evaluatedAt": "2026-05-05T23:45:29.035Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.110Z",
+          "evaluatedAt": "2026-05-05T23:45:29.035Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.110Z",
+          "evaluatedAt": "2026-05-05T23:45:29.035Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.111Z",
+        "evaluatedAt": "2026-05-05T23:45:29.037Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.111Z",
+          "evaluatedAt": "2026-05-05T23:45:29.037Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.111Z",
+          "evaluatedAt": "2026-05-05T23:45:29.037Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.113Z",
+        "evaluatedAt": "2026-05-05T23:45:29.038Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.113Z",
+          "evaluatedAt": "2026-05-05T23:45:29.038Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.113Z",
+          "evaluatedAt": "2026-05-05T23:45:29.038Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.114Z",
+        "evaluatedAt": "2026-05-05T23:45:29.040Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.114Z",
+          "evaluatedAt": "2026-05-05T23:45:29.040Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.114Z",
+          "evaluatedAt": "2026-05-05T23:45:29.040Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.116Z",
+        "evaluatedAt": "2026-05-05T23:45:29.041Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.116Z",
+          "evaluatedAt": "2026-05-05T23:45:29.041Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.116Z",
+          "evaluatedAt": "2026-05-05T23:45:29.041Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.117Z",
+        "evaluatedAt": "2026-05-05T23:45:29.042Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.117Z",
+          "evaluatedAt": "2026-05-05T23:45:29.042Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.117Z",
+          "evaluatedAt": "2026-05-05T23:45:29.042Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.119Z",
+        "evaluatedAt": "2026-05-05T23:45:29.044Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.119Z",
+          "evaluatedAt": "2026-05-05T23:45:29.044Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.119Z",
+          "evaluatedAt": "2026-05-05T23:45:29.044Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.120Z",
+        "evaluatedAt": "2026-05-05T23:45:29.045Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.120Z",
+          "evaluatedAt": "2026-05-05T23:45:29.045Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.120Z",
+          "evaluatedAt": "2026-05-05T23:45:29.045Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.122Z",
+        "evaluatedAt": "2026-05-05T23:45:29.046Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.122Z",
+          "evaluatedAt": "2026-05-05T23:45:29.046Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.122Z",
+          "evaluatedAt": "2026-05-05T23:45:29.046Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.123Z",
+        "evaluatedAt": "2026-05-05T23:45:29.047Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.123Z",
+          "evaluatedAt": "2026-05-05T23:45:29.047Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.123Z",
+          "evaluatedAt": "2026-05-05T23:45:29.047Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.125Z",
+        "evaluatedAt": "2026-05-05T23:45:29.048Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.125Z",
+          "evaluatedAt": "2026-05-05T23:45:29.048Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.125Z",
+          "evaluatedAt": "2026-05-05T23:45:29.048Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.126Z",
+        "evaluatedAt": "2026-05-05T23:45:29.050Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.126Z",
+          "evaluatedAt": "2026-05-05T23:45:29.050Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.126Z",
+          "evaluatedAt": "2026-05-05T23:45:29.050Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.128Z",
+        "evaluatedAt": "2026-05-05T23:45:29.051Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.128Z",
+          "evaluatedAt": "2026-05-05T23:45:29.051Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.128Z",
+          "evaluatedAt": "2026-05-05T23:45:29.051Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.129Z",
+        "evaluatedAt": "2026-05-05T23:45:29.053Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.129Z",
+          "evaluatedAt": "2026-05-05T23:45:29.053Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.129Z",
+          "evaluatedAt": "2026-05-05T23:45:29.053Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3078,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.130Z",
+        "evaluatedAt": "2026-05-05T23:45:29.054Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3133,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.131Z",
+          "evaluatedAt": "2026-05-05T23:45:29.054Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3151,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.131Z",
+          "evaluatedAt": "2026-05-05T23:45:29.054Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3215,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.132Z",
+        "evaluatedAt": "2026-05-05T23:45:29.056Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3270,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.132Z",
+          "evaluatedAt": "2026-05-05T23:45:29.056Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3288,7 +3288,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.132Z",
+          "evaluatedAt": "2026-05-05T23:45:29.056Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3352,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.133Z",
+        "evaluatedAt": "2026-05-05T23:45:29.057Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3407,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.134Z",
+          "evaluatedAt": "2026-05-05T23:45:29.057Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3425,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.134Z",
+          "evaluatedAt": "2026-05-05T23:45:29.057Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3489,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.135Z",
+        "evaluatedAt": "2026-05-05T23:45:29.058Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3544,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.135Z",
+          "evaluatedAt": "2026-05-05T23:45:29.058Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3562,7 +3562,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.135Z",
+          "evaluatedAt": "2026-05-05T23:45:29.058Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3626,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.136Z",
+        "evaluatedAt": "2026-05-05T23:45:29.060Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3681,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.136Z",
+          "evaluatedAt": "2026-05-05T23:45:29.060Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3699,7 +3699,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.136Z",
+          "evaluatedAt": "2026-05-05T23:45:29.060Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3763,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.137Z",
+        "evaluatedAt": "2026-05-05T23:45:29.061Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3818,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.137Z",
+          "evaluatedAt": "2026-05-05T23:45:29.061Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3836,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.137Z",
+          "evaluatedAt": "2026-05-05T23:45:29.061Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3900,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.139Z",
+        "evaluatedAt": "2026-05-05T23:45:29.063Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3955,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.139Z",
+          "evaluatedAt": "2026-05-05T23:45:29.063Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3973,7 +3973,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.139Z",
+          "evaluatedAt": "2026-05-05T23:45:29.063Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -4037,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.140Z",
+        "evaluatedAt": "2026-05-05T23:45:29.064Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -4092,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.140Z",
+          "evaluatedAt": "2026-05-05T23:45:29.064Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -4110,7 +4110,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.140Z",
+          "evaluatedAt": "2026-05-05T23:45:29.064Z",
           "evaluatedVersion": "1.0.0"
         }
       }

--- a/data/skill-index/GPTomics_bioSkills.json
+++ b/data/skill-index/GPTomics_bioSkills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/GPTomics/bioSkills.git",
   "owner": "GPTomics",
   "repo": "bioSkills",
-  "updatedAt": "2026-04-30T23:05:23.593Z",
+  "updatedAt": "2026-05-05T23:45:36.336Z",
   "skillCount": 439,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.904Z",
+        "evaluatedAt": "2026-05-05T23:45:35.640Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.905Z",
+          "evaluatedAt": "2026-05-05T23:45:35.640Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.905Z",
+          "evaluatedAt": "2026-05-05T23:45:35.640Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.906Z",
+        "evaluatedAt": "2026-05-05T23:45:35.641Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.906Z",
+          "evaluatedAt": "2026-05-05T23:45:35.641Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.906Z",
+          "evaluatedAt": "2026-05-05T23:45:35.641Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.908Z",
+        "evaluatedAt": "2026-05-05T23:45:35.643Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.908Z",
+          "evaluatedAt": "2026-05-05T23:45:35.643Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.908Z",
+          "evaluatedAt": "2026-05-05T23:45:35.643Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.910Z",
+        "evaluatedAt": "2026-05-05T23:45:35.645Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.910Z",
+          "evaluatedAt": "2026-05-05T23:45:35.645Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.910Z",
+          "evaluatedAt": "2026-05-05T23:45:35.645Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.911Z",
+        "evaluatedAt": "2026-05-05T23:45:35.647Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.911Z",
+          "evaluatedAt": "2026-05-05T23:45:35.647Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.911Z",
+          "evaluatedAt": "2026-05-05T23:45:35.647Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.913Z",
+        "evaluatedAt": "2026-05-05T23:45:35.649Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.914Z",
+          "evaluatedAt": "2026-05-05T23:45:35.649Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.914Z",
+          "evaluatedAt": "2026-05-05T23:45:35.649Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.916Z",
+        "evaluatedAt": "2026-05-05T23:45:35.652Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.916Z",
+          "evaluatedAt": "2026-05-05T23:45:35.652Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.916Z",
+          "evaluatedAt": "2026-05-05T23:45:35.652Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.918Z",
+        "evaluatedAt": "2026-05-05T23:45:35.655Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.918Z",
+          "evaluatedAt": "2026-05-05T23:45:35.655Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.918Z",
+          "evaluatedAt": "2026-05-05T23:45:35.655Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.921Z",
+        "evaluatedAt": "2026-05-05T23:45:35.657Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.921Z",
+          "evaluatedAt": "2026-05-05T23:45:35.657Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.921Z",
+          "evaluatedAt": "2026-05-05T23:45:35.657Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.923Z",
+        "evaluatedAt": "2026-05-05T23:45:35.659Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.923Z",
+          "evaluatedAt": "2026-05-05T23:45:35.659Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.923Z",
+          "evaluatedAt": "2026-05-05T23:45:35.659Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.925Z",
+        "evaluatedAt": "2026-05-05T23:45:35.661Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.925Z",
+          "evaluatedAt": "2026-05-05T23:45:35.661Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.925Z",
+          "evaluatedAt": "2026-05-05T23:45:35.661Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.926Z",
+        "evaluatedAt": "2026-05-05T23:45:35.662Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.926Z",
+          "evaluatedAt": "2026-05-05T23:45:35.662Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.926Z",
+          "evaluatedAt": "2026-05-05T23:45:35.662Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.928Z",
+        "evaluatedAt": "2026-05-05T23:45:35.664Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.928Z",
+          "evaluatedAt": "2026-05-05T23:45:35.664Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.928Z",
+          "evaluatedAt": "2026-05-05T23:45:35.664Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.929Z",
+        "evaluatedAt": "2026-05-05T23:45:35.665Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.929Z",
+          "evaluatedAt": "2026-05-05T23:45:35.666Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.929Z",
+          "evaluatedAt": "2026-05-05T23:45:35.666Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.931Z",
+        "evaluatedAt": "2026-05-05T23:45:35.667Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.931Z",
+          "evaluatedAt": "2026-05-05T23:45:35.667Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.931Z",
+          "evaluatedAt": "2026-05-05T23:45:35.667Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.932Z",
+        "evaluatedAt": "2026-05-05T23:45:35.669Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.932Z",
+          "evaluatedAt": "2026-05-05T23:45:35.669Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.932Z",
+          "evaluatedAt": "2026-05-05T23:45:35.669Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.934Z",
+        "evaluatedAt": "2026-05-05T23:45:35.670Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.934Z",
+          "evaluatedAt": "2026-05-05T23:45:35.670Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.934Z",
+          "evaluatedAt": "2026-05-05T23:45:35.670Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.935Z",
+        "evaluatedAt": "2026-05-05T23:45:35.672Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.935Z",
+          "evaluatedAt": "2026-05-05T23:45:35.672Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.935Z",
+          "evaluatedAt": "2026-05-05T23:45:35.672Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.937Z",
+        "evaluatedAt": "2026-05-05T23:45:35.674Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.937Z",
+          "evaluatedAt": "2026-05-05T23:45:35.674Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.937Z",
+          "evaluatedAt": "2026-05-05T23:45:35.674Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.939Z",
+        "evaluatedAt": "2026-05-05T23:45:35.676Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.939Z",
+          "evaluatedAt": "2026-05-05T23:45:35.676Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.939Z",
+          "evaluatedAt": "2026-05-05T23:45:35.676Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.940Z",
+        "evaluatedAt": "2026-05-05T23:45:35.677Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.940Z",
+          "evaluatedAt": "2026-05-05T23:45:35.677Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.940Z",
+          "evaluatedAt": "2026-05-05T23:45:35.677Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.942Z",
+        "evaluatedAt": "2026-05-05T23:45:35.679Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.942Z",
+          "evaluatedAt": "2026-05-05T23:45:35.679Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.942Z",
+          "evaluatedAt": "2026-05-05T23:45:35.679Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3078,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.944Z",
+        "evaluatedAt": "2026-05-05T23:45:35.680Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3133,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.944Z",
+          "evaluatedAt": "2026-05-05T23:45:35.681Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3151,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.944Z",
+          "evaluatedAt": "2026-05-05T23:45:35.681Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3215,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.946Z",
+        "evaluatedAt": "2026-05-05T23:45:35.682Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3270,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.946Z",
+          "evaluatedAt": "2026-05-05T23:45:35.682Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3288,7 +3288,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.946Z",
+          "evaluatedAt": "2026-05-05T23:45:35.682Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3352,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.948Z",
+        "evaluatedAt": "2026-05-05T23:45:35.684Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3407,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.948Z",
+          "evaluatedAt": "2026-05-05T23:45:35.684Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3425,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.948Z",
+          "evaluatedAt": "2026-05-05T23:45:35.684Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3489,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.949Z",
+        "evaluatedAt": "2026-05-05T23:45:35.686Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3544,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.949Z",
+          "evaluatedAt": "2026-05-05T23:45:35.686Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3562,7 +3562,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.949Z",
+          "evaluatedAt": "2026-05-05T23:45:35.686Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3626,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.951Z",
+        "evaluatedAt": "2026-05-05T23:45:35.687Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3681,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.951Z",
+          "evaluatedAt": "2026-05-05T23:45:35.687Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3699,7 +3699,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.951Z",
+          "evaluatedAt": "2026-05-05T23:45:35.687Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3763,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.953Z",
+        "evaluatedAt": "2026-05-05T23:45:35.689Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3818,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.953Z",
+          "evaluatedAt": "2026-05-05T23:45:35.689Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3836,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.953Z",
+          "evaluatedAt": "2026-05-05T23:45:35.689Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3900,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.954Z",
+        "evaluatedAt": "2026-05-05T23:45:35.691Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3955,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.954Z",
+          "evaluatedAt": "2026-05-05T23:45:35.691Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3973,7 +3973,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.954Z",
+          "evaluatedAt": "2026-05-05T23:45:35.691Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4037,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.956Z",
+        "evaluatedAt": "2026-05-05T23:45:35.692Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4092,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.956Z",
+          "evaluatedAt": "2026-05-05T23:45:35.692Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4110,7 +4110,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.956Z",
+          "evaluatedAt": "2026-05-05T23:45:35.692Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4174,7 +4174,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.958Z",
+        "evaluatedAt": "2026-05-05T23:45:35.695Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4229,7 +4229,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.958Z",
+          "evaluatedAt": "2026-05-05T23:45:35.695Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4247,7 +4247,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.958Z",
+          "evaluatedAt": "2026-05-05T23:45:35.695Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4311,7 +4311,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.961Z",
+        "evaluatedAt": "2026-05-05T23:45:35.697Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4366,7 +4366,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.961Z",
+          "evaluatedAt": "2026-05-05T23:45:35.697Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4384,7 +4384,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.961Z",
+          "evaluatedAt": "2026-05-05T23:45:35.697Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4448,7 +4448,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.964Z",
+        "evaluatedAt": "2026-05-05T23:45:35.700Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4503,7 +4503,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.964Z",
+          "evaluatedAt": "2026-05-05T23:45:35.700Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4521,7 +4521,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.964Z",
+          "evaluatedAt": "2026-05-05T23:45:35.700Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4585,7 +4585,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.966Z",
+        "evaluatedAt": "2026-05-05T23:45:35.701Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4640,7 +4640,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.966Z",
+          "evaluatedAt": "2026-05-05T23:45:35.701Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4658,7 +4658,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.966Z",
+          "evaluatedAt": "2026-05-05T23:45:35.701Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4722,7 +4722,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.967Z",
+        "evaluatedAt": "2026-05-05T23:45:35.703Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4777,7 +4777,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.967Z",
+          "evaluatedAt": "2026-05-05T23:45:35.703Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4795,7 +4795,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.967Z",
+          "evaluatedAt": "2026-05-05T23:45:35.703Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4859,7 +4859,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.969Z",
+        "evaluatedAt": "2026-05-05T23:45:35.704Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4914,7 +4914,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.969Z",
+          "evaluatedAt": "2026-05-05T23:45:35.704Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4932,7 +4932,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.969Z",
+          "evaluatedAt": "2026-05-05T23:45:35.704Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4996,7 +4996,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.971Z",
+        "evaluatedAt": "2026-05-05T23:45:35.706Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5051,7 +5051,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.971Z",
+          "evaluatedAt": "2026-05-05T23:45:35.706Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5069,7 +5069,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.971Z",
+          "evaluatedAt": "2026-05-05T23:45:35.706Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5133,7 +5133,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.973Z",
+        "evaluatedAt": "2026-05-05T23:45:35.708Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5188,7 +5188,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.973Z",
+          "evaluatedAt": "2026-05-05T23:45:35.708Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5206,7 +5206,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.973Z",
+          "evaluatedAt": "2026-05-05T23:45:35.708Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5270,7 +5270,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.975Z",
+        "evaluatedAt": "2026-05-05T23:45:35.710Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5325,7 +5325,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.975Z",
+          "evaluatedAt": "2026-05-05T23:45:35.710Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5343,7 +5343,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.975Z",
+          "evaluatedAt": "2026-05-05T23:45:35.710Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5407,7 +5407,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.977Z",
+        "evaluatedAt": "2026-05-05T23:45:35.712Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5462,7 +5462,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.977Z",
+          "evaluatedAt": "2026-05-05T23:45:35.712Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5480,7 +5480,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.977Z",
+          "evaluatedAt": "2026-05-05T23:45:35.712Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5544,7 +5544,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.978Z",
+        "evaluatedAt": "2026-05-05T23:45:35.714Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5599,7 +5599,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.978Z",
+          "evaluatedAt": "2026-05-05T23:45:35.714Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5617,7 +5617,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.978Z",
+          "evaluatedAt": "2026-05-05T23:45:35.714Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5681,7 +5681,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.980Z",
+        "evaluatedAt": "2026-05-05T23:45:35.715Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5736,7 +5736,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.980Z",
+          "evaluatedAt": "2026-05-05T23:45:35.715Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5754,7 +5754,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.980Z",
+          "evaluatedAt": "2026-05-05T23:45:35.715Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5818,7 +5818,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.981Z",
+        "evaluatedAt": "2026-05-05T23:45:35.717Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5873,7 +5873,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.981Z",
+          "evaluatedAt": "2026-05-05T23:45:35.717Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5891,7 +5891,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.981Z",
+          "evaluatedAt": "2026-05-05T23:45:35.717Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5955,7 +5955,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.982Z",
+        "evaluatedAt": "2026-05-05T23:45:35.718Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6010,7 +6010,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.982Z",
+          "evaluatedAt": "2026-05-05T23:45:35.718Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6028,7 +6028,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.982Z",
+          "evaluatedAt": "2026-05-05T23:45:35.718Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6092,7 +6092,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.984Z",
+        "evaluatedAt": "2026-05-05T23:45:35.719Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6147,7 +6147,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.984Z",
+          "evaluatedAt": "2026-05-05T23:45:35.719Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6165,7 +6165,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.984Z",
+          "evaluatedAt": "2026-05-05T23:45:35.719Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6229,7 +6229,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.985Z",
+        "evaluatedAt": "2026-05-05T23:45:35.720Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6284,7 +6284,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.985Z",
+          "evaluatedAt": "2026-05-05T23:45:35.720Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6302,7 +6302,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.985Z",
+          "evaluatedAt": "2026-05-05T23:45:35.720Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6366,7 +6366,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.986Z",
+        "evaluatedAt": "2026-05-05T23:45:35.722Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6421,7 +6421,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.986Z",
+          "evaluatedAt": "2026-05-05T23:45:35.722Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6439,7 +6439,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.986Z",
+          "evaluatedAt": "2026-05-05T23:45:35.722Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6503,7 +6503,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.987Z",
+        "evaluatedAt": "2026-05-05T23:45:35.723Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6558,7 +6558,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.987Z",
+          "evaluatedAt": "2026-05-05T23:45:35.723Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6576,7 +6576,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.988Z",
+          "evaluatedAt": "2026-05-05T23:45:35.723Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6640,7 +6640,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.989Z",
+        "evaluatedAt": "2026-05-05T23:45:35.725Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6695,7 +6695,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.989Z",
+          "evaluatedAt": "2026-05-05T23:45:35.725Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6713,7 +6713,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.989Z",
+          "evaluatedAt": "2026-05-05T23:45:35.725Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6777,7 +6777,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.991Z",
+        "evaluatedAt": "2026-05-05T23:45:35.726Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6832,7 +6832,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.991Z",
+          "evaluatedAt": "2026-05-05T23:45:35.726Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6850,7 +6850,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.991Z",
+          "evaluatedAt": "2026-05-05T23:45:35.726Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6914,7 +6914,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.992Z",
+        "evaluatedAt": "2026-05-05T23:45:35.728Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6969,7 +6969,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.992Z",
+          "evaluatedAt": "2026-05-05T23:45:35.728Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6987,7 +6987,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.992Z",
+          "evaluatedAt": "2026-05-05T23:45:35.728Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7051,7 +7051,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.993Z",
+        "evaluatedAt": "2026-05-05T23:45:35.729Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7106,7 +7106,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.993Z",
+          "evaluatedAt": "2026-05-05T23:45:35.729Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7124,7 +7124,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.993Z",
+          "evaluatedAt": "2026-05-05T23:45:35.729Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7188,7 +7188,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.994Z",
+        "evaluatedAt": "2026-05-05T23:45:35.730Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7243,7 +7243,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.994Z",
+          "evaluatedAt": "2026-05-05T23:45:35.730Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7261,7 +7261,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.994Z",
+          "evaluatedAt": "2026-05-05T23:45:35.730Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7325,7 +7325,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.995Z",
+        "evaluatedAt": "2026-05-05T23:45:35.730Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7380,7 +7380,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.995Z",
+          "evaluatedAt": "2026-05-05T23:45:35.730Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7398,7 +7398,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.995Z",
+          "evaluatedAt": "2026-05-05T23:45:35.730Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7462,7 +7462,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.996Z",
+        "evaluatedAt": "2026-05-05T23:45:35.731Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7517,7 +7517,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.996Z",
+          "evaluatedAt": "2026-05-05T23:45:35.731Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7535,7 +7535,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.996Z",
+          "evaluatedAt": "2026-05-05T23:45:35.731Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7599,7 +7599,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.997Z",
+        "evaluatedAt": "2026-05-05T23:45:35.732Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7654,7 +7654,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.997Z",
+          "evaluatedAt": "2026-05-05T23:45:35.732Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7672,7 +7672,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.997Z",
+          "evaluatedAt": "2026-05-05T23:45:35.732Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7736,7 +7736,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:22.998Z",
+        "evaluatedAt": "2026-05-05T23:45:35.734Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7791,7 +7791,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.998Z",
+          "evaluatedAt": "2026-05-05T23:45:35.734Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7809,7 +7809,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:22.998Z",
+          "evaluatedAt": "2026-05-05T23:45:35.734Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7873,7 +7873,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.000Z",
+        "evaluatedAt": "2026-05-05T23:45:35.736Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7928,7 +7928,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.000Z",
+          "evaluatedAt": "2026-05-05T23:45:35.737Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7946,7 +7946,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.000Z",
+          "evaluatedAt": "2026-05-05T23:45:35.737Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8010,7 +8010,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.003Z",
+        "evaluatedAt": "2026-05-05T23:45:35.739Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8065,7 +8065,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.003Z",
+          "evaluatedAt": "2026-05-05T23:45:35.739Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8083,7 +8083,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.003Z",
+          "evaluatedAt": "2026-05-05T23:45:35.739Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8147,7 +8147,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.005Z",
+        "evaluatedAt": "2026-05-05T23:45:35.741Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8202,7 +8202,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.005Z",
+          "evaluatedAt": "2026-05-05T23:45:35.741Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8220,7 +8220,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.005Z",
+          "evaluatedAt": "2026-05-05T23:45:35.741Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8284,7 +8284,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.007Z",
+        "evaluatedAt": "2026-05-05T23:45:35.743Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8339,7 +8339,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.007Z",
+          "evaluatedAt": "2026-05-05T23:45:35.744Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8357,7 +8357,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.007Z",
+          "evaluatedAt": "2026-05-05T23:45:35.744Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8421,7 +8421,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.010Z",
+        "evaluatedAt": "2026-05-05T23:45:35.746Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8476,7 +8476,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.010Z",
+          "evaluatedAt": "2026-05-05T23:45:35.746Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8494,7 +8494,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.010Z",
+          "evaluatedAt": "2026-05-05T23:45:35.746Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8558,7 +8558,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.012Z",
+        "evaluatedAt": "2026-05-05T23:45:35.748Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8613,7 +8613,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.012Z",
+          "evaluatedAt": "2026-05-05T23:45:35.748Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8631,7 +8631,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.012Z",
+          "evaluatedAt": "2026-05-05T23:45:35.748Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8695,7 +8695,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.014Z",
+        "evaluatedAt": "2026-05-05T23:45:35.750Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8750,7 +8750,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.014Z",
+          "evaluatedAt": "2026-05-05T23:45:35.750Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8768,7 +8768,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.014Z",
+          "evaluatedAt": "2026-05-05T23:45:35.750Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8832,7 +8832,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.016Z",
+        "evaluatedAt": "2026-05-05T23:45:35.752Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8887,7 +8887,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.016Z",
+          "evaluatedAt": "2026-05-05T23:45:35.752Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8905,7 +8905,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.016Z",
+          "evaluatedAt": "2026-05-05T23:45:35.752Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8969,7 +8969,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.018Z",
+        "evaluatedAt": "2026-05-05T23:45:35.753Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9024,7 +9024,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.018Z",
+          "evaluatedAt": "2026-05-05T23:45:35.753Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9042,7 +9042,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.018Z",
+          "evaluatedAt": "2026-05-05T23:45:35.753Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9106,7 +9106,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.019Z",
+        "evaluatedAt": "2026-05-05T23:45:35.755Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9161,7 +9161,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.019Z",
+          "evaluatedAt": "2026-05-05T23:45:35.755Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9179,7 +9179,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.019Z",
+          "evaluatedAt": "2026-05-05T23:45:35.755Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9243,7 +9243,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.021Z",
+        "evaluatedAt": "2026-05-05T23:45:35.757Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9298,7 +9298,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.021Z",
+          "evaluatedAt": "2026-05-05T23:45:35.757Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9316,7 +9316,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.021Z",
+          "evaluatedAt": "2026-05-05T23:45:35.757Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9380,7 +9380,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.022Z",
+        "evaluatedAt": "2026-05-05T23:45:35.758Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9435,7 +9435,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.022Z",
+          "evaluatedAt": "2026-05-05T23:45:35.758Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9453,7 +9453,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.022Z",
+          "evaluatedAt": "2026-05-05T23:45:35.758Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9517,7 +9517,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.024Z",
+        "evaluatedAt": "2026-05-05T23:45:35.759Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9572,7 +9572,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.024Z",
+          "evaluatedAt": "2026-05-05T23:45:35.759Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9590,7 +9590,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.024Z",
+          "evaluatedAt": "2026-05-05T23:45:35.759Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9654,7 +9654,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.025Z",
+        "evaluatedAt": "2026-05-05T23:45:35.761Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9709,7 +9709,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.025Z",
+          "evaluatedAt": "2026-05-05T23:45:35.761Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9727,7 +9727,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.025Z",
+          "evaluatedAt": "2026-05-05T23:45:35.761Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9791,7 +9791,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.026Z",
+        "evaluatedAt": "2026-05-05T23:45:35.762Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9846,7 +9846,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.027Z",
+          "evaluatedAt": "2026-05-05T23:45:35.762Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9864,7 +9864,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.027Z",
+          "evaluatedAt": "2026-05-05T23:45:35.762Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9928,7 +9928,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.028Z",
+        "evaluatedAt": "2026-05-05T23:45:35.764Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9983,7 +9983,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.028Z",
+          "evaluatedAt": "2026-05-05T23:45:35.764Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10001,7 +10001,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.028Z",
+          "evaluatedAt": "2026-05-05T23:45:35.764Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10065,7 +10065,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.030Z",
+        "evaluatedAt": "2026-05-05T23:45:35.766Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10120,7 +10120,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.030Z",
+          "evaluatedAt": "2026-05-05T23:45:35.766Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10138,7 +10138,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.030Z",
+          "evaluatedAt": "2026-05-05T23:45:35.766Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10202,7 +10202,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.032Z",
+        "evaluatedAt": "2026-05-05T23:45:35.768Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10257,7 +10257,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.032Z",
+          "evaluatedAt": "2026-05-05T23:45:35.768Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10275,7 +10275,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.032Z",
+          "evaluatedAt": "2026-05-05T23:45:35.768Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10339,7 +10339,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.033Z",
+        "evaluatedAt": "2026-05-05T23:45:35.769Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10394,7 +10394,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.033Z",
+          "evaluatedAt": "2026-05-05T23:45:35.769Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10412,7 +10412,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.033Z",
+          "evaluatedAt": "2026-05-05T23:45:35.769Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10476,7 +10476,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.034Z",
+        "evaluatedAt": "2026-05-05T23:45:35.771Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10531,7 +10531,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.035Z",
+          "evaluatedAt": "2026-05-05T23:45:35.771Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10549,7 +10549,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.035Z",
+          "evaluatedAt": "2026-05-05T23:45:35.771Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10613,7 +10613,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.036Z",
+        "evaluatedAt": "2026-05-05T23:45:35.772Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10668,7 +10668,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.036Z",
+          "evaluatedAt": "2026-05-05T23:45:35.772Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10686,7 +10686,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.036Z",
+          "evaluatedAt": "2026-05-05T23:45:35.772Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10750,7 +10750,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.038Z",
+        "evaluatedAt": "2026-05-05T23:45:35.773Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10805,7 +10805,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.038Z",
+          "evaluatedAt": "2026-05-05T23:45:35.773Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10823,7 +10823,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.038Z",
+          "evaluatedAt": "2026-05-05T23:45:35.773Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10887,7 +10887,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.039Z",
+        "evaluatedAt": "2026-05-05T23:45:35.775Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10942,7 +10942,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.039Z",
+          "evaluatedAt": "2026-05-05T23:45:35.775Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10960,7 +10960,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.039Z",
+          "evaluatedAt": "2026-05-05T23:45:35.775Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11024,7 +11024,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.040Z",
+        "evaluatedAt": "2026-05-05T23:45:35.776Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11079,7 +11079,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.040Z",
+          "evaluatedAt": "2026-05-05T23:45:35.776Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11097,7 +11097,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.041Z",
+          "evaluatedAt": "2026-05-05T23:45:35.776Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11161,7 +11161,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.042Z",
+        "evaluatedAt": "2026-05-05T23:45:35.778Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11216,7 +11216,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.042Z",
+          "evaluatedAt": "2026-05-05T23:45:35.778Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11234,7 +11234,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.042Z",
+          "evaluatedAt": "2026-05-05T23:45:35.778Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11298,7 +11298,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.043Z",
+        "evaluatedAt": "2026-05-05T23:45:35.779Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11353,7 +11353,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.043Z",
+          "evaluatedAt": "2026-05-05T23:45:35.779Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11371,7 +11371,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.043Z",
+          "evaluatedAt": "2026-05-05T23:45:35.779Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11435,7 +11435,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.044Z",
+        "evaluatedAt": "2026-05-05T23:45:35.780Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11490,7 +11490,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.044Z",
+          "evaluatedAt": "2026-05-05T23:45:35.780Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11508,7 +11508,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.044Z",
+          "evaluatedAt": "2026-05-05T23:45:35.780Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11572,7 +11572,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.046Z",
+        "evaluatedAt": "2026-05-05T23:45:35.782Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11627,7 +11627,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.046Z",
+          "evaluatedAt": "2026-05-05T23:45:35.782Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11645,7 +11645,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.046Z",
+          "evaluatedAt": "2026-05-05T23:45:35.782Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11709,7 +11709,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.047Z",
+        "evaluatedAt": "2026-05-05T23:45:35.783Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11764,7 +11764,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.047Z",
+          "evaluatedAt": "2026-05-05T23:45:35.783Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11782,7 +11782,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.047Z",
+          "evaluatedAt": "2026-05-05T23:45:35.783Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11846,7 +11846,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.049Z",
+        "evaluatedAt": "2026-05-05T23:45:35.785Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11901,7 +11901,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.049Z",
+          "evaluatedAt": "2026-05-05T23:45:35.785Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11919,7 +11919,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.049Z",
+          "evaluatedAt": "2026-05-05T23:45:35.785Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11983,7 +11983,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.051Z",
+        "evaluatedAt": "2026-05-05T23:45:35.787Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12038,7 +12038,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.051Z",
+          "evaluatedAt": "2026-05-05T23:45:35.787Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12056,7 +12056,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.051Z",
+          "evaluatedAt": "2026-05-05T23:45:35.787Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12120,7 +12120,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.052Z",
+        "evaluatedAt": "2026-05-05T23:45:35.788Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12175,7 +12175,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.052Z",
+          "evaluatedAt": "2026-05-05T23:45:35.788Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12193,7 +12193,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.052Z",
+          "evaluatedAt": "2026-05-05T23:45:35.788Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12257,7 +12257,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.054Z",
+        "evaluatedAt": "2026-05-05T23:45:35.790Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12312,7 +12312,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.054Z",
+          "evaluatedAt": "2026-05-05T23:45:35.790Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12330,7 +12330,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.054Z",
+          "evaluatedAt": "2026-05-05T23:45:35.790Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12394,7 +12394,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.057Z",
+        "evaluatedAt": "2026-05-05T23:45:35.792Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12449,7 +12449,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.057Z",
+          "evaluatedAt": "2026-05-05T23:45:35.792Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12467,7 +12467,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.057Z",
+          "evaluatedAt": "2026-05-05T23:45:35.792Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12531,7 +12531,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.059Z",
+        "evaluatedAt": "2026-05-05T23:45:35.795Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12586,7 +12586,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.059Z",
+          "evaluatedAt": "2026-05-05T23:45:35.795Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12604,7 +12604,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.059Z",
+          "evaluatedAt": "2026-05-05T23:45:35.795Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12668,7 +12668,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.062Z",
+        "evaluatedAt": "2026-05-05T23:45:35.797Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12723,7 +12723,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.062Z",
+          "evaluatedAt": "2026-05-05T23:45:35.797Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12741,7 +12741,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.062Z",
+          "evaluatedAt": "2026-05-05T23:45:35.797Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12805,7 +12805,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.064Z",
+        "evaluatedAt": "2026-05-05T23:45:35.799Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12860,7 +12860,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.064Z",
+          "evaluatedAt": "2026-05-05T23:45:35.799Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12878,7 +12878,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.064Z",
+          "evaluatedAt": "2026-05-05T23:45:35.799Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12942,7 +12942,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.066Z",
+        "evaluatedAt": "2026-05-05T23:45:35.801Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12997,7 +12997,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.066Z",
+          "evaluatedAt": "2026-05-05T23:45:35.801Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13015,7 +13015,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.066Z",
+          "evaluatedAt": "2026-05-05T23:45:35.801Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13079,7 +13079,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.068Z",
+        "evaluatedAt": "2026-05-05T23:45:35.803Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13134,7 +13134,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.068Z",
+          "evaluatedAt": "2026-05-05T23:45:35.803Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13152,7 +13152,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.068Z",
+          "evaluatedAt": "2026-05-05T23:45:35.803Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13216,7 +13216,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.070Z",
+        "evaluatedAt": "2026-05-05T23:45:35.804Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13271,7 +13271,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.070Z",
+          "evaluatedAt": "2026-05-05T23:45:35.805Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13289,7 +13289,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.070Z",
+          "evaluatedAt": "2026-05-05T23:45:35.805Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13353,7 +13353,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.071Z",
+        "evaluatedAt": "2026-05-05T23:45:35.806Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13408,7 +13408,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.071Z",
+          "evaluatedAt": "2026-05-05T23:45:35.806Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13426,7 +13426,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.071Z",
+          "evaluatedAt": "2026-05-05T23:45:35.806Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13490,7 +13490,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.073Z",
+        "evaluatedAt": "2026-05-05T23:45:35.808Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13545,7 +13545,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.073Z",
+          "evaluatedAt": "2026-05-05T23:45:35.808Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13563,7 +13563,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.073Z",
+          "evaluatedAt": "2026-05-05T23:45:35.808Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13627,7 +13627,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.075Z",
+        "evaluatedAt": "2026-05-05T23:45:35.810Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13682,7 +13682,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.075Z",
+          "evaluatedAt": "2026-05-05T23:45:35.810Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13700,7 +13700,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.075Z",
+          "evaluatedAt": "2026-05-05T23:45:35.810Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13764,7 +13764,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.076Z",
+        "evaluatedAt": "2026-05-05T23:45:35.812Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13819,7 +13819,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.076Z",
+          "evaluatedAt": "2026-05-05T23:45:35.812Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13837,7 +13837,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.076Z",
+          "evaluatedAt": "2026-05-05T23:45:35.812Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13901,7 +13901,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.078Z",
+        "evaluatedAt": "2026-05-05T23:45:35.814Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13956,7 +13956,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.078Z",
+          "evaluatedAt": "2026-05-05T23:45:35.814Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13974,7 +13974,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.078Z",
+          "evaluatedAt": "2026-05-05T23:45:35.814Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14038,7 +14038,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.080Z",
+        "evaluatedAt": "2026-05-05T23:45:35.816Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14093,7 +14093,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.080Z",
+          "evaluatedAt": "2026-05-05T23:45:35.816Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14111,7 +14111,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.080Z",
+          "evaluatedAt": "2026-05-05T23:45:35.816Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14175,7 +14175,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.082Z",
+        "evaluatedAt": "2026-05-05T23:45:35.818Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14230,7 +14230,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.082Z",
+          "evaluatedAt": "2026-05-05T23:45:35.818Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14248,7 +14248,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.082Z",
+          "evaluatedAt": "2026-05-05T23:45:35.818Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14312,7 +14312,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.084Z",
+        "evaluatedAt": "2026-05-05T23:45:35.820Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14367,7 +14367,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.084Z",
+          "evaluatedAt": "2026-05-05T23:45:35.820Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14385,7 +14385,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.084Z",
+          "evaluatedAt": "2026-05-05T23:45:35.820Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14449,7 +14449,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.085Z",
+        "evaluatedAt": "2026-05-05T23:45:35.822Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14504,7 +14504,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.085Z",
+          "evaluatedAt": "2026-05-05T23:45:35.822Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14522,7 +14522,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.085Z",
+          "evaluatedAt": "2026-05-05T23:45:35.822Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14586,7 +14586,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.087Z",
+        "evaluatedAt": "2026-05-05T23:45:35.823Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14641,7 +14641,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.087Z",
+          "evaluatedAt": "2026-05-05T23:45:35.823Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14659,7 +14659,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.087Z",
+          "evaluatedAt": "2026-05-05T23:45:35.823Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14723,7 +14723,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.088Z",
+        "evaluatedAt": "2026-05-05T23:45:35.825Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14778,7 +14778,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.088Z",
+          "evaluatedAt": "2026-05-05T23:45:35.825Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14796,7 +14796,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.088Z",
+          "evaluatedAt": "2026-05-05T23:45:35.825Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14860,7 +14860,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.090Z",
+        "evaluatedAt": "2026-05-05T23:45:35.826Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14915,7 +14915,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.090Z",
+          "evaluatedAt": "2026-05-05T23:45:35.826Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14933,7 +14933,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.090Z",
+          "evaluatedAt": "2026-05-05T23:45:35.826Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14997,7 +14997,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.091Z",
+        "evaluatedAt": "2026-05-05T23:45:35.827Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15052,7 +15052,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.091Z",
+          "evaluatedAt": "2026-05-05T23:45:35.827Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15070,7 +15070,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.092Z",
+          "evaluatedAt": "2026-05-05T23:45:35.827Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15134,7 +15134,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.093Z",
+        "evaluatedAt": "2026-05-05T23:45:35.829Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15189,7 +15189,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.093Z",
+          "evaluatedAt": "2026-05-05T23:45:35.829Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15207,7 +15207,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.093Z",
+          "evaluatedAt": "2026-05-05T23:45:35.829Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15271,7 +15271,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.094Z",
+        "evaluatedAt": "2026-05-05T23:45:35.830Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15326,7 +15326,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.094Z",
+          "evaluatedAt": "2026-05-05T23:45:35.830Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15344,7 +15344,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.094Z",
+          "evaluatedAt": "2026-05-05T23:45:35.830Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15408,7 +15408,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.095Z",
+        "evaluatedAt": "2026-05-05T23:45:35.831Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15463,7 +15463,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.095Z",
+          "evaluatedAt": "2026-05-05T23:45:35.831Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15481,7 +15481,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.095Z",
+          "evaluatedAt": "2026-05-05T23:45:35.831Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15545,7 +15545,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.095Z",
+        "evaluatedAt": "2026-05-05T23:45:35.832Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15600,7 +15600,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.095Z",
+          "evaluatedAt": "2026-05-05T23:45:35.832Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15618,7 +15618,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.095Z",
+          "evaluatedAt": "2026-05-05T23:45:35.832Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15682,7 +15682,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.096Z",
+        "evaluatedAt": "2026-05-05T23:45:35.833Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15737,7 +15737,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.096Z",
+          "evaluatedAt": "2026-05-05T23:45:35.833Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15755,7 +15755,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.096Z",
+          "evaluatedAt": "2026-05-05T23:45:35.833Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15819,7 +15819,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.097Z",
+        "evaluatedAt": "2026-05-05T23:45:35.833Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15874,7 +15874,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.097Z",
+          "evaluatedAt": "2026-05-05T23:45:35.833Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15892,7 +15892,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.097Z",
+          "evaluatedAt": "2026-05-05T23:45:35.833Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15956,7 +15956,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.098Z",
+        "evaluatedAt": "2026-05-05T23:45:35.834Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16011,7 +16011,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.098Z",
+          "evaluatedAt": "2026-05-05T23:45:35.834Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16029,7 +16029,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.098Z",
+          "evaluatedAt": "2026-05-05T23:45:35.834Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16093,7 +16093,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.098Z",
+        "evaluatedAt": "2026-05-05T23:45:35.835Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16148,7 +16148,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.098Z",
+          "evaluatedAt": "2026-05-05T23:45:35.835Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16166,7 +16166,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.098Z",
+          "evaluatedAt": "2026-05-05T23:45:35.835Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16230,7 +16230,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.099Z",
+        "evaluatedAt": "2026-05-05T23:45:35.836Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16285,7 +16285,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.099Z",
+          "evaluatedAt": "2026-05-05T23:45:35.836Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16303,7 +16303,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.099Z",
+          "evaluatedAt": "2026-05-05T23:45:35.836Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16367,7 +16367,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.100Z",
+        "evaluatedAt": "2026-05-05T23:45:35.837Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16422,7 +16422,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.100Z",
+          "evaluatedAt": "2026-05-05T23:45:35.837Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16440,7 +16440,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.100Z",
+          "evaluatedAt": "2026-05-05T23:45:35.837Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16504,7 +16504,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.101Z",
+        "evaluatedAt": "2026-05-05T23:45:35.838Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16559,7 +16559,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.101Z",
+          "evaluatedAt": "2026-05-05T23:45:35.838Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16577,7 +16577,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.101Z",
+          "evaluatedAt": "2026-05-05T23:45:35.838Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16641,7 +16641,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.104Z",
+        "evaluatedAt": "2026-05-05T23:45:35.841Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16696,7 +16696,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.104Z",
+          "evaluatedAt": "2026-05-05T23:45:35.841Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16714,7 +16714,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.104Z",
+          "evaluatedAt": "2026-05-05T23:45:35.841Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16778,7 +16778,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.106Z",
+        "evaluatedAt": "2026-05-05T23:45:35.843Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16833,7 +16833,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.106Z",
+          "evaluatedAt": "2026-05-05T23:45:35.843Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16851,7 +16851,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.106Z",
+          "evaluatedAt": "2026-05-05T23:45:35.843Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16915,7 +16915,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.108Z",
+        "evaluatedAt": "2026-05-05T23:45:35.846Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16970,7 +16970,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.108Z",
+          "evaluatedAt": "2026-05-05T23:45:35.846Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16988,7 +16988,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.108Z",
+          "evaluatedAt": "2026-05-05T23:45:35.846Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17052,7 +17052,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.110Z",
+        "evaluatedAt": "2026-05-05T23:45:35.848Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17107,7 +17107,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.110Z",
+          "evaluatedAt": "2026-05-05T23:45:35.848Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17125,7 +17125,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.110Z",
+          "evaluatedAt": "2026-05-05T23:45:35.848Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17189,7 +17189,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.112Z",
+        "evaluatedAt": "2026-05-05T23:45:35.850Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17244,7 +17244,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.112Z",
+          "evaluatedAt": "2026-05-05T23:45:35.850Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17262,7 +17262,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.112Z",
+          "evaluatedAt": "2026-05-05T23:45:35.850Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17326,7 +17326,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.114Z",
+        "evaluatedAt": "2026-05-05T23:45:35.851Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17381,7 +17381,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.114Z",
+          "evaluatedAt": "2026-05-05T23:45:35.851Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17399,7 +17399,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.114Z",
+          "evaluatedAt": "2026-05-05T23:45:35.851Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17463,7 +17463,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.115Z",
+        "evaluatedAt": "2026-05-05T23:45:35.853Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17518,7 +17518,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.115Z",
+          "evaluatedAt": "2026-05-05T23:45:35.853Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17536,7 +17536,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.115Z",
+          "evaluatedAt": "2026-05-05T23:45:35.853Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17600,7 +17600,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.117Z",
+        "evaluatedAt": "2026-05-05T23:45:35.854Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17655,7 +17655,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.117Z",
+          "evaluatedAt": "2026-05-05T23:45:35.854Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17673,7 +17673,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.117Z",
+          "evaluatedAt": "2026-05-05T23:45:35.854Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17737,7 +17737,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.118Z",
+        "evaluatedAt": "2026-05-05T23:45:35.855Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17792,7 +17792,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.118Z",
+          "evaluatedAt": "2026-05-05T23:45:35.855Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17810,7 +17810,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.118Z",
+          "evaluatedAt": "2026-05-05T23:45:35.855Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17874,7 +17874,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.120Z",
+        "evaluatedAt": "2026-05-05T23:45:35.857Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17929,7 +17929,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.120Z",
+          "evaluatedAt": "2026-05-05T23:45:35.857Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17947,7 +17947,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.120Z",
+          "evaluatedAt": "2026-05-05T23:45:35.857Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18011,7 +18011,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.121Z",
+        "evaluatedAt": "2026-05-05T23:45:35.859Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18066,7 +18066,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.121Z",
+          "evaluatedAt": "2026-05-05T23:45:35.859Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18084,7 +18084,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.121Z",
+          "evaluatedAt": "2026-05-05T23:45:35.859Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18148,7 +18148,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.123Z",
+        "evaluatedAt": "2026-05-05T23:45:35.860Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18203,7 +18203,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.123Z",
+          "evaluatedAt": "2026-05-05T23:45:35.860Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18221,7 +18221,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.123Z",
+          "evaluatedAt": "2026-05-05T23:45:35.860Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18285,7 +18285,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.124Z",
+        "evaluatedAt": "2026-05-05T23:45:35.862Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18340,7 +18340,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.124Z",
+          "evaluatedAt": "2026-05-05T23:45:35.862Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18358,7 +18358,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.124Z",
+          "evaluatedAt": "2026-05-05T23:45:35.862Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18422,7 +18422,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.125Z",
+        "evaluatedAt": "2026-05-05T23:45:35.863Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18477,7 +18477,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.125Z",
+          "evaluatedAt": "2026-05-05T23:45:35.863Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18495,7 +18495,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.125Z",
+          "evaluatedAt": "2026-05-05T23:45:35.863Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18559,7 +18559,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.127Z",
+        "evaluatedAt": "2026-05-05T23:45:35.864Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18614,7 +18614,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.127Z",
+          "evaluatedAt": "2026-05-05T23:45:35.864Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18632,7 +18632,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.127Z",
+          "evaluatedAt": "2026-05-05T23:45:35.864Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18696,7 +18696,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.128Z",
+        "evaluatedAt": "2026-05-05T23:45:35.865Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18751,7 +18751,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.128Z",
+          "evaluatedAt": "2026-05-05T23:45:35.865Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18769,7 +18769,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.128Z",
+          "evaluatedAt": "2026-05-05T23:45:35.865Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18833,7 +18833,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.130Z",
+        "evaluatedAt": "2026-05-05T23:45:35.867Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18888,7 +18888,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.130Z",
+          "evaluatedAt": "2026-05-05T23:45:35.867Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18906,7 +18906,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.130Z",
+          "evaluatedAt": "2026-05-05T23:45:35.867Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18970,7 +18970,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.132Z",
+        "evaluatedAt": "2026-05-05T23:45:35.869Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19025,7 +19025,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.132Z",
+          "evaluatedAt": "2026-05-05T23:45:35.869Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19043,7 +19043,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.132Z",
+          "evaluatedAt": "2026-05-05T23:45:35.869Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19107,7 +19107,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.134Z",
+        "evaluatedAt": "2026-05-05T23:45:35.871Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19162,7 +19162,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.134Z",
+          "evaluatedAt": "2026-05-05T23:45:35.871Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19180,7 +19180,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.134Z",
+          "evaluatedAt": "2026-05-05T23:45:35.871Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19244,7 +19244,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.136Z",
+        "evaluatedAt": "2026-05-05T23:45:35.873Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19299,7 +19299,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.136Z",
+          "evaluatedAt": "2026-05-05T23:45:35.873Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19317,7 +19317,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.136Z",
+          "evaluatedAt": "2026-05-05T23:45:35.873Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19381,7 +19381,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.137Z",
+        "evaluatedAt": "2026-05-05T23:45:35.874Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19436,7 +19436,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.137Z",
+          "evaluatedAt": "2026-05-05T23:45:35.874Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19454,7 +19454,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.137Z",
+          "evaluatedAt": "2026-05-05T23:45:35.874Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19518,7 +19518,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.139Z",
+        "evaluatedAt": "2026-05-05T23:45:35.875Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19573,7 +19573,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.139Z",
+          "evaluatedAt": "2026-05-05T23:45:35.875Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19591,7 +19591,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.139Z",
+          "evaluatedAt": "2026-05-05T23:45:35.875Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19655,7 +19655,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.141Z",
+        "evaluatedAt": "2026-05-05T23:45:35.877Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19710,7 +19710,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.141Z",
+          "evaluatedAt": "2026-05-05T23:45:35.877Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19728,7 +19728,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.141Z",
+          "evaluatedAt": "2026-05-05T23:45:35.877Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19792,7 +19792,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.143Z",
+        "evaluatedAt": "2026-05-05T23:45:35.879Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19847,7 +19847,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.143Z",
+          "evaluatedAt": "2026-05-05T23:45:35.879Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19865,7 +19865,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.143Z",
+          "evaluatedAt": "2026-05-05T23:45:35.879Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19929,7 +19929,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.144Z",
+        "evaluatedAt": "2026-05-05T23:45:35.880Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19984,7 +19984,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.144Z",
+          "evaluatedAt": "2026-05-05T23:45:35.880Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20002,7 +20002,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.144Z",
+          "evaluatedAt": "2026-05-05T23:45:35.880Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20066,7 +20066,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.146Z",
+        "evaluatedAt": "2026-05-05T23:45:35.882Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20121,7 +20121,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.146Z",
+          "evaluatedAt": "2026-05-05T23:45:35.882Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20139,7 +20139,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.146Z",
+          "evaluatedAt": "2026-05-05T23:45:35.882Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20203,7 +20203,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.148Z",
+        "evaluatedAt": "2026-05-05T23:45:35.883Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20258,7 +20258,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.148Z",
+          "evaluatedAt": "2026-05-05T23:45:35.883Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20276,7 +20276,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.148Z",
+          "evaluatedAt": "2026-05-05T23:45:35.883Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20340,7 +20340,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.149Z",
+        "evaluatedAt": "2026-05-05T23:45:35.885Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20395,7 +20395,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.149Z",
+          "evaluatedAt": "2026-05-05T23:45:35.885Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20413,7 +20413,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.149Z",
+          "evaluatedAt": "2026-05-05T23:45:35.885Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20477,7 +20477,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.151Z",
+        "evaluatedAt": "2026-05-05T23:45:35.886Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20532,7 +20532,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.151Z",
+          "evaluatedAt": "2026-05-05T23:45:35.886Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20550,7 +20550,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.151Z",
+          "evaluatedAt": "2026-05-05T23:45:35.886Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20614,7 +20614,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.152Z",
+        "evaluatedAt": "2026-05-05T23:45:35.888Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20669,7 +20669,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.152Z",
+          "evaluatedAt": "2026-05-05T23:45:35.888Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20687,7 +20687,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.152Z",
+          "evaluatedAt": "2026-05-05T23:45:35.888Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20751,7 +20751,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.153Z",
+        "evaluatedAt": "2026-05-05T23:45:35.889Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20806,7 +20806,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.153Z",
+          "evaluatedAt": "2026-05-05T23:45:35.889Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20824,7 +20824,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.154Z",
+          "evaluatedAt": "2026-05-05T23:45:35.889Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20888,7 +20888,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.155Z",
+        "evaluatedAt": "2026-05-05T23:45:35.891Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20943,7 +20943,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.155Z",
+          "evaluatedAt": "2026-05-05T23:45:35.891Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20961,7 +20961,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.155Z",
+          "evaluatedAt": "2026-05-05T23:45:35.891Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21025,7 +21025,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.156Z",
+        "evaluatedAt": "2026-05-05T23:45:35.892Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21080,7 +21080,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.156Z",
+          "evaluatedAt": "2026-05-05T23:45:35.892Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21098,7 +21098,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.156Z",
+          "evaluatedAt": "2026-05-05T23:45:35.892Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21162,7 +21162,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.157Z",
+        "evaluatedAt": "2026-05-05T23:45:35.893Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21217,7 +21217,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.157Z",
+          "evaluatedAt": "2026-05-05T23:45:35.893Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21235,7 +21235,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.157Z",
+          "evaluatedAt": "2026-05-05T23:45:35.893Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21299,7 +21299,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.159Z",
+        "evaluatedAt": "2026-05-05T23:45:35.895Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21354,7 +21354,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.159Z",
+          "evaluatedAt": "2026-05-05T23:45:35.895Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21372,7 +21372,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.159Z",
+          "evaluatedAt": "2026-05-05T23:45:35.895Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21436,7 +21436,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.160Z",
+        "evaluatedAt": "2026-05-05T23:45:35.896Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21491,7 +21491,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.160Z",
+          "evaluatedAt": "2026-05-05T23:45:35.896Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21509,7 +21509,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.160Z",
+          "evaluatedAt": "2026-05-05T23:45:35.896Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21573,7 +21573,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.162Z",
+        "evaluatedAt": "2026-05-05T23:45:35.898Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21628,7 +21628,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.162Z",
+          "evaluatedAt": "2026-05-05T23:45:35.898Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21646,7 +21646,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.162Z",
+          "evaluatedAt": "2026-05-05T23:45:35.898Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21710,7 +21710,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.163Z",
+        "evaluatedAt": "2026-05-05T23:45:35.899Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21765,7 +21765,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.163Z",
+          "evaluatedAt": "2026-05-05T23:45:35.899Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21783,7 +21783,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.163Z",
+          "evaluatedAt": "2026-05-05T23:45:35.899Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21847,7 +21847,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.165Z",
+        "evaluatedAt": "2026-05-05T23:45:35.901Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21902,7 +21902,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.165Z",
+          "evaluatedAt": "2026-05-05T23:45:35.901Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21920,7 +21920,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.165Z",
+          "evaluatedAt": "2026-05-05T23:45:35.901Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21984,7 +21984,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.166Z",
+        "evaluatedAt": "2026-05-05T23:45:35.902Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22039,7 +22039,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.166Z",
+          "evaluatedAt": "2026-05-05T23:45:35.902Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22057,7 +22057,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.166Z",
+          "evaluatedAt": "2026-05-05T23:45:35.902Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22121,7 +22121,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.168Z",
+        "evaluatedAt": "2026-05-05T23:45:35.904Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22176,7 +22176,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.168Z",
+          "evaluatedAt": "2026-05-05T23:45:35.904Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22194,7 +22194,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.168Z",
+          "evaluatedAt": "2026-05-05T23:45:35.904Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22258,7 +22258,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.169Z",
+        "evaluatedAt": "2026-05-05T23:45:35.905Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22313,7 +22313,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.169Z",
+          "evaluatedAt": "2026-05-05T23:45:35.906Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22331,7 +22331,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.169Z",
+          "evaluatedAt": "2026-05-05T23:45:35.906Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22395,7 +22395,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.171Z",
+        "evaluatedAt": "2026-05-05T23:45:35.907Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22450,7 +22450,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.171Z",
+          "evaluatedAt": "2026-05-05T23:45:35.907Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22468,7 +22468,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.171Z",
+          "evaluatedAt": "2026-05-05T23:45:35.907Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22532,7 +22532,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.173Z",
+        "evaluatedAt": "2026-05-05T23:45:35.909Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22587,7 +22587,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.173Z",
+          "evaluatedAt": "2026-05-05T23:45:35.909Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22605,7 +22605,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.173Z",
+          "evaluatedAt": "2026-05-05T23:45:35.909Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22669,7 +22669,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.174Z",
+        "evaluatedAt": "2026-05-05T23:45:35.911Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22724,7 +22724,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.174Z",
+          "evaluatedAt": "2026-05-05T23:45:35.911Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22742,7 +22742,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.174Z",
+          "evaluatedAt": "2026-05-05T23:45:35.911Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22806,7 +22806,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.176Z",
+        "evaluatedAt": "2026-05-05T23:45:35.912Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22861,7 +22861,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.176Z",
+          "evaluatedAt": "2026-05-05T23:45:35.912Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22879,7 +22879,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.176Z",
+          "evaluatedAt": "2026-05-05T23:45:35.912Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22943,7 +22943,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.178Z",
+        "evaluatedAt": "2026-05-05T23:45:35.915Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22998,7 +22998,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.178Z",
+          "evaluatedAt": "2026-05-05T23:45:35.915Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23016,7 +23016,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.178Z",
+          "evaluatedAt": "2026-05-05T23:45:35.915Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23080,7 +23080,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.179Z",
+        "evaluatedAt": "2026-05-05T23:45:35.916Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23135,7 +23135,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.179Z",
+          "evaluatedAt": "2026-05-05T23:45:35.916Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23153,7 +23153,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.179Z",
+          "evaluatedAt": "2026-05-05T23:45:35.916Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23217,7 +23217,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.181Z",
+        "evaluatedAt": "2026-05-05T23:45:35.918Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23272,7 +23272,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.181Z",
+          "evaluatedAt": "2026-05-05T23:45:35.918Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23290,7 +23290,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.181Z",
+          "evaluatedAt": "2026-05-05T23:45:35.918Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23354,7 +23354,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.182Z",
+        "evaluatedAt": "2026-05-05T23:45:35.920Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23409,7 +23409,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.182Z",
+          "evaluatedAt": "2026-05-05T23:45:35.920Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23427,7 +23427,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.182Z",
+          "evaluatedAt": "2026-05-05T23:45:35.920Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23491,7 +23491,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.184Z",
+        "evaluatedAt": "2026-05-05T23:45:35.921Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23546,7 +23546,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.184Z",
+          "evaluatedAt": "2026-05-05T23:45:35.921Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23564,7 +23564,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.184Z",
+          "evaluatedAt": "2026-05-05T23:45:35.921Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23628,7 +23628,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.185Z",
+        "evaluatedAt": "2026-05-05T23:45:35.922Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23683,7 +23683,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.185Z",
+          "evaluatedAt": "2026-05-05T23:45:35.923Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23701,7 +23701,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.185Z",
+          "evaluatedAt": "2026-05-05T23:45:35.923Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23765,7 +23765,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.187Z",
+        "evaluatedAt": "2026-05-05T23:45:35.924Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23820,7 +23820,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.187Z",
+          "evaluatedAt": "2026-05-05T23:45:35.924Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23838,7 +23838,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.187Z",
+          "evaluatedAt": "2026-05-05T23:45:35.924Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23902,7 +23902,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.188Z",
+        "evaluatedAt": "2026-05-05T23:45:35.926Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23957,7 +23957,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.188Z",
+          "evaluatedAt": "2026-05-05T23:45:35.926Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23975,7 +23975,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.188Z",
+          "evaluatedAt": "2026-05-05T23:45:35.926Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24039,7 +24039,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.190Z",
+        "evaluatedAt": "2026-05-05T23:45:35.927Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24094,7 +24094,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.190Z",
+          "evaluatedAt": "2026-05-05T23:45:35.927Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24112,7 +24112,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.190Z",
+          "evaluatedAt": "2026-05-05T23:45:35.927Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24176,7 +24176,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.191Z",
+        "evaluatedAt": "2026-05-05T23:45:35.929Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24231,7 +24231,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.191Z",
+          "evaluatedAt": "2026-05-05T23:45:35.929Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24249,7 +24249,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.191Z",
+          "evaluatedAt": "2026-05-05T23:45:35.929Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24313,7 +24313,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.192Z",
+        "evaluatedAt": "2026-05-05T23:45:35.930Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24368,7 +24368,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.192Z",
+          "evaluatedAt": "2026-05-05T23:45:35.930Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24386,7 +24386,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.192Z",
+          "evaluatedAt": "2026-05-05T23:45:35.930Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24450,7 +24450,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.194Z",
+        "evaluatedAt": "2026-05-05T23:45:35.932Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24505,7 +24505,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.194Z",
+          "evaluatedAt": "2026-05-05T23:45:35.932Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24523,7 +24523,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.194Z",
+          "evaluatedAt": "2026-05-05T23:45:35.932Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24587,7 +24587,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.195Z",
+        "evaluatedAt": "2026-05-05T23:45:35.933Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24642,7 +24642,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.195Z",
+          "evaluatedAt": "2026-05-05T23:45:35.933Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24660,7 +24660,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.195Z",
+          "evaluatedAt": "2026-05-05T23:45:35.933Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24724,7 +24724,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.197Z",
+        "evaluatedAt": "2026-05-05T23:45:35.935Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24779,7 +24779,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.197Z",
+          "evaluatedAt": "2026-05-05T23:45:35.935Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24797,7 +24797,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.197Z",
+          "evaluatedAt": "2026-05-05T23:45:35.935Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24861,7 +24861,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.198Z",
+        "evaluatedAt": "2026-05-05T23:45:35.937Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24916,7 +24916,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.198Z",
+          "evaluatedAt": "2026-05-05T23:45:35.937Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24934,7 +24934,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.198Z",
+          "evaluatedAt": "2026-05-05T23:45:35.937Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24998,7 +24998,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.200Z",
+        "evaluatedAt": "2026-05-05T23:45:35.938Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25053,7 +25053,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.200Z",
+          "evaluatedAt": "2026-05-05T23:45:35.938Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25071,7 +25071,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.200Z",
+          "evaluatedAt": "2026-05-05T23:45:35.938Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25135,7 +25135,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.201Z",
+        "evaluatedAt": "2026-05-05T23:45:35.940Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25190,7 +25190,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.201Z",
+          "evaluatedAt": "2026-05-05T23:45:35.940Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25208,7 +25208,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.201Z",
+          "evaluatedAt": "2026-05-05T23:45:35.940Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25272,7 +25272,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.203Z",
+        "evaluatedAt": "2026-05-05T23:45:35.942Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25327,7 +25327,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.203Z",
+          "evaluatedAt": "2026-05-05T23:45:35.942Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25345,7 +25345,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.203Z",
+          "evaluatedAt": "2026-05-05T23:45:35.942Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25409,7 +25409,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.204Z",
+        "evaluatedAt": "2026-05-05T23:45:35.943Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25464,7 +25464,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.205Z",
+          "evaluatedAt": "2026-05-05T23:45:35.943Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25482,7 +25482,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.204Z",
+          "evaluatedAt": "2026-05-05T23:45:35.943Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25546,7 +25546,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.206Z",
+        "evaluatedAt": "2026-05-05T23:45:35.945Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25601,7 +25601,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.206Z",
+          "evaluatedAt": "2026-05-05T23:45:35.945Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25619,7 +25619,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.206Z",
+          "evaluatedAt": "2026-05-05T23:45:35.945Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25683,7 +25683,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.208Z",
+        "evaluatedAt": "2026-05-05T23:45:35.947Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25738,7 +25738,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.208Z",
+          "evaluatedAt": "2026-05-05T23:45:35.947Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25756,7 +25756,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.208Z",
+          "evaluatedAt": "2026-05-05T23:45:35.947Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25820,7 +25820,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.210Z",
+        "evaluatedAt": "2026-05-05T23:45:35.948Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25875,7 +25875,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.210Z",
+          "evaluatedAt": "2026-05-05T23:45:35.949Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25893,7 +25893,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.210Z",
+          "evaluatedAt": "2026-05-05T23:45:35.949Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25957,7 +25957,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.211Z",
+        "evaluatedAt": "2026-05-05T23:45:35.950Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26012,7 +26012,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.211Z",
+          "evaluatedAt": "2026-05-05T23:45:35.950Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26030,7 +26030,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.211Z",
+          "evaluatedAt": "2026-05-05T23:45:35.950Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26094,7 +26094,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.213Z",
+        "evaluatedAt": "2026-05-05T23:45:35.951Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26149,7 +26149,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.213Z",
+          "evaluatedAt": "2026-05-05T23:45:35.951Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26167,7 +26167,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.213Z",
+          "evaluatedAt": "2026-05-05T23:45:35.951Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26231,7 +26231,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.214Z",
+        "evaluatedAt": "2026-05-05T23:45:35.953Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26286,7 +26286,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.214Z",
+          "evaluatedAt": "2026-05-05T23:45:35.953Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26304,7 +26304,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.214Z",
+          "evaluatedAt": "2026-05-05T23:45:35.953Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26368,7 +26368,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.216Z",
+        "evaluatedAt": "2026-05-05T23:45:35.955Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26423,7 +26423,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.216Z",
+          "evaluatedAt": "2026-05-05T23:45:35.955Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26441,7 +26441,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.216Z",
+          "evaluatedAt": "2026-05-05T23:45:35.955Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26505,7 +26505,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.217Z",
+        "evaluatedAt": "2026-05-05T23:45:35.956Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26560,7 +26560,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.217Z",
+          "evaluatedAt": "2026-05-05T23:45:35.956Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26578,7 +26578,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.217Z",
+          "evaluatedAt": "2026-05-05T23:45:35.956Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26642,7 +26642,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.218Z",
+        "evaluatedAt": "2026-05-05T23:45:35.957Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26697,7 +26697,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.218Z",
+          "evaluatedAt": "2026-05-05T23:45:35.957Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26715,7 +26715,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.219Z",
+          "evaluatedAt": "2026-05-05T23:45:35.957Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26779,7 +26779,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.220Z",
+        "evaluatedAt": "2026-05-05T23:45:35.959Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26834,7 +26834,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.220Z",
+          "evaluatedAt": "2026-05-05T23:45:35.959Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26852,7 +26852,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.220Z",
+          "evaluatedAt": "2026-05-05T23:45:35.959Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26916,7 +26916,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.221Z",
+        "evaluatedAt": "2026-05-05T23:45:35.960Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26971,7 +26971,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.221Z",
+          "evaluatedAt": "2026-05-05T23:45:35.960Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26989,7 +26989,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.221Z",
+          "evaluatedAt": "2026-05-05T23:45:35.960Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27053,7 +27053,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.222Z",
+        "evaluatedAt": "2026-05-05T23:45:35.961Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27108,7 +27108,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.222Z",
+          "evaluatedAt": "2026-05-05T23:45:35.961Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27126,7 +27126,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.222Z",
+          "evaluatedAt": "2026-05-05T23:45:35.961Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27190,7 +27190,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.224Z",
+        "evaluatedAt": "2026-05-05T23:45:35.962Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27245,7 +27245,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.224Z",
+          "evaluatedAt": "2026-05-05T23:45:35.962Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27263,7 +27263,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.224Z",
+          "evaluatedAt": "2026-05-05T23:45:35.962Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27327,7 +27327,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.225Z",
+        "evaluatedAt": "2026-05-05T23:45:35.963Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27382,7 +27382,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.225Z",
+          "evaluatedAt": "2026-05-05T23:45:35.963Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27400,7 +27400,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.225Z",
+          "evaluatedAt": "2026-05-05T23:45:35.963Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27464,7 +27464,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.226Z",
+        "evaluatedAt": "2026-05-05T23:45:35.965Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27519,7 +27519,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.226Z",
+          "evaluatedAt": "2026-05-05T23:45:35.965Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27537,7 +27537,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.226Z",
+          "evaluatedAt": "2026-05-05T23:45:35.965Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27601,7 +27601,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.228Z",
+        "evaluatedAt": "2026-05-05T23:45:35.966Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27656,7 +27656,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.228Z",
+          "evaluatedAt": "2026-05-05T23:45:35.966Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27674,7 +27674,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.228Z",
+          "evaluatedAt": "2026-05-05T23:45:35.966Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27738,7 +27738,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.229Z",
+        "evaluatedAt": "2026-05-05T23:45:35.967Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27793,7 +27793,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.229Z",
+          "evaluatedAt": "2026-05-05T23:45:35.967Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27811,7 +27811,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.229Z",
+          "evaluatedAt": "2026-05-05T23:45:35.967Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27875,7 +27875,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.230Z",
+        "evaluatedAt": "2026-05-05T23:45:35.968Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27930,7 +27930,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.230Z",
+          "evaluatedAt": "2026-05-05T23:45:35.968Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27948,7 +27948,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.230Z",
+          "evaluatedAt": "2026-05-05T23:45:35.968Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28012,7 +28012,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.231Z",
+        "evaluatedAt": "2026-05-05T23:45:35.969Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28067,7 +28067,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.231Z",
+          "evaluatedAt": "2026-05-05T23:45:35.969Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28085,7 +28085,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.231Z",
+          "evaluatedAt": "2026-05-05T23:45:35.969Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28149,7 +28149,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.233Z",
+        "evaluatedAt": "2026-05-05T23:45:35.971Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28204,7 +28204,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.233Z",
+          "evaluatedAt": "2026-05-05T23:45:35.971Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28222,7 +28222,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.233Z",
+          "evaluatedAt": "2026-05-05T23:45:35.971Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28286,7 +28286,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.234Z",
+        "evaluatedAt": "2026-05-05T23:45:35.972Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28341,7 +28341,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.234Z",
+          "evaluatedAt": "2026-05-05T23:45:35.972Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28359,7 +28359,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.234Z",
+          "evaluatedAt": "2026-05-05T23:45:35.972Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28423,7 +28423,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.235Z",
+        "evaluatedAt": "2026-05-05T23:45:35.974Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28478,7 +28478,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.235Z",
+          "evaluatedAt": "2026-05-05T23:45:35.974Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28496,7 +28496,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.235Z",
+          "evaluatedAt": "2026-05-05T23:45:35.974Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28560,7 +28560,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.237Z",
+        "evaluatedAt": "2026-05-05T23:45:35.975Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28615,7 +28615,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.237Z",
+          "evaluatedAt": "2026-05-05T23:45:35.975Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28633,7 +28633,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.237Z",
+          "evaluatedAt": "2026-05-05T23:45:35.975Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28697,7 +28697,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.238Z",
+        "evaluatedAt": "2026-05-05T23:45:35.977Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28752,7 +28752,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.238Z",
+          "evaluatedAt": "2026-05-05T23:45:35.977Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28770,7 +28770,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.238Z",
+          "evaluatedAt": "2026-05-05T23:45:35.977Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28834,7 +28834,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.240Z",
+        "evaluatedAt": "2026-05-05T23:45:35.979Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28889,7 +28889,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.240Z",
+          "evaluatedAt": "2026-05-05T23:45:35.979Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28907,7 +28907,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.240Z",
+          "evaluatedAt": "2026-05-05T23:45:35.979Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28971,7 +28971,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.242Z",
+        "evaluatedAt": "2026-05-05T23:45:35.981Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29026,7 +29026,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.242Z",
+          "evaluatedAt": "2026-05-05T23:45:35.981Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29044,7 +29044,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.242Z",
+          "evaluatedAt": "2026-05-05T23:45:35.981Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29108,7 +29108,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.244Z",
+        "evaluatedAt": "2026-05-05T23:45:35.983Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29163,7 +29163,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.244Z",
+          "evaluatedAt": "2026-05-05T23:45:35.983Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29181,7 +29181,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.244Z",
+          "evaluatedAt": "2026-05-05T23:45:35.983Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29245,7 +29245,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.246Z",
+        "evaluatedAt": "2026-05-05T23:45:35.985Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29300,7 +29300,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.246Z",
+          "evaluatedAt": "2026-05-05T23:45:35.985Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29318,7 +29318,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.246Z",
+          "evaluatedAt": "2026-05-05T23:45:35.985Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29382,7 +29382,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.247Z",
+        "evaluatedAt": "2026-05-05T23:45:35.986Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29437,7 +29437,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.247Z",
+          "evaluatedAt": "2026-05-05T23:45:35.986Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29455,7 +29455,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.247Z",
+          "evaluatedAt": "2026-05-05T23:45:35.986Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29519,7 +29519,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.249Z",
+        "evaluatedAt": "2026-05-05T23:45:35.987Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29574,7 +29574,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.249Z",
+          "evaluatedAt": "2026-05-05T23:45:35.987Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29592,7 +29592,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.249Z",
+          "evaluatedAt": "2026-05-05T23:45:35.987Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29656,7 +29656,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.250Z",
+        "evaluatedAt": "2026-05-05T23:45:35.989Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29711,7 +29711,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.250Z",
+          "evaluatedAt": "2026-05-05T23:45:35.989Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29729,7 +29729,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.250Z",
+          "evaluatedAt": "2026-05-05T23:45:35.989Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29793,7 +29793,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.251Z",
+        "evaluatedAt": "2026-05-05T23:45:35.990Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29848,7 +29848,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.251Z",
+          "evaluatedAt": "2026-05-05T23:45:35.990Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29866,7 +29866,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.251Z",
+          "evaluatedAt": "2026-05-05T23:45:35.990Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29930,7 +29930,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.252Z",
+        "evaluatedAt": "2026-05-05T23:45:35.991Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29985,7 +29985,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.252Z",
+          "evaluatedAt": "2026-05-05T23:45:35.992Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30003,7 +30003,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.252Z",
+          "evaluatedAt": "2026-05-05T23:45:35.992Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30067,7 +30067,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.253Z",
+        "evaluatedAt": "2026-05-05T23:45:35.993Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30122,7 +30122,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.253Z",
+          "evaluatedAt": "2026-05-05T23:45:35.993Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30140,7 +30140,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.253Z",
+          "evaluatedAt": "2026-05-05T23:45:35.993Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30204,7 +30204,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.255Z",
+        "evaluatedAt": "2026-05-05T23:45:35.994Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30259,7 +30259,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.255Z",
+          "evaluatedAt": "2026-05-05T23:45:35.994Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30277,7 +30277,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.255Z",
+          "evaluatedAt": "2026-05-05T23:45:35.994Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30341,7 +30341,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.256Z",
+        "evaluatedAt": "2026-05-05T23:45:35.996Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30396,7 +30396,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.256Z",
+          "evaluatedAt": "2026-05-05T23:45:35.996Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30414,7 +30414,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.256Z",
+          "evaluatedAt": "2026-05-05T23:45:35.996Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30478,7 +30478,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.257Z",
+        "evaluatedAt": "2026-05-05T23:45:35.997Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30533,7 +30533,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.257Z",
+          "evaluatedAt": "2026-05-05T23:45:35.997Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30551,7 +30551,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.257Z",
+          "evaluatedAt": "2026-05-05T23:45:35.997Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30615,7 +30615,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.259Z",
+        "evaluatedAt": "2026-05-05T23:45:35.998Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30670,7 +30670,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.259Z",
+          "evaluatedAt": "2026-05-05T23:45:35.999Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30688,7 +30688,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.259Z",
+          "evaluatedAt": "2026-05-05T23:45:35.999Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30752,7 +30752,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.260Z",
+        "evaluatedAt": "2026-05-05T23:45:36.001Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30807,7 +30807,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.260Z",
+          "evaluatedAt": "2026-05-05T23:45:36.001Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30825,7 +30825,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.260Z",
+          "evaluatedAt": "2026-05-05T23:45:36.001Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30889,7 +30889,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.262Z",
+        "evaluatedAt": "2026-05-05T23:45:36.003Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30944,7 +30944,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.262Z",
+          "evaluatedAt": "2026-05-05T23:45:36.003Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30962,7 +30962,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.262Z",
+          "evaluatedAt": "2026-05-05T23:45:36.003Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31026,7 +31026,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.263Z",
+        "evaluatedAt": "2026-05-05T23:45:36.004Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31081,7 +31081,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.263Z",
+          "evaluatedAt": "2026-05-05T23:45:36.004Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31099,7 +31099,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.263Z",
+          "evaluatedAt": "2026-05-05T23:45:36.004Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31163,7 +31163,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.264Z",
+        "evaluatedAt": "2026-05-05T23:45:36.005Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31218,7 +31218,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.265Z",
+          "evaluatedAt": "2026-05-05T23:45:36.005Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31236,7 +31236,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.265Z",
+          "evaluatedAt": "2026-05-05T23:45:36.005Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31300,7 +31300,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.266Z",
+        "evaluatedAt": "2026-05-05T23:45:36.006Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31355,7 +31355,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.266Z",
+          "evaluatedAt": "2026-05-05T23:45:36.006Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31373,7 +31373,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.266Z",
+          "evaluatedAt": "2026-05-05T23:45:36.006Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31437,7 +31437,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.267Z",
+        "evaluatedAt": "2026-05-05T23:45:36.007Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31492,7 +31492,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.267Z",
+          "evaluatedAt": "2026-05-05T23:45:36.007Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31510,7 +31510,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.267Z",
+          "evaluatedAt": "2026-05-05T23:45:36.007Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31574,7 +31574,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.268Z",
+        "evaluatedAt": "2026-05-05T23:45:36.009Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31629,7 +31629,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.268Z",
+          "evaluatedAt": "2026-05-05T23:45:36.009Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31647,7 +31647,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.268Z",
+          "evaluatedAt": "2026-05-05T23:45:36.009Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31711,7 +31711,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.269Z",
+        "evaluatedAt": "2026-05-05T23:45:36.010Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31766,7 +31766,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.269Z",
+          "evaluatedAt": "2026-05-05T23:45:36.010Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31784,7 +31784,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.269Z",
+          "evaluatedAt": "2026-05-05T23:45:36.010Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31848,7 +31848,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.270Z",
+        "evaluatedAt": "2026-05-05T23:45:36.011Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31903,7 +31903,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.270Z",
+          "evaluatedAt": "2026-05-05T23:45:36.011Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31921,7 +31921,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.270Z",
+          "evaluatedAt": "2026-05-05T23:45:36.011Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31985,7 +31985,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.271Z",
+        "evaluatedAt": "2026-05-05T23:45:36.012Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32040,7 +32040,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.271Z",
+          "evaluatedAt": "2026-05-05T23:45:36.012Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32058,7 +32058,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.271Z",
+          "evaluatedAt": "2026-05-05T23:45:36.012Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32122,7 +32122,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.272Z",
+        "evaluatedAt": "2026-05-05T23:45:36.014Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32177,7 +32177,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.272Z",
+          "evaluatedAt": "2026-05-05T23:45:36.014Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32195,7 +32195,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.272Z",
+          "evaluatedAt": "2026-05-05T23:45:36.014Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32259,7 +32259,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.274Z",
+        "evaluatedAt": "2026-05-05T23:45:36.015Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32314,7 +32314,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.274Z",
+          "evaluatedAt": "2026-05-05T23:45:36.015Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32332,7 +32332,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.274Z",
+          "evaluatedAt": "2026-05-05T23:45:36.015Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32396,7 +32396,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.275Z",
+        "evaluatedAt": "2026-05-05T23:45:36.017Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32451,7 +32451,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.275Z",
+          "evaluatedAt": "2026-05-05T23:45:36.017Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32469,7 +32469,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.275Z",
+          "evaluatedAt": "2026-05-05T23:45:36.017Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32533,7 +32533,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.277Z",
+        "evaluatedAt": "2026-05-05T23:45:36.019Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32588,7 +32588,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.277Z",
+          "evaluatedAt": "2026-05-05T23:45:36.019Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32606,7 +32606,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.277Z",
+          "evaluatedAt": "2026-05-05T23:45:36.019Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32670,7 +32670,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.278Z",
+        "evaluatedAt": "2026-05-05T23:45:36.021Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32725,7 +32725,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.279Z",
+          "evaluatedAt": "2026-05-05T23:45:36.021Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32743,7 +32743,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.279Z",
+          "evaluatedAt": "2026-05-05T23:45:36.021Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32807,7 +32807,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.280Z",
+        "evaluatedAt": "2026-05-05T23:45:36.022Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32862,7 +32862,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.280Z",
+          "evaluatedAt": "2026-05-05T23:45:36.022Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32880,7 +32880,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.280Z",
+          "evaluatedAt": "2026-05-05T23:45:36.022Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32944,7 +32944,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.281Z",
+        "evaluatedAt": "2026-05-05T23:45:36.024Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32999,7 +32999,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.281Z",
+          "evaluatedAt": "2026-05-05T23:45:36.024Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33017,7 +33017,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.281Z",
+          "evaluatedAt": "2026-05-05T23:45:36.024Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33081,7 +33081,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.283Z",
+        "evaluatedAt": "2026-05-05T23:45:36.026Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33136,7 +33136,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.283Z",
+          "evaluatedAt": "2026-05-05T23:45:36.026Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33154,7 +33154,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.283Z",
+          "evaluatedAt": "2026-05-05T23:45:36.026Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33218,7 +33218,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.285Z",
+        "evaluatedAt": "2026-05-05T23:45:36.028Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33273,7 +33273,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.285Z",
+          "evaluatedAt": "2026-05-05T23:45:36.029Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33291,7 +33291,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.285Z",
+          "evaluatedAt": "2026-05-05T23:45:36.029Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33355,7 +33355,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.287Z",
+        "evaluatedAt": "2026-05-05T23:45:36.031Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33410,7 +33410,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.287Z",
+          "evaluatedAt": "2026-05-05T23:45:36.031Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33428,7 +33428,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.287Z",
+          "evaluatedAt": "2026-05-05T23:45:36.031Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33492,7 +33492,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.289Z",
+        "evaluatedAt": "2026-05-05T23:45:36.033Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33547,7 +33547,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.289Z",
+          "evaluatedAt": "2026-05-05T23:45:36.033Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33565,7 +33565,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.289Z",
+          "evaluatedAt": "2026-05-05T23:45:36.033Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33629,7 +33629,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.290Z",
+        "evaluatedAt": "2026-05-05T23:45:36.034Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33684,7 +33684,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.290Z",
+          "evaluatedAt": "2026-05-05T23:45:36.034Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33702,7 +33702,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.290Z",
+          "evaluatedAt": "2026-05-05T23:45:36.034Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33766,7 +33766,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.292Z",
+        "evaluatedAt": "2026-05-05T23:45:36.036Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33821,7 +33821,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.292Z",
+          "evaluatedAt": "2026-05-05T23:45:36.036Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33839,7 +33839,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.292Z",
+          "evaluatedAt": "2026-05-05T23:45:36.036Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33903,7 +33903,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.294Z",
+        "evaluatedAt": "2026-05-05T23:45:36.038Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33958,7 +33958,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.294Z",
+          "evaluatedAt": "2026-05-05T23:45:36.038Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33976,7 +33976,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.294Z",
+          "evaluatedAt": "2026-05-05T23:45:36.038Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34040,7 +34040,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.295Z",
+        "evaluatedAt": "2026-05-05T23:45:36.040Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34095,7 +34095,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.295Z",
+          "evaluatedAt": "2026-05-05T23:45:36.040Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34113,7 +34113,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.295Z",
+          "evaluatedAt": "2026-05-05T23:45:36.040Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34177,7 +34177,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.297Z",
+        "evaluatedAt": "2026-05-05T23:45:36.042Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34232,7 +34232,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.297Z",
+          "evaluatedAt": "2026-05-05T23:45:36.042Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34250,7 +34250,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.297Z",
+          "evaluatedAt": "2026-05-05T23:45:36.042Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34314,7 +34314,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.299Z",
+        "evaluatedAt": "2026-05-05T23:45:36.044Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34369,7 +34369,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.299Z",
+          "evaluatedAt": "2026-05-05T23:45:36.044Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34387,7 +34387,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.299Z",
+          "evaluatedAt": "2026-05-05T23:45:36.044Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34451,7 +34451,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.300Z",
+        "evaluatedAt": "2026-05-05T23:45:36.045Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34506,7 +34506,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.300Z",
+          "evaluatedAt": "2026-05-05T23:45:36.045Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34524,7 +34524,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.300Z",
+          "evaluatedAt": "2026-05-05T23:45:36.045Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34588,7 +34588,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.301Z",
+        "evaluatedAt": "2026-05-05T23:45:36.046Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34643,7 +34643,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.301Z",
+          "evaluatedAt": "2026-05-05T23:45:36.046Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34661,7 +34661,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.301Z",
+          "evaluatedAt": "2026-05-05T23:45:36.046Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34725,7 +34725,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.302Z",
+        "evaluatedAt": "2026-05-05T23:45:36.047Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34780,7 +34780,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.302Z",
+          "evaluatedAt": "2026-05-05T23:45:36.048Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34798,7 +34798,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.302Z",
+          "evaluatedAt": "2026-05-05T23:45:36.048Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34862,7 +34862,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.304Z",
+        "evaluatedAt": "2026-05-05T23:45:36.049Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34917,7 +34917,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.304Z",
+          "evaluatedAt": "2026-05-05T23:45:36.049Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34935,7 +34935,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.304Z",
+          "evaluatedAt": "2026-05-05T23:45:36.049Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34999,7 +34999,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.305Z",
+        "evaluatedAt": "2026-05-05T23:45:36.051Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35054,7 +35054,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.305Z",
+          "evaluatedAt": "2026-05-05T23:45:36.051Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35072,7 +35072,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.305Z",
+          "evaluatedAt": "2026-05-05T23:45:36.051Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35136,7 +35136,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.308Z",
+        "evaluatedAt": "2026-05-05T23:45:36.053Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35191,7 +35191,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.308Z",
+          "evaluatedAt": "2026-05-05T23:45:36.053Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35209,7 +35209,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.308Z",
+          "evaluatedAt": "2026-05-05T23:45:36.053Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35273,7 +35273,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.310Z",
+        "evaluatedAt": "2026-05-05T23:45:36.055Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35328,7 +35328,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.310Z",
+          "evaluatedAt": "2026-05-05T23:45:36.055Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35346,7 +35346,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.310Z",
+          "evaluatedAt": "2026-05-05T23:45:36.055Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35410,7 +35410,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.312Z",
+        "evaluatedAt": "2026-05-05T23:45:36.057Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35465,7 +35465,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.312Z",
+          "evaluatedAt": "2026-05-05T23:45:36.057Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35483,7 +35483,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.312Z",
+          "evaluatedAt": "2026-05-05T23:45:36.057Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35547,7 +35547,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.314Z",
+        "evaluatedAt": "2026-05-05T23:45:36.059Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35602,7 +35602,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.314Z",
+          "evaluatedAt": "2026-05-05T23:45:36.059Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35620,7 +35620,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.314Z",
+          "evaluatedAt": "2026-05-05T23:45:36.059Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35684,7 +35684,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.315Z",
+        "evaluatedAt": "2026-05-05T23:45:36.061Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35739,7 +35739,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.315Z",
+          "evaluatedAt": "2026-05-05T23:45:36.061Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35757,7 +35757,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.315Z",
+          "evaluatedAt": "2026-05-05T23:45:36.061Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35821,7 +35821,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.317Z",
+        "evaluatedAt": "2026-05-05T23:45:36.062Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35876,7 +35876,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.317Z",
+          "evaluatedAt": "2026-05-05T23:45:36.062Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35894,7 +35894,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.317Z",
+          "evaluatedAt": "2026-05-05T23:45:36.062Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35958,7 +35958,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.319Z",
+        "evaluatedAt": "2026-05-05T23:45:36.064Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36013,7 +36013,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.319Z",
+          "evaluatedAt": "2026-05-05T23:45:36.064Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36031,7 +36031,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.319Z",
+          "evaluatedAt": "2026-05-05T23:45:36.064Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36095,7 +36095,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.320Z",
+        "evaluatedAt": "2026-05-05T23:45:36.066Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36150,7 +36150,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.320Z",
+          "evaluatedAt": "2026-05-05T23:45:36.066Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36168,7 +36168,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.320Z",
+          "evaluatedAt": "2026-05-05T23:45:36.066Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36232,7 +36232,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.322Z",
+        "evaluatedAt": "2026-05-05T23:45:36.068Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36287,7 +36287,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.322Z",
+          "evaluatedAt": "2026-05-05T23:45:36.068Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36305,7 +36305,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.322Z",
+          "evaluatedAt": "2026-05-05T23:45:36.068Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36369,7 +36369,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.323Z",
+        "evaluatedAt": "2026-05-05T23:45:36.069Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36424,7 +36424,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.323Z",
+          "evaluatedAt": "2026-05-05T23:45:36.069Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36442,7 +36442,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.323Z",
+          "evaluatedAt": "2026-05-05T23:45:36.069Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36506,7 +36506,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.325Z",
+        "evaluatedAt": "2026-05-05T23:45:36.070Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36561,7 +36561,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.325Z",
+          "evaluatedAt": "2026-05-05T23:45:36.071Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36579,7 +36579,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.325Z",
+          "evaluatedAt": "2026-05-05T23:45:36.071Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36643,7 +36643,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.326Z",
+        "evaluatedAt": "2026-05-05T23:45:36.072Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36698,7 +36698,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.326Z",
+          "evaluatedAt": "2026-05-05T23:45:36.072Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36716,7 +36716,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.326Z",
+          "evaluatedAt": "2026-05-05T23:45:36.072Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36780,7 +36780,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.328Z",
+        "evaluatedAt": "2026-05-05T23:45:36.074Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36835,7 +36835,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.328Z",
+          "evaluatedAt": "2026-05-05T23:45:36.074Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36853,7 +36853,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.328Z",
+          "evaluatedAt": "2026-05-05T23:45:36.074Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36917,7 +36917,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.330Z",
+        "evaluatedAt": "2026-05-05T23:45:36.076Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36972,7 +36972,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.330Z",
+          "evaluatedAt": "2026-05-05T23:45:36.076Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36990,7 +36990,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.330Z",
+          "evaluatedAt": "2026-05-05T23:45:36.076Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37054,7 +37054,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.331Z",
+        "evaluatedAt": "2026-05-05T23:45:36.077Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37109,7 +37109,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.331Z",
+          "evaluatedAt": "2026-05-05T23:45:36.077Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37127,7 +37127,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.331Z",
+          "evaluatedAt": "2026-05-05T23:45:36.077Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37191,7 +37191,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.333Z",
+        "evaluatedAt": "2026-05-05T23:45:36.079Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37246,7 +37246,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.333Z",
+          "evaluatedAt": "2026-05-05T23:45:36.079Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37264,7 +37264,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.333Z",
+          "evaluatedAt": "2026-05-05T23:45:36.079Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37328,7 +37328,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.334Z",
+        "evaluatedAt": "2026-05-05T23:45:36.081Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37383,7 +37383,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.334Z",
+          "evaluatedAt": "2026-05-05T23:45:36.081Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37401,7 +37401,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.334Z",
+          "evaluatedAt": "2026-05-05T23:45:36.081Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37465,7 +37465,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.335Z",
+        "evaluatedAt": "2026-05-05T23:45:36.082Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37520,7 +37520,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.335Z",
+          "evaluatedAt": "2026-05-05T23:45:36.082Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37538,7 +37538,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.335Z",
+          "evaluatedAt": "2026-05-05T23:45:36.082Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37602,7 +37602,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.337Z",
+        "evaluatedAt": "2026-05-05T23:45:36.084Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37657,7 +37657,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.337Z",
+          "evaluatedAt": "2026-05-05T23:45:36.084Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37675,7 +37675,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.337Z",
+          "evaluatedAt": "2026-05-05T23:45:36.084Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37739,7 +37739,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.338Z",
+        "evaluatedAt": "2026-05-05T23:45:36.085Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37794,7 +37794,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.338Z",
+          "evaluatedAt": "2026-05-05T23:45:36.085Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37812,7 +37812,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.338Z",
+          "evaluatedAt": "2026-05-05T23:45:36.085Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37876,7 +37876,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.340Z",
+        "evaluatedAt": "2026-05-05T23:45:36.087Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37931,7 +37931,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.340Z",
+          "evaluatedAt": "2026-05-05T23:45:36.087Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37949,7 +37949,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.340Z",
+          "evaluatedAt": "2026-05-05T23:45:36.087Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38013,7 +38013,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.341Z",
+        "evaluatedAt": "2026-05-05T23:45:36.088Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38068,7 +38068,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.341Z",
+          "evaluatedAt": "2026-05-05T23:45:36.088Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38086,7 +38086,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.341Z",
+          "evaluatedAt": "2026-05-05T23:45:36.088Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38150,7 +38150,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.342Z",
+        "evaluatedAt": "2026-05-05T23:45:36.089Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38205,7 +38205,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.343Z",
+          "evaluatedAt": "2026-05-05T23:45:36.090Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38223,7 +38223,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.343Z",
+          "evaluatedAt": "2026-05-05T23:45:36.090Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38287,7 +38287,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.344Z",
+        "evaluatedAt": "2026-05-05T23:45:36.091Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38342,7 +38342,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.344Z",
+          "evaluatedAt": "2026-05-05T23:45:36.091Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38360,7 +38360,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.344Z",
+          "evaluatedAt": "2026-05-05T23:45:36.091Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38424,7 +38424,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.345Z",
+        "evaluatedAt": "2026-05-05T23:45:36.092Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38479,7 +38479,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.345Z",
+          "evaluatedAt": "2026-05-05T23:45:36.092Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38497,7 +38497,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.345Z",
+          "evaluatedAt": "2026-05-05T23:45:36.092Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38561,7 +38561,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.346Z",
+        "evaluatedAt": "2026-05-05T23:45:36.093Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38616,7 +38616,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.346Z",
+          "evaluatedAt": "2026-05-05T23:45:36.093Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38634,7 +38634,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.346Z",
+          "evaluatedAt": "2026-05-05T23:45:36.093Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38698,7 +38698,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.348Z",
+        "evaluatedAt": "2026-05-05T23:45:36.095Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38753,7 +38753,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.348Z",
+          "evaluatedAt": "2026-05-05T23:45:36.095Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38771,7 +38771,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.348Z",
+          "evaluatedAt": "2026-05-05T23:45:36.095Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38835,7 +38835,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.349Z",
+        "evaluatedAt": "2026-05-05T23:45:36.096Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38890,7 +38890,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.349Z",
+          "evaluatedAt": "2026-05-05T23:45:36.096Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38908,7 +38908,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.349Z",
+          "evaluatedAt": "2026-05-05T23:45:36.096Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38972,7 +38972,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.350Z",
+        "evaluatedAt": "2026-05-05T23:45:36.097Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39027,7 +39027,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.350Z",
+          "evaluatedAt": "2026-05-05T23:45:36.097Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39045,7 +39045,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.350Z",
+          "evaluatedAt": "2026-05-05T23:45:36.097Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39109,7 +39109,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.351Z",
+        "evaluatedAt": "2026-05-05T23:45:36.098Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39164,7 +39164,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.351Z",
+          "evaluatedAt": "2026-05-05T23:45:36.098Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39182,7 +39182,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.351Z",
+          "evaluatedAt": "2026-05-05T23:45:36.098Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39246,7 +39246,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.352Z",
+        "evaluatedAt": "2026-05-05T23:45:36.099Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39301,7 +39301,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.352Z",
+          "evaluatedAt": "2026-05-05T23:45:36.099Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39319,7 +39319,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.352Z",
+          "evaluatedAt": "2026-05-05T23:45:36.099Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39383,7 +39383,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.353Z",
+        "evaluatedAt": "2026-05-05T23:45:36.101Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39438,7 +39438,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.353Z",
+          "evaluatedAt": "2026-05-05T23:45:36.101Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39456,7 +39456,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.353Z",
+          "evaluatedAt": "2026-05-05T23:45:36.101Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39520,7 +39520,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.354Z",
+        "evaluatedAt": "2026-05-05T23:45:36.102Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39575,7 +39575,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.354Z",
+          "evaluatedAt": "2026-05-05T23:45:36.102Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39593,7 +39593,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.354Z",
+          "evaluatedAt": "2026-05-05T23:45:36.102Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39657,7 +39657,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.355Z",
+        "evaluatedAt": "2026-05-05T23:45:36.103Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39712,7 +39712,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.355Z",
+          "evaluatedAt": "2026-05-05T23:45:36.103Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39730,7 +39730,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.355Z",
+          "evaluatedAt": "2026-05-05T23:45:36.103Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39794,7 +39794,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.357Z",
+        "evaluatedAt": "2026-05-05T23:45:36.104Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39849,7 +39849,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.357Z",
+          "evaluatedAt": "2026-05-05T23:45:36.104Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39867,7 +39867,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.357Z",
+          "evaluatedAt": "2026-05-05T23:45:36.104Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39931,7 +39931,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.358Z",
+        "evaluatedAt": "2026-05-05T23:45:36.106Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39986,7 +39986,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.358Z",
+          "evaluatedAt": "2026-05-05T23:45:36.106Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40004,7 +40004,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.358Z",
+          "evaluatedAt": "2026-05-05T23:45:36.106Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40068,7 +40068,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.359Z",
+        "evaluatedAt": "2026-05-05T23:45:36.107Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40123,7 +40123,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.359Z",
+          "evaluatedAt": "2026-05-05T23:45:36.107Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40141,7 +40141,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.359Z",
+          "evaluatedAt": "2026-05-05T23:45:36.107Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40205,7 +40205,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.361Z",
+        "evaluatedAt": "2026-05-05T23:45:36.109Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40260,7 +40260,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.361Z",
+          "evaluatedAt": "2026-05-05T23:45:36.109Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40278,7 +40278,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.361Z",
+          "evaluatedAt": "2026-05-05T23:45:36.109Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40342,7 +40342,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.362Z",
+        "evaluatedAt": "2026-05-05T23:45:36.111Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40397,7 +40397,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.362Z",
+          "evaluatedAt": "2026-05-05T23:45:36.111Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40415,7 +40415,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.362Z",
+          "evaluatedAt": "2026-05-05T23:45:36.111Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40479,7 +40479,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.363Z",
+        "evaluatedAt": "2026-05-05T23:45:36.112Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40534,7 +40534,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.363Z",
+          "evaluatedAt": "2026-05-05T23:45:36.112Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40552,7 +40552,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.363Z",
+          "evaluatedAt": "2026-05-05T23:45:36.112Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40616,7 +40616,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.364Z",
+        "evaluatedAt": "2026-05-05T23:45:36.113Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40671,7 +40671,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.364Z",
+          "evaluatedAt": "2026-05-05T23:45:36.113Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40689,7 +40689,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.364Z",
+          "evaluatedAt": "2026-05-05T23:45:36.113Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40753,7 +40753,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.365Z",
+        "evaluatedAt": "2026-05-05T23:45:36.114Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40808,7 +40808,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.365Z",
+          "evaluatedAt": "2026-05-05T23:45:36.114Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40826,7 +40826,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.365Z",
+          "evaluatedAt": "2026-05-05T23:45:36.114Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40890,7 +40890,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.366Z",
+        "evaluatedAt": "2026-05-05T23:45:36.115Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40945,7 +40945,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.366Z",
+          "evaluatedAt": "2026-05-05T23:45:36.115Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40963,7 +40963,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.366Z",
+          "evaluatedAt": "2026-05-05T23:45:36.115Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41027,7 +41027,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.367Z",
+        "evaluatedAt": "2026-05-05T23:45:36.116Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41082,7 +41082,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.367Z",
+          "evaluatedAt": "2026-05-05T23:45:36.116Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41100,7 +41100,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.367Z",
+          "evaluatedAt": "2026-05-05T23:45:36.116Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41164,7 +41164,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.369Z",
+        "evaluatedAt": "2026-05-05T23:45:36.117Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41219,7 +41219,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.369Z",
+          "evaluatedAt": "2026-05-05T23:45:36.117Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41237,7 +41237,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.369Z",
+          "evaluatedAt": "2026-05-05T23:45:36.117Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41301,7 +41301,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.370Z",
+        "evaluatedAt": "2026-05-05T23:45:36.119Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41356,7 +41356,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.370Z",
+          "evaluatedAt": "2026-05-05T23:45:36.119Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41374,7 +41374,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.370Z",
+          "evaluatedAt": "2026-05-05T23:45:36.119Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41438,7 +41438,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.371Z",
+        "evaluatedAt": "2026-05-05T23:45:36.120Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41493,7 +41493,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.371Z",
+          "evaluatedAt": "2026-05-05T23:45:36.120Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41511,7 +41511,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.371Z",
+          "evaluatedAt": "2026-05-05T23:45:36.120Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41575,7 +41575,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.373Z",
+        "evaluatedAt": "2026-05-05T23:45:36.122Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41630,7 +41630,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.373Z",
+          "evaluatedAt": "2026-05-05T23:45:36.122Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41648,7 +41648,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.373Z",
+          "evaluatedAt": "2026-05-05T23:45:36.122Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41712,7 +41712,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.374Z",
+        "evaluatedAt": "2026-05-05T23:45:36.123Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41767,7 +41767,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.374Z",
+          "evaluatedAt": "2026-05-05T23:45:36.123Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41785,7 +41785,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.374Z",
+          "evaluatedAt": "2026-05-05T23:45:36.123Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41849,7 +41849,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.376Z",
+        "evaluatedAt": "2026-05-05T23:45:36.125Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41904,7 +41904,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.376Z",
+          "evaluatedAt": "2026-05-05T23:45:36.125Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41922,7 +41922,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.376Z",
+          "evaluatedAt": "2026-05-05T23:45:36.125Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41986,7 +41986,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.378Z",
+        "evaluatedAt": "2026-05-05T23:45:36.126Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42041,7 +42041,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.378Z",
+          "evaluatedAt": "2026-05-05T23:45:36.126Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42059,7 +42059,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.378Z",
+          "evaluatedAt": "2026-05-05T23:45:36.126Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42123,7 +42123,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.379Z",
+        "evaluatedAt": "2026-05-05T23:45:36.127Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42178,7 +42178,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.379Z",
+          "evaluatedAt": "2026-05-05T23:45:36.127Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42196,7 +42196,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.379Z",
+          "evaluatedAt": "2026-05-05T23:45:36.127Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42260,7 +42260,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.380Z",
+        "evaluatedAt": "2026-05-05T23:45:36.129Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42315,7 +42315,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.380Z",
+          "evaluatedAt": "2026-05-05T23:45:36.129Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42333,7 +42333,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.380Z",
+          "evaluatedAt": "2026-05-05T23:45:36.129Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42397,7 +42397,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.381Z",
+        "evaluatedAt": "2026-05-05T23:45:36.130Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42452,7 +42452,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.381Z",
+          "evaluatedAt": "2026-05-05T23:45:36.130Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42470,7 +42470,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.381Z",
+          "evaluatedAt": "2026-05-05T23:45:36.130Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42534,7 +42534,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.383Z",
+        "evaluatedAt": "2026-05-05T23:45:36.131Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42589,7 +42589,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.383Z",
+          "evaluatedAt": "2026-05-05T23:45:36.131Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42607,7 +42607,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.383Z",
+          "evaluatedAt": "2026-05-05T23:45:36.131Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42671,7 +42671,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.384Z",
+        "evaluatedAt": "2026-05-05T23:45:36.132Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42726,7 +42726,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.384Z",
+          "evaluatedAt": "2026-05-05T23:45:36.132Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42744,7 +42744,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.384Z",
+          "evaluatedAt": "2026-05-05T23:45:36.132Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42808,7 +42808,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.385Z",
+        "evaluatedAt": "2026-05-05T23:45:36.134Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42863,7 +42863,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.385Z",
+          "evaluatedAt": "2026-05-05T23:45:36.134Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42881,7 +42881,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.385Z",
+          "evaluatedAt": "2026-05-05T23:45:36.134Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42945,7 +42945,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.386Z",
+        "evaluatedAt": "2026-05-05T23:45:36.135Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43000,7 +43000,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.386Z",
+          "evaluatedAt": "2026-05-05T23:45:36.135Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43018,7 +43018,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.386Z",
+          "evaluatedAt": "2026-05-05T23:45:36.135Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43082,7 +43082,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.388Z",
+        "evaluatedAt": "2026-05-05T23:45:36.137Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43137,7 +43137,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.388Z",
+          "evaluatedAt": "2026-05-05T23:45:36.137Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43155,7 +43155,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.388Z",
+          "evaluatedAt": "2026-05-05T23:45:36.137Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43219,7 +43219,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.389Z",
+        "evaluatedAt": "2026-05-05T23:45:36.138Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43274,7 +43274,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.389Z",
+          "evaluatedAt": "2026-05-05T23:45:36.138Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43292,7 +43292,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.389Z",
+          "evaluatedAt": "2026-05-05T23:45:36.138Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43356,7 +43356,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.391Z",
+        "evaluatedAt": "2026-05-05T23:45:36.140Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43411,7 +43411,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.391Z",
+          "evaluatedAt": "2026-05-05T23:45:36.140Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43429,7 +43429,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.391Z",
+          "evaluatedAt": "2026-05-05T23:45:36.140Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43493,7 +43493,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.393Z",
+        "evaluatedAt": "2026-05-05T23:45:36.142Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43548,7 +43548,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.393Z",
+          "evaluatedAt": "2026-05-05T23:45:36.142Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43566,7 +43566,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.393Z",
+          "evaluatedAt": "2026-05-05T23:45:36.142Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43630,7 +43630,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.395Z",
+        "evaluatedAt": "2026-05-05T23:45:36.143Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43685,7 +43685,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.395Z",
+          "evaluatedAt": "2026-05-05T23:45:36.143Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43703,7 +43703,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.395Z",
+          "evaluatedAt": "2026-05-05T23:45:36.143Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43767,7 +43767,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.396Z",
+        "evaluatedAt": "2026-05-05T23:45:36.145Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43822,7 +43822,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.396Z",
+          "evaluatedAt": "2026-05-05T23:45:36.145Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43840,7 +43840,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.396Z",
+          "evaluatedAt": "2026-05-05T23:45:36.145Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43904,7 +43904,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.397Z",
+        "evaluatedAt": "2026-05-05T23:45:36.146Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43959,7 +43959,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.397Z",
+          "evaluatedAt": "2026-05-05T23:45:36.146Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43977,7 +43977,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.397Z",
+          "evaluatedAt": "2026-05-05T23:45:36.146Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44041,7 +44041,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.399Z",
+        "evaluatedAt": "2026-05-05T23:45:36.147Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44096,7 +44096,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.399Z",
+          "evaluatedAt": "2026-05-05T23:45:36.148Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44114,7 +44114,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.399Z",
+          "evaluatedAt": "2026-05-05T23:45:36.148Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44178,7 +44178,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.400Z",
+        "evaluatedAt": "2026-05-05T23:45:36.149Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44233,7 +44233,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.400Z",
+          "evaluatedAt": "2026-05-05T23:45:36.149Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44251,7 +44251,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.400Z",
+          "evaluatedAt": "2026-05-05T23:45:36.149Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44315,7 +44315,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.402Z",
+        "evaluatedAt": "2026-05-05T23:45:36.151Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44370,7 +44370,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.402Z",
+          "evaluatedAt": "2026-05-05T23:45:36.151Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44388,7 +44388,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.402Z",
+          "evaluatedAt": "2026-05-05T23:45:36.151Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44452,7 +44452,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.403Z",
+        "evaluatedAt": "2026-05-05T23:45:36.152Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44507,7 +44507,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.403Z",
+          "evaluatedAt": "2026-05-05T23:45:36.152Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44525,7 +44525,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.403Z",
+          "evaluatedAt": "2026-05-05T23:45:36.152Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44589,7 +44589,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.405Z",
+        "evaluatedAt": "2026-05-05T23:45:36.154Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44644,7 +44644,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.405Z",
+          "evaluatedAt": "2026-05-05T23:45:36.154Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44662,7 +44662,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.405Z",
+          "evaluatedAt": "2026-05-05T23:45:36.154Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44726,7 +44726,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.406Z",
+        "evaluatedAt": "2026-05-05T23:45:36.155Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44781,7 +44781,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.406Z",
+          "evaluatedAt": "2026-05-05T23:45:36.155Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44799,7 +44799,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.406Z",
+          "evaluatedAt": "2026-05-05T23:45:36.155Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44863,7 +44863,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.408Z",
+        "evaluatedAt": "2026-05-05T23:45:36.157Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44918,7 +44918,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.408Z",
+          "evaluatedAt": "2026-05-05T23:45:36.157Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44936,7 +44936,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.408Z",
+          "evaluatedAt": "2026-05-05T23:45:36.157Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45000,7 +45000,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.410Z",
+        "evaluatedAt": "2026-05-05T23:45:36.158Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45055,7 +45055,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.410Z",
+          "evaluatedAt": "2026-05-05T23:45:36.158Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45073,7 +45073,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.410Z",
+          "evaluatedAt": "2026-05-05T23:45:36.158Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45137,7 +45137,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.411Z",
+        "evaluatedAt": "2026-05-05T23:45:36.160Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45192,7 +45192,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.411Z",
+          "evaluatedAt": "2026-05-05T23:45:36.160Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45210,7 +45210,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.411Z",
+          "evaluatedAt": "2026-05-05T23:45:36.160Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45274,7 +45274,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.413Z",
+        "evaluatedAt": "2026-05-05T23:45:36.161Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45329,7 +45329,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.413Z",
+          "evaluatedAt": "2026-05-05T23:45:36.161Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45347,7 +45347,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.413Z",
+          "evaluatedAt": "2026-05-05T23:45:36.161Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45411,7 +45411,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.414Z",
+        "evaluatedAt": "2026-05-05T23:45:36.163Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45466,7 +45466,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.414Z",
+          "evaluatedAt": "2026-05-05T23:45:36.163Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45484,7 +45484,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.415Z",
+          "evaluatedAt": "2026-05-05T23:45:36.163Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45548,7 +45548,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.416Z",
+        "evaluatedAt": "2026-05-05T23:45:36.165Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45603,7 +45603,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.416Z",
+          "evaluatedAt": "2026-05-05T23:45:36.165Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45621,7 +45621,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.416Z",
+          "evaluatedAt": "2026-05-05T23:45:36.165Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45685,7 +45685,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.418Z",
+        "evaluatedAt": "2026-05-05T23:45:36.166Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45740,7 +45740,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.418Z",
+          "evaluatedAt": "2026-05-05T23:45:36.166Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45758,7 +45758,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.418Z",
+          "evaluatedAt": "2026-05-05T23:45:36.166Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45822,7 +45822,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.419Z",
+        "evaluatedAt": "2026-05-05T23:45:36.168Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45877,7 +45877,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.419Z",
+          "evaluatedAt": "2026-05-05T23:45:36.168Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45895,7 +45895,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.419Z",
+          "evaluatedAt": "2026-05-05T23:45:36.168Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45959,7 +45959,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.420Z",
+        "evaluatedAt": "2026-05-05T23:45:36.169Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46014,7 +46014,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.420Z",
+          "evaluatedAt": "2026-05-05T23:45:36.169Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46032,7 +46032,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.420Z",
+          "evaluatedAt": "2026-05-05T23:45:36.169Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46096,7 +46096,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.422Z",
+        "evaluatedAt": "2026-05-05T23:45:36.170Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46151,7 +46151,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.422Z",
+          "evaluatedAt": "2026-05-05T23:45:36.170Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46169,7 +46169,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.422Z",
+          "evaluatedAt": "2026-05-05T23:45:36.170Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46233,7 +46233,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.424Z",
+        "evaluatedAt": "2026-05-05T23:45:36.172Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46288,7 +46288,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.424Z",
+          "evaluatedAt": "2026-05-05T23:45:36.172Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46306,7 +46306,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.424Z",
+          "evaluatedAt": "2026-05-05T23:45:36.172Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46370,7 +46370,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.426Z",
+        "evaluatedAt": "2026-05-05T23:45:36.174Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46425,7 +46425,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.426Z",
+          "evaluatedAt": "2026-05-05T23:45:36.174Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46443,7 +46443,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.426Z",
+          "evaluatedAt": "2026-05-05T23:45:36.174Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46507,7 +46507,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.428Z",
+        "evaluatedAt": "2026-05-05T23:45:36.175Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46562,7 +46562,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.428Z",
+          "evaluatedAt": "2026-05-05T23:45:36.175Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46580,7 +46580,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.428Z",
+          "evaluatedAt": "2026-05-05T23:45:36.175Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46644,7 +46644,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.429Z",
+        "evaluatedAt": "2026-05-05T23:45:36.176Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46699,7 +46699,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.429Z",
+          "evaluatedAt": "2026-05-05T23:45:36.177Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46717,7 +46717,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.429Z",
+          "evaluatedAt": "2026-05-05T23:45:36.177Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46781,7 +46781,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.430Z",
+        "evaluatedAt": "2026-05-05T23:45:36.178Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46836,7 +46836,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.430Z",
+          "evaluatedAt": "2026-05-05T23:45:36.178Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46854,7 +46854,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.430Z",
+          "evaluatedAt": "2026-05-05T23:45:36.178Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46918,7 +46918,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.431Z",
+        "evaluatedAt": "2026-05-05T23:45:36.179Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46973,7 +46973,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.431Z",
+          "evaluatedAt": "2026-05-05T23:45:36.179Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46991,7 +46991,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.431Z",
+          "evaluatedAt": "2026-05-05T23:45:36.179Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47055,7 +47055,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.433Z",
+        "evaluatedAt": "2026-05-05T23:45:36.180Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47110,7 +47110,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.433Z",
+          "evaluatedAt": "2026-05-05T23:45:36.180Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47128,7 +47128,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.433Z",
+          "evaluatedAt": "2026-05-05T23:45:36.180Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47192,7 +47192,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.434Z",
+        "evaluatedAt": "2026-05-05T23:45:36.181Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47247,7 +47247,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.434Z",
+          "evaluatedAt": "2026-05-05T23:45:36.181Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47265,7 +47265,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.434Z",
+          "evaluatedAt": "2026-05-05T23:45:36.181Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47329,7 +47329,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.435Z",
+        "evaluatedAt": "2026-05-05T23:45:36.182Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47384,7 +47384,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.435Z",
+          "evaluatedAt": "2026-05-05T23:45:36.182Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47402,7 +47402,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.435Z",
+          "evaluatedAt": "2026-05-05T23:45:36.182Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47466,7 +47466,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.436Z",
+        "evaluatedAt": "2026-05-05T23:45:36.184Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47521,7 +47521,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.436Z",
+          "evaluatedAt": "2026-05-05T23:45:36.184Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47539,7 +47539,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.436Z",
+          "evaluatedAt": "2026-05-05T23:45:36.184Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47603,7 +47603,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.438Z",
+        "evaluatedAt": "2026-05-05T23:45:36.185Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47658,7 +47658,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.438Z",
+          "evaluatedAt": "2026-05-05T23:45:36.185Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47676,7 +47676,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.438Z",
+          "evaluatedAt": "2026-05-05T23:45:36.185Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47740,7 +47740,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.439Z",
+        "evaluatedAt": "2026-05-05T23:45:36.187Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47795,7 +47795,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.439Z",
+          "evaluatedAt": "2026-05-05T23:45:36.187Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47813,7 +47813,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.439Z",
+          "evaluatedAt": "2026-05-05T23:45:36.187Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47877,7 +47877,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.441Z",
+        "evaluatedAt": "2026-05-05T23:45:36.188Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47932,7 +47932,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.441Z",
+          "evaluatedAt": "2026-05-05T23:45:36.188Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47950,7 +47950,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.441Z",
+          "evaluatedAt": "2026-05-05T23:45:36.188Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48014,7 +48014,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.442Z",
+        "evaluatedAt": "2026-05-05T23:45:36.190Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48069,7 +48069,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.442Z",
+          "evaluatedAt": "2026-05-05T23:45:36.190Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48087,7 +48087,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.442Z",
+          "evaluatedAt": "2026-05-05T23:45:36.190Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48151,7 +48151,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.444Z",
+        "evaluatedAt": "2026-05-05T23:45:36.191Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48206,7 +48206,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.444Z",
+          "evaluatedAt": "2026-05-05T23:45:36.191Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48224,7 +48224,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.444Z",
+          "evaluatedAt": "2026-05-05T23:45:36.191Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48288,7 +48288,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.445Z",
+        "evaluatedAt": "2026-05-05T23:45:36.192Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48343,7 +48343,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.445Z",
+          "evaluatedAt": "2026-05-05T23:45:36.192Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48361,7 +48361,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.445Z",
+          "evaluatedAt": "2026-05-05T23:45:36.192Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48425,7 +48425,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.447Z",
+        "evaluatedAt": "2026-05-05T23:45:36.194Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48480,7 +48480,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.447Z",
+          "evaluatedAt": "2026-05-05T23:45:36.194Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48498,7 +48498,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.447Z",
+          "evaluatedAt": "2026-05-05T23:45:36.194Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48562,7 +48562,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.448Z",
+        "evaluatedAt": "2026-05-05T23:45:36.195Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48617,7 +48617,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.448Z",
+          "evaluatedAt": "2026-05-05T23:45:36.195Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48635,7 +48635,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.448Z",
+          "evaluatedAt": "2026-05-05T23:45:36.195Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48699,7 +48699,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.449Z",
+        "evaluatedAt": "2026-05-05T23:45:36.196Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48754,7 +48754,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.449Z",
+          "evaluatedAt": "2026-05-05T23:45:36.196Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48772,7 +48772,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.449Z",
+          "evaluatedAt": "2026-05-05T23:45:36.196Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48836,7 +48836,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.450Z",
+        "evaluatedAt": "2026-05-05T23:45:36.197Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48891,7 +48891,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.450Z",
+          "evaluatedAt": "2026-05-05T23:45:36.197Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48909,7 +48909,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.450Z",
+          "evaluatedAt": "2026-05-05T23:45:36.197Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48973,7 +48973,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.452Z",
+        "evaluatedAt": "2026-05-05T23:45:36.199Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49028,7 +49028,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.452Z",
+          "evaluatedAt": "2026-05-05T23:45:36.199Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49046,7 +49046,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.452Z",
+          "evaluatedAt": "2026-05-05T23:45:36.199Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49110,7 +49110,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.453Z",
+        "evaluatedAt": "2026-05-05T23:45:36.200Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49165,7 +49165,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.453Z",
+          "evaluatedAt": "2026-05-05T23:45:36.200Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49183,7 +49183,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.453Z",
+          "evaluatedAt": "2026-05-05T23:45:36.200Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49247,7 +49247,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.454Z",
+        "evaluatedAt": "2026-05-05T23:45:36.201Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49302,7 +49302,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.454Z",
+          "evaluatedAt": "2026-05-05T23:45:36.201Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49320,7 +49320,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.454Z",
+          "evaluatedAt": "2026-05-05T23:45:36.201Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49384,7 +49384,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.455Z",
+        "evaluatedAt": "2026-05-05T23:45:36.202Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49439,7 +49439,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.455Z",
+          "evaluatedAt": "2026-05-05T23:45:36.202Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49457,7 +49457,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.455Z",
+          "evaluatedAt": "2026-05-05T23:45:36.202Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49521,7 +49521,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.457Z",
+        "evaluatedAt": "2026-05-05T23:45:36.204Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49576,7 +49576,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.457Z",
+          "evaluatedAt": "2026-05-05T23:45:36.204Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49594,7 +49594,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.457Z",
+          "evaluatedAt": "2026-05-05T23:45:36.204Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49658,7 +49658,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.459Z",
+        "evaluatedAt": "2026-05-05T23:45:36.206Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49713,7 +49713,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.459Z",
+          "evaluatedAt": "2026-05-05T23:45:36.206Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49731,7 +49731,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.459Z",
+          "evaluatedAt": "2026-05-05T23:45:36.206Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49795,7 +49795,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.460Z",
+        "evaluatedAt": "2026-05-05T23:45:36.207Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49850,7 +49850,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.460Z",
+          "evaluatedAt": "2026-05-05T23:45:36.207Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49868,7 +49868,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.460Z",
+          "evaluatedAt": "2026-05-05T23:45:36.207Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49932,7 +49932,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.462Z",
+        "evaluatedAt": "2026-05-05T23:45:36.209Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49987,7 +49987,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.462Z",
+          "evaluatedAt": "2026-05-05T23:45:36.209Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50005,7 +50005,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.462Z",
+          "evaluatedAt": "2026-05-05T23:45:36.209Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50069,7 +50069,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.463Z",
+        "evaluatedAt": "2026-05-05T23:45:36.210Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50124,7 +50124,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.463Z",
+          "evaluatedAt": "2026-05-05T23:45:36.210Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50142,7 +50142,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.463Z",
+          "evaluatedAt": "2026-05-05T23:45:36.210Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50206,7 +50206,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.465Z",
+        "evaluatedAt": "2026-05-05T23:45:36.211Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50261,7 +50261,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.465Z",
+          "evaluatedAt": "2026-05-05T23:45:36.211Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50279,7 +50279,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.465Z",
+          "evaluatedAt": "2026-05-05T23:45:36.211Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50343,7 +50343,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.466Z",
+        "evaluatedAt": "2026-05-05T23:45:36.213Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50398,7 +50398,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.466Z",
+          "evaluatedAt": "2026-05-05T23:45:36.213Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50416,7 +50416,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.466Z",
+          "evaluatedAt": "2026-05-05T23:45:36.213Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50480,7 +50480,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.467Z",
+        "evaluatedAt": "2026-05-05T23:45:36.214Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50535,7 +50535,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.467Z",
+          "evaluatedAt": "2026-05-05T23:45:36.214Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50553,7 +50553,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.467Z",
+          "evaluatedAt": "2026-05-05T23:45:36.214Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50617,7 +50617,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.469Z",
+        "evaluatedAt": "2026-05-05T23:45:36.215Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50672,7 +50672,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.469Z",
+          "evaluatedAt": "2026-05-05T23:45:36.215Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50690,7 +50690,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.469Z",
+          "evaluatedAt": "2026-05-05T23:45:36.215Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50754,7 +50754,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.470Z",
+        "evaluatedAt": "2026-05-05T23:45:36.216Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50809,7 +50809,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.470Z",
+          "evaluatedAt": "2026-05-05T23:45:36.216Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50827,7 +50827,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.470Z",
+          "evaluatedAt": "2026-05-05T23:45:36.216Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50891,7 +50891,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.471Z",
+        "evaluatedAt": "2026-05-05T23:45:36.217Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50946,7 +50946,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.471Z",
+          "evaluatedAt": "2026-05-05T23:45:36.217Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50964,7 +50964,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.471Z",
+          "evaluatedAt": "2026-05-05T23:45:36.217Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51028,7 +51028,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.472Z",
+        "evaluatedAt": "2026-05-05T23:45:36.218Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51083,7 +51083,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.472Z",
+          "evaluatedAt": "2026-05-05T23:45:36.218Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51101,7 +51101,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.472Z",
+          "evaluatedAt": "2026-05-05T23:45:36.218Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51165,7 +51165,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.473Z",
+        "evaluatedAt": "2026-05-05T23:45:36.219Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51220,7 +51220,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.473Z",
+          "evaluatedAt": "2026-05-05T23:45:36.219Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51238,7 +51238,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.473Z",
+          "evaluatedAt": "2026-05-05T23:45:36.219Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51302,7 +51302,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.475Z",
+        "evaluatedAt": "2026-05-05T23:45:36.221Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51357,7 +51357,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.475Z",
+          "evaluatedAt": "2026-05-05T23:45:36.221Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51375,7 +51375,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.475Z",
+          "evaluatedAt": "2026-05-05T23:45:36.221Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51439,7 +51439,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.476Z",
+        "evaluatedAt": "2026-05-05T23:45:36.222Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51494,7 +51494,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.476Z",
+          "evaluatedAt": "2026-05-05T23:45:36.222Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51512,7 +51512,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.476Z",
+          "evaluatedAt": "2026-05-05T23:45:36.222Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51576,7 +51576,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.478Z",
+        "evaluatedAt": "2026-05-05T23:45:36.224Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51631,7 +51631,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.478Z",
+          "evaluatedAt": "2026-05-05T23:45:36.224Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51649,7 +51649,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.478Z",
+          "evaluatedAt": "2026-05-05T23:45:36.224Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51713,7 +51713,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.480Z",
+        "evaluatedAt": "2026-05-05T23:45:36.226Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51768,7 +51768,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.480Z",
+          "evaluatedAt": "2026-05-05T23:45:36.226Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51786,7 +51786,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.480Z",
+          "evaluatedAt": "2026-05-05T23:45:36.226Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51850,7 +51850,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.482Z",
+        "evaluatedAt": "2026-05-05T23:45:36.227Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51905,7 +51905,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.482Z",
+          "evaluatedAt": "2026-05-05T23:45:36.227Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51923,7 +51923,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.482Z",
+          "evaluatedAt": "2026-05-05T23:45:36.227Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51987,7 +51987,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.483Z",
+        "evaluatedAt": "2026-05-05T23:45:36.229Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52042,7 +52042,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.483Z",
+          "evaluatedAt": "2026-05-05T23:45:36.229Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52060,7 +52060,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.483Z",
+          "evaluatedAt": "2026-05-05T23:45:36.229Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52124,7 +52124,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.484Z",
+        "evaluatedAt": "2026-05-05T23:45:36.231Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52179,7 +52179,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.484Z",
+          "evaluatedAt": "2026-05-05T23:45:36.231Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52197,7 +52197,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.484Z",
+          "evaluatedAt": "2026-05-05T23:45:36.231Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52261,7 +52261,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.486Z",
+        "evaluatedAt": "2026-05-05T23:45:36.232Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52316,7 +52316,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.486Z",
+          "evaluatedAt": "2026-05-05T23:45:36.232Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52334,7 +52334,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.486Z",
+          "evaluatedAt": "2026-05-05T23:45:36.232Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52398,7 +52398,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.488Z",
+        "evaluatedAt": "2026-05-05T23:45:36.234Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52453,7 +52453,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.488Z",
+          "evaluatedAt": "2026-05-05T23:45:36.234Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52471,7 +52471,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.488Z",
+          "evaluatedAt": "2026-05-05T23:45:36.234Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52535,7 +52535,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.491Z",
+        "evaluatedAt": "2026-05-05T23:45:36.236Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52590,7 +52590,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.491Z",
+          "evaluatedAt": "2026-05-05T23:45:36.236Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52608,7 +52608,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.491Z",
+          "evaluatedAt": "2026-05-05T23:45:36.236Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52672,7 +52672,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.493Z",
+        "evaluatedAt": "2026-05-05T23:45:36.239Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52727,7 +52727,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.493Z",
+          "evaluatedAt": "2026-05-05T23:45:36.239Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52745,7 +52745,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.493Z",
+          "evaluatedAt": "2026-05-05T23:45:36.239Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52809,7 +52809,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.495Z",
+        "evaluatedAt": "2026-05-05T23:45:36.241Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52864,7 +52864,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.495Z",
+          "evaluatedAt": "2026-05-05T23:45:36.241Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52882,7 +52882,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.495Z",
+          "evaluatedAt": "2026-05-05T23:45:36.241Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52946,7 +52946,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.497Z",
+        "evaluatedAt": "2026-05-05T23:45:36.243Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53001,7 +53001,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.497Z",
+          "evaluatedAt": "2026-05-05T23:45:36.244Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53019,7 +53019,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.497Z",
+          "evaluatedAt": "2026-05-05T23:45:36.244Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53083,7 +53083,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.500Z",
+        "evaluatedAt": "2026-05-05T23:45:36.246Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53138,7 +53138,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.500Z",
+          "evaluatedAt": "2026-05-05T23:45:36.246Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53156,7 +53156,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.500Z",
+          "evaluatedAt": "2026-05-05T23:45:36.246Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53220,7 +53220,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.502Z",
+        "evaluatedAt": "2026-05-05T23:45:36.248Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53275,7 +53275,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.502Z",
+          "evaluatedAt": "2026-05-05T23:45:36.248Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53293,7 +53293,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.502Z",
+          "evaluatedAt": "2026-05-05T23:45:36.248Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53357,7 +53357,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.504Z",
+        "evaluatedAt": "2026-05-05T23:45:36.250Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53412,7 +53412,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.504Z",
+          "evaluatedAt": "2026-05-05T23:45:36.250Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53430,7 +53430,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.504Z",
+          "evaluatedAt": "2026-05-05T23:45:36.250Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53494,7 +53494,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.506Z",
+        "evaluatedAt": "2026-05-05T23:45:36.252Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53549,7 +53549,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.506Z",
+          "evaluatedAt": "2026-05-05T23:45:36.252Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53567,7 +53567,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.506Z",
+          "evaluatedAt": "2026-05-05T23:45:36.252Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53631,7 +53631,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.509Z",
+        "evaluatedAt": "2026-05-05T23:45:36.254Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53686,7 +53686,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.509Z",
+          "evaluatedAt": "2026-05-05T23:45:36.254Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53704,7 +53704,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.509Z",
+          "evaluatedAt": "2026-05-05T23:45:36.254Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53768,7 +53768,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.511Z",
+        "evaluatedAt": "2026-05-05T23:45:36.257Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53823,7 +53823,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.511Z",
+          "evaluatedAt": "2026-05-05T23:45:36.257Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53841,7 +53841,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.511Z",
+          "evaluatedAt": "2026-05-05T23:45:36.257Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53905,7 +53905,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.513Z",
+        "evaluatedAt": "2026-05-05T23:45:36.258Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53960,7 +53960,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.513Z",
+          "evaluatedAt": "2026-05-05T23:45:36.258Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53978,7 +53978,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.513Z",
+          "evaluatedAt": "2026-05-05T23:45:36.258Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54042,7 +54042,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.514Z",
+        "evaluatedAt": "2026-05-05T23:45:36.260Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54097,7 +54097,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.514Z",
+          "evaluatedAt": "2026-05-05T23:45:36.260Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54115,7 +54115,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.514Z",
+          "evaluatedAt": "2026-05-05T23:45:36.260Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54179,7 +54179,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.516Z",
+        "evaluatedAt": "2026-05-05T23:45:36.261Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54234,7 +54234,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.516Z",
+          "evaluatedAt": "2026-05-05T23:45:36.261Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54252,7 +54252,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.516Z",
+          "evaluatedAt": "2026-05-05T23:45:36.261Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54316,7 +54316,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.517Z",
+        "evaluatedAt": "2026-05-05T23:45:36.263Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54371,7 +54371,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.517Z",
+          "evaluatedAt": "2026-05-05T23:45:36.263Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54389,7 +54389,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.517Z",
+          "evaluatedAt": "2026-05-05T23:45:36.263Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54453,7 +54453,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.519Z",
+        "evaluatedAt": "2026-05-05T23:45:36.264Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54508,7 +54508,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.519Z",
+          "evaluatedAt": "2026-05-05T23:45:36.264Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54526,7 +54526,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.519Z",
+          "evaluatedAt": "2026-05-05T23:45:36.264Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54590,7 +54590,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.521Z",
+        "evaluatedAt": "2026-05-05T23:45:36.266Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54645,7 +54645,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.521Z",
+          "evaluatedAt": "2026-05-05T23:45:36.266Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54663,7 +54663,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.521Z",
+          "evaluatedAt": "2026-05-05T23:45:36.266Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54727,7 +54727,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.523Z",
+        "evaluatedAt": "2026-05-05T23:45:36.268Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54782,7 +54782,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.523Z",
+          "evaluatedAt": "2026-05-05T23:45:36.268Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54800,7 +54800,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.523Z",
+          "evaluatedAt": "2026-05-05T23:45:36.268Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54864,7 +54864,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.525Z",
+        "evaluatedAt": "2026-05-05T23:45:36.270Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54919,7 +54919,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.525Z",
+          "evaluatedAt": "2026-05-05T23:45:36.270Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54937,7 +54937,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.525Z",
+          "evaluatedAt": "2026-05-05T23:45:36.271Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55001,7 +55001,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.527Z",
+        "evaluatedAt": "2026-05-05T23:45:36.273Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55056,7 +55056,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.527Z",
+          "evaluatedAt": "2026-05-05T23:45:36.273Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55074,7 +55074,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.527Z",
+          "evaluatedAt": "2026-05-05T23:45:36.273Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55138,7 +55138,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.529Z",
+        "evaluatedAt": "2026-05-05T23:45:36.275Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55193,7 +55193,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.529Z",
+          "evaluatedAt": "2026-05-05T23:45:36.275Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55211,7 +55211,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.529Z",
+          "evaluatedAt": "2026-05-05T23:45:36.275Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55275,7 +55275,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.531Z",
+        "evaluatedAt": "2026-05-05T23:45:36.276Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55330,7 +55330,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.531Z",
+          "evaluatedAt": "2026-05-05T23:45:36.276Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55348,7 +55348,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.531Z",
+          "evaluatedAt": "2026-05-05T23:45:36.276Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55412,7 +55412,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.533Z",
+        "evaluatedAt": "2026-05-05T23:45:36.278Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55467,7 +55467,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.533Z",
+          "evaluatedAt": "2026-05-05T23:45:36.278Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55485,7 +55485,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.533Z",
+          "evaluatedAt": "2026-05-05T23:45:36.278Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55549,7 +55549,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.535Z",
+        "evaluatedAt": "2026-05-05T23:45:36.280Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55604,7 +55604,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.535Z",
+          "evaluatedAt": "2026-05-05T23:45:36.280Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55622,7 +55622,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.535Z",
+          "evaluatedAt": "2026-05-05T23:45:36.280Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55686,7 +55686,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.537Z",
+        "evaluatedAt": "2026-05-05T23:45:36.282Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55741,7 +55741,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.537Z",
+          "evaluatedAt": "2026-05-05T23:45:36.282Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55759,7 +55759,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.537Z",
+          "evaluatedAt": "2026-05-05T23:45:36.282Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55823,7 +55823,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.539Z",
+        "evaluatedAt": "2026-05-05T23:45:36.284Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55878,7 +55878,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.539Z",
+          "evaluatedAt": "2026-05-05T23:45:36.284Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55896,7 +55896,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.539Z",
+          "evaluatedAt": "2026-05-05T23:45:36.284Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55960,7 +55960,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.541Z",
+        "evaluatedAt": "2026-05-05T23:45:36.286Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56015,7 +56015,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.541Z",
+          "evaluatedAt": "2026-05-05T23:45:36.286Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56033,7 +56033,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.541Z",
+          "evaluatedAt": "2026-05-05T23:45:36.286Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56097,7 +56097,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.544Z",
+        "evaluatedAt": "2026-05-05T23:45:36.288Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56152,7 +56152,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.544Z",
+          "evaluatedAt": "2026-05-05T23:45:36.288Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56170,7 +56170,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.544Z",
+          "evaluatedAt": "2026-05-05T23:45:36.288Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56234,7 +56234,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.546Z",
+        "evaluatedAt": "2026-05-05T23:45:36.290Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56289,7 +56289,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.546Z",
+          "evaluatedAt": "2026-05-05T23:45:36.290Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56307,7 +56307,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.546Z",
+          "evaluatedAt": "2026-05-05T23:45:36.290Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56371,7 +56371,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.549Z",
+        "evaluatedAt": "2026-05-05T23:45:36.292Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56426,7 +56426,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.549Z",
+          "evaluatedAt": "2026-05-05T23:45:36.293Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56444,7 +56444,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.549Z",
+          "evaluatedAt": "2026-05-05T23:45:36.293Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56508,7 +56508,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.551Z",
+        "evaluatedAt": "2026-05-05T23:45:36.294Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56563,7 +56563,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.551Z",
+          "evaluatedAt": "2026-05-05T23:45:36.294Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56581,7 +56581,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.551Z",
+          "evaluatedAt": "2026-05-05T23:45:36.294Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56645,7 +56645,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.553Z",
+        "evaluatedAt": "2026-05-05T23:45:36.296Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56700,7 +56700,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.553Z",
+          "evaluatedAt": "2026-05-05T23:45:36.296Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56718,7 +56718,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.553Z",
+          "evaluatedAt": "2026-05-05T23:45:36.296Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56782,7 +56782,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.555Z",
+        "evaluatedAt": "2026-05-05T23:45:36.298Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56837,7 +56837,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.555Z",
+          "evaluatedAt": "2026-05-05T23:45:36.298Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56855,7 +56855,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.555Z",
+          "evaluatedAt": "2026-05-05T23:45:36.298Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56919,7 +56919,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.556Z",
+        "evaluatedAt": "2026-05-05T23:45:36.300Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56974,7 +56974,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.556Z",
+          "evaluatedAt": "2026-05-05T23:45:36.300Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56992,7 +56992,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.556Z",
+          "evaluatedAt": "2026-05-05T23:45:36.300Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57056,7 +57056,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.558Z",
+        "evaluatedAt": "2026-05-05T23:45:36.301Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57111,7 +57111,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.558Z",
+          "evaluatedAt": "2026-05-05T23:45:36.301Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57129,7 +57129,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.558Z",
+          "evaluatedAt": "2026-05-05T23:45:36.301Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57193,7 +57193,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.559Z",
+        "evaluatedAt": "2026-05-05T23:45:36.303Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57248,7 +57248,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.559Z",
+          "evaluatedAt": "2026-05-05T23:45:36.303Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57266,7 +57266,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.559Z",
+          "evaluatedAt": "2026-05-05T23:45:36.303Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57330,7 +57330,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.561Z",
+        "evaluatedAt": "2026-05-05T23:45:36.304Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57385,7 +57385,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.561Z",
+          "evaluatedAt": "2026-05-05T23:45:36.304Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57403,7 +57403,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.561Z",
+          "evaluatedAt": "2026-05-05T23:45:36.304Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57467,7 +57467,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.563Z",
+        "evaluatedAt": "2026-05-05T23:45:36.306Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57522,7 +57522,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.563Z",
+          "evaluatedAt": "2026-05-05T23:45:36.306Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57540,7 +57540,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.563Z",
+          "evaluatedAt": "2026-05-05T23:45:36.306Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57604,7 +57604,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.565Z",
+        "evaluatedAt": "2026-05-05T23:45:36.308Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57659,7 +57659,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.565Z",
+          "evaluatedAt": "2026-05-05T23:45:36.308Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57677,7 +57677,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.565Z",
+          "evaluatedAt": "2026-05-05T23:45:36.308Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57741,7 +57741,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.567Z",
+        "evaluatedAt": "2026-05-05T23:45:36.309Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57796,7 +57796,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.567Z",
+          "evaluatedAt": "2026-05-05T23:45:36.309Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57814,7 +57814,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.567Z",
+          "evaluatedAt": "2026-05-05T23:45:36.309Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57878,7 +57878,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.568Z",
+        "evaluatedAt": "2026-05-05T23:45:36.310Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57933,7 +57933,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.568Z",
+          "evaluatedAt": "2026-05-05T23:45:36.311Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57951,7 +57951,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.568Z",
+          "evaluatedAt": "2026-05-05T23:45:36.311Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58015,7 +58015,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.570Z",
+        "evaluatedAt": "2026-05-05T23:45:36.312Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58070,7 +58070,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.570Z",
+          "evaluatedAt": "2026-05-05T23:45:36.312Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58088,7 +58088,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.570Z",
+          "evaluatedAt": "2026-05-05T23:45:36.312Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58152,7 +58152,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.572Z",
+        "evaluatedAt": "2026-05-05T23:45:36.314Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58207,7 +58207,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.572Z",
+          "evaluatedAt": "2026-05-05T23:45:36.314Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58225,7 +58225,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.572Z",
+          "evaluatedAt": "2026-05-05T23:45:36.314Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58289,7 +58289,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.573Z",
+        "evaluatedAt": "2026-05-05T23:45:36.316Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58344,7 +58344,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.574Z",
+          "evaluatedAt": "2026-05-05T23:45:36.316Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58362,7 +58362,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.574Z",
+          "evaluatedAt": "2026-05-05T23:45:36.316Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58426,7 +58426,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.575Z",
+        "evaluatedAt": "2026-05-05T23:45:36.317Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58481,7 +58481,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.575Z",
+          "evaluatedAt": "2026-05-05T23:45:36.317Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58499,7 +58499,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.575Z",
+          "evaluatedAt": "2026-05-05T23:45:36.317Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58563,7 +58563,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.577Z",
+        "evaluatedAt": "2026-05-05T23:45:36.319Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58618,7 +58618,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.577Z",
+          "evaluatedAt": "2026-05-05T23:45:36.319Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58636,7 +58636,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.577Z",
+          "evaluatedAt": "2026-05-05T23:45:36.319Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58700,7 +58700,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.579Z",
+        "evaluatedAt": "2026-05-05T23:45:36.321Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58755,7 +58755,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.579Z",
+          "evaluatedAt": "2026-05-05T23:45:36.321Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58773,7 +58773,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.579Z",
+          "evaluatedAt": "2026-05-05T23:45:36.321Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58837,7 +58837,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.580Z",
+        "evaluatedAt": "2026-05-05T23:45:36.322Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58892,7 +58892,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.580Z",
+          "evaluatedAt": "2026-05-05T23:45:36.322Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58910,7 +58910,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.580Z",
+          "evaluatedAt": "2026-05-05T23:45:36.322Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58974,7 +58974,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.581Z",
+        "evaluatedAt": "2026-05-05T23:45:36.323Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59029,7 +59029,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.581Z",
+          "evaluatedAt": "2026-05-05T23:45:36.323Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59047,7 +59047,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.581Z",
+          "evaluatedAt": "2026-05-05T23:45:36.323Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59111,7 +59111,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.583Z",
+        "evaluatedAt": "2026-05-05T23:45:36.325Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59166,7 +59166,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.583Z",
+          "evaluatedAt": "2026-05-05T23:45:36.325Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59184,7 +59184,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.583Z",
+          "evaluatedAt": "2026-05-05T23:45:36.325Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59248,7 +59248,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.584Z",
+        "evaluatedAt": "2026-05-05T23:45:36.326Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59303,7 +59303,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.585Z",
+          "evaluatedAt": "2026-05-05T23:45:36.326Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59321,7 +59321,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.585Z",
+          "evaluatedAt": "2026-05-05T23:45:36.326Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59385,7 +59385,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.586Z",
+        "evaluatedAt": "2026-05-05T23:45:36.327Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59440,7 +59440,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.586Z",
+          "evaluatedAt": "2026-05-05T23:45:36.327Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59458,7 +59458,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.586Z",
+          "evaluatedAt": "2026-05-05T23:45:36.327Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59522,7 +59522,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.587Z",
+        "evaluatedAt": "2026-05-05T23:45:36.329Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59577,7 +59577,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.587Z",
+          "evaluatedAt": "2026-05-05T23:45:36.329Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59595,7 +59595,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.587Z",
+          "evaluatedAt": "2026-05-05T23:45:36.329Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59659,7 +59659,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.588Z",
+        "evaluatedAt": "2026-05-05T23:45:36.330Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59714,7 +59714,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.588Z",
+          "evaluatedAt": "2026-05-05T23:45:36.330Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59732,7 +59732,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.588Z",
+          "evaluatedAt": "2026-05-05T23:45:36.330Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59796,7 +59796,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.590Z",
+        "evaluatedAt": "2026-05-05T23:45:36.331Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59851,7 +59851,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.590Z",
+          "evaluatedAt": "2026-05-05T23:45:36.332Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59869,7 +59869,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.590Z",
+          "evaluatedAt": "2026-05-05T23:45:36.332Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59933,7 +59933,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.591Z",
+        "evaluatedAt": "2026-05-05T23:45:36.334Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59988,7 +59988,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.592Z",
+          "evaluatedAt": "2026-05-05T23:45:36.334Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60006,7 +60006,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.592Z",
+          "evaluatedAt": "2026-05-05T23:45:36.334Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60070,7 +60070,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:23.592Z",
+        "evaluatedAt": "2026-05-05T23:45:36.335Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60125,7 +60125,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.593Z",
+          "evaluatedAt": "2026-05-05T23:45:36.335Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60143,7 +60143,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:23.593Z",
+          "evaluatedAt": "2026-05-05T23:45:36.335Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/Galaxy-Dawn_claude-scholar.json
+++ b/data/skill-index/Galaxy-Dawn_claude-scholar.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Galaxy-Dawn/claude-scholar.git",
   "owner": "Galaxy-Dawn",
   "repo": "claude-scholar",
-  "updatedAt": "2026-04-30T23:05:18.506Z",
+  "updatedAt": "2026-05-05T23:45:31.312Z",
   "skillCount": 39,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.448Z",
+        "evaluatedAt": "2026-05-05T23:45:31.250Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.448Z",
+          "evaluatedAt": "2026-05-05T23:45:31.250Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.448Z",
+          "evaluatedAt": "2026-05-05T23:45:31.250Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.449Z",
+        "evaluatedAt": "2026-05-05T23:45:31.252Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.450Z",
+          "evaluatedAt": "2026-05-05T23:45:31.252Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.450Z",
+          "evaluatedAt": "2026-05-05T23:45:31.252Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.451Z",
+        "evaluatedAt": "2026-05-05T23:45:31.254Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.451Z",
+          "evaluatedAt": "2026-05-05T23:45:31.254Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.451Z",
+          "evaluatedAt": "2026-05-05T23:45:31.254Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.453Z",
+        "evaluatedAt": "2026-05-05T23:45:31.256Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.453Z",
+          "evaluatedAt": "2026-05-05T23:45:31.256Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.453Z",
+          "evaluatedAt": "2026-05-05T23:45:31.256Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.454Z",
+        "evaluatedAt": "2026-05-05T23:45:31.257Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.454Z",
+          "evaluatedAt": "2026-05-05T23:45:31.257Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.454Z",
+          "evaluatedAt": "2026-05-05T23:45:31.257Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.457Z",
+        "evaluatedAt": "2026-05-05T23:45:31.260Z",
         "evaluatedVersion": "0.2.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.457Z",
+          "evaluatedAt": "2026-05-05T23:45:31.260Z",
           "evaluatedVersion": "0.2.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.457Z",
+          "evaluatedAt": "2026-05-05T23:45:31.260Z",
           "evaluatedVersion": "0.2.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.459Z",
+        "evaluatedAt": "2026-05-05T23:45:31.262Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.459Z",
+          "evaluatedAt": "2026-05-05T23:45:31.262Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.459Z",
+          "evaluatedAt": "2026-05-05T23:45:31.262Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.459Z",
+        "evaluatedAt": "2026-05-05T23:45:31.263Z",
         "evaluatedVersion": "0.5.1"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.459Z",
+          "evaluatedAt": "2026-05-05T23:45:31.263Z",
           "evaluatedVersion": "0.5.1"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.459Z",
+          "evaluatedAt": "2026-05-05T23:45:31.263Z",
           "evaluatedVersion": "0.5.1"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.460Z",
+        "evaluatedAt": "2026-05-05T23:45:31.264Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.460Z",
+          "evaluatedAt": "2026-05-05T23:45:31.264Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.460Z",
+          "evaluatedAt": "2026-05-05T23:45:31.264Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.461Z",
+        "evaluatedAt": "2026-05-05T23:45:31.265Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.462Z",
+          "evaluatedAt": "2026-05-05T23:45:31.265Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.462Z",
+          "evaluatedAt": "2026-05-05T23:45:31.265Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.463Z",
+        "evaluatedAt": "2026-05-05T23:45:31.267Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.463Z",
+          "evaluatedAt": "2026-05-05T23:45:31.267Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.463Z",
+          "evaluatedAt": "2026-05-05T23:45:31.267Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.464Z",
+        "evaluatedAt": "2026-05-05T23:45:31.268Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.464Z",
+          "evaluatedAt": "2026-05-05T23:45:31.268Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.464Z",
+          "evaluatedAt": "2026-05-05T23:45:31.268Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.467Z",
+        "evaluatedAt": "2026-05-05T23:45:31.270Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.467Z",
+          "evaluatedAt": "2026-05-05T23:45:31.270Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.467Z",
+          "evaluatedAt": "2026-05-05T23:45:31.270Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.468Z",
+        "evaluatedAt": "2026-05-05T23:45:31.272Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.468Z",
+          "evaluatedAt": "2026-05-05T23:45:31.272Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.468Z",
+          "evaluatedAt": "2026-05-05T23:45:31.272Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.470Z",
+        "evaluatedAt": "2026-05-05T23:45:31.274Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.470Z",
+          "evaluatedAt": "2026-05-05T23:45:31.274Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.470Z",
+          "evaluatedAt": "2026-05-05T23:45:31.274Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.472Z",
+        "evaluatedAt": "2026-05-05T23:45:31.276Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.472Z",
+          "evaluatedAt": "2026-05-05T23:45:31.276Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.472Z",
+          "evaluatedAt": "2026-05-05T23:45:31.276Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.476Z",
+        "evaluatedAt": "2026-05-05T23:45:31.280Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.476Z",
+          "evaluatedAt": "2026-05-05T23:45:31.280Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.476Z",
+          "evaluatedAt": "2026-05-05T23:45:31.280Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.479Z",
+        "evaluatedAt": "2026-05-05T23:45:31.283Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.479Z",
+          "evaluatedAt": "2026-05-05T23:45:31.283Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.479Z",
+          "evaluatedAt": "2026-05-05T23:45:31.283Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.480Z",
+        "evaluatedAt": "2026-05-05T23:45:31.284Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.480Z",
+          "evaluatedAt": "2026-05-05T23:45:31.284Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.480Z",
+          "evaluatedAt": "2026-05-05T23:45:31.284Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.480Z",
+        "evaluatedAt": "2026-05-05T23:45:31.284Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.480Z",
+          "evaluatedAt": "2026-05-05T23:45:31.284Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.480Z",
+          "evaluatedAt": "2026-05-05T23:45:31.284Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.481Z",
+        "evaluatedAt": "2026-05-05T23:45:31.285Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.481Z",
+          "evaluatedAt": "2026-05-05T23:45:31.285Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.481Z",
+          "evaluatedAt": "2026-05-05T23:45:31.285Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.481Z",
+        "evaluatedAt": "2026-05-05T23:45:31.286Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.482Z",
+          "evaluatedAt": "2026-05-05T23:45:31.286Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.482Z",
+          "evaluatedAt": "2026-05-05T23:45:31.286Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -3078,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.483Z",
+        "evaluatedAt": "2026-05-05T23:45:31.287Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -3133,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.483Z",
+          "evaluatedAt": "2026-05-05T23:45:31.287Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3151,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.483Z",
+          "evaluatedAt": "2026-05-05T23:45:31.287Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -3215,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.485Z",
+        "evaluatedAt": "2026-05-05T23:45:31.289Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -3270,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.485Z",
+          "evaluatedAt": "2026-05-05T23:45:31.289Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -3288,7 +3288,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.485Z",
+          "evaluatedAt": "2026-05-05T23:45:31.289Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -3352,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.486Z",
+        "evaluatedAt": "2026-05-05T23:45:31.291Z",
         "evaluatedVersion": "0.2.0"
       },
       "evalSummaries": {
@@ -3407,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.486Z",
+          "evaluatedAt": "2026-05-05T23:45:31.291Z",
           "evaluatedVersion": "0.2.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3425,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.486Z",
+          "evaluatedAt": "2026-05-05T23:45:31.291Z",
           "evaluatedVersion": "0.2.0"
         }
       }
@@ -3489,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.488Z",
+        "evaluatedAt": "2026-05-05T23:45:31.293Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -3544,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.488Z",
+          "evaluatedAt": "2026-05-05T23:45:31.293Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -3562,7 +3562,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.488Z",
+          "evaluatedAt": "2026-05-05T23:45:31.293Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -3626,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.490Z",
+        "evaluatedAt": "2026-05-05T23:45:31.295Z",
         "evaluatedVersion": "0.2.0"
       },
       "evalSummaries": {
@@ -3681,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.490Z",
+          "evaluatedAt": "2026-05-05T23:45:31.295Z",
           "evaluatedVersion": "0.2.0"
         },
         "skill-best-practice": {
@@ -3699,7 +3699,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.490Z",
+          "evaluatedAt": "2026-05-05T23:45:31.295Z",
           "evaluatedVersion": "0.2.0"
         }
       }
@@ -3763,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.491Z",
+        "evaluatedAt": "2026-05-05T23:45:31.296Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -3818,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.491Z",
+          "evaluatedAt": "2026-05-05T23:45:31.296Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3836,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.491Z",
+          "evaluatedAt": "2026-05-05T23:45:31.296Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -3900,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.492Z",
+        "evaluatedAt": "2026-05-05T23:45:31.297Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -3955,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.492Z",
+          "evaluatedAt": "2026-05-05T23:45:31.297Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -3973,7 +3973,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.492Z",
+          "evaluatedAt": "2026-05-05T23:45:31.297Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -4037,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.493Z",
+        "evaluatedAt": "2026-05-05T23:45:31.299Z",
         "evaluatedVersion": "0.2.0"
       },
       "evalSummaries": {
@@ -4092,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.493Z",
+          "evaluatedAt": "2026-05-05T23:45:31.299Z",
           "evaluatedVersion": "0.2.0"
         },
         "skill-best-practice": {
@@ -4110,7 +4110,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.493Z",
+          "evaluatedAt": "2026-05-05T23:45:31.299Z",
           "evaluatedVersion": "0.2.0"
         }
       }
@@ -4174,7 +4174,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.494Z",
+        "evaluatedAt": "2026-05-05T23:45:31.300Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -4229,7 +4229,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.494Z",
+          "evaluatedAt": "2026-05-05T23:45:31.300Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -4247,7 +4247,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.494Z",
+          "evaluatedAt": "2026-05-05T23:45:31.300Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -4311,7 +4311,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.496Z",
+        "evaluatedAt": "2026-05-05T23:45:31.302Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -4366,7 +4366,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.496Z",
+          "evaluatedAt": "2026-05-05T23:45:31.302Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -4384,7 +4384,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.496Z",
+          "evaluatedAt": "2026-05-05T23:45:31.302Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -4448,7 +4448,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.497Z",
+        "evaluatedAt": "2026-05-05T23:45:31.303Z",
         "evaluatedVersion": "0.2.0"
       },
       "evalSummaries": {
@@ -4503,7 +4503,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.497Z",
+          "evaluatedAt": "2026-05-05T23:45:31.303Z",
           "evaluatedVersion": "0.2.0"
         },
         "skill-best-practice": {
@@ -4521,7 +4521,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.497Z",
+          "evaluatedAt": "2026-05-05T23:45:31.303Z",
           "evaluatedVersion": "0.2.0"
         }
       }
@@ -4585,7 +4585,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.499Z",
+        "evaluatedAt": "2026-05-05T23:45:31.305Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -4640,7 +4640,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.499Z",
+          "evaluatedAt": "2026-05-05T23:45:31.305Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -4658,7 +4658,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.499Z",
+          "evaluatedAt": "2026-05-05T23:45:31.305Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -4722,7 +4722,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.501Z",
+        "evaluatedAt": "2026-05-05T23:45:31.307Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -4777,7 +4777,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.501Z",
+          "evaluatedAt": "2026-05-05T23:45:31.307Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -4795,7 +4795,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.501Z",
+          "evaluatedAt": "2026-05-05T23:45:31.307Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -4859,7 +4859,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.502Z",
+        "evaluatedAt": "2026-05-05T23:45:31.308Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -4914,7 +4914,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.502Z",
+          "evaluatedAt": "2026-05-05T23:45:31.308Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -4932,7 +4932,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.502Z",
+          "evaluatedAt": "2026-05-05T23:45:31.308Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -4996,7 +4996,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.503Z",
+        "evaluatedAt": "2026-05-05T23:45:31.309Z",
         "evaluatedVersion": "0.1.0"
       },
       "evalSummaries": {
@@ -5051,7 +5051,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.503Z",
+          "evaluatedAt": "2026-05-05T23:45:31.309Z",
           "evaluatedVersion": "0.1.0"
         },
         "skill-best-practice": {
@@ -5069,7 +5069,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.503Z",
+          "evaluatedAt": "2026-05-05T23:45:31.309Z",
           "evaluatedVersion": "0.1.0"
         }
       }
@@ -5133,7 +5133,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.505Z",
+        "evaluatedAt": "2026-05-05T23:45:31.310Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -5188,7 +5188,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.505Z",
+          "evaluatedAt": "2026-05-05T23:45:31.310Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -5206,7 +5206,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.505Z",
+          "evaluatedAt": "2026-05-05T23:45:31.310Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -5270,7 +5270,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:18.506Z",
+        "evaluatedAt": "2026-05-05T23:45:31.311Z",
         "evaluatedVersion": "0.3.0"
       },
       "evalSummaries": {
@@ -5325,7 +5325,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.506Z",
+          "evaluatedAt": "2026-05-05T23:45:31.311Z",
           "evaluatedVersion": "0.3.0"
         },
         "skill-best-practice": {
@@ -5343,7 +5343,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:18.506Z",
+          "evaluatedAt": "2026-05-05T23:45:31.311Z",
           "evaluatedVersion": "0.3.0"
         }
       }

--- a/data/skill-index/Imbad0202_academic-research-skills.json
+++ b/data/skill-index/Imbad0202_academic-research-skills.json
@@ -2,8 +2,8 @@
   "repoUrl": "https://github.com/Imbad0202/academic-research-skills.git",
   "owner": "Imbad0202",
   "repo": "academic-research-skills",
-  "updatedAt": "2026-04-30T23:05:33.834Z",
-  "skillCount": 4,
+  "updatedAt": "2026-05-05T23:45:47.088Z",
+  "skillCount": 8,
   "skills": [
     {
       "name": "academic-paper",
@@ -16,9 +16,9 @@
       "installUrl": "github:Imbad0202/academic-research-skills:academic-paper",
       "relPath": "academic-paper",
       "verified": true,
-      "tokenCount": 5095,
+      "tokenCount": 8429,
       "evalSummary": {
-        "overallScore": 70,
+        "overallScore": 69,
         "grade": "C",
         "categories": [
           {
@@ -36,13 +36,13 @@
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 7,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
@@ -54,7 +54,7 @@
           {
             "id": "testability",
             "name": "Testability",
-            "score": 5,
+            "score": 7,
             "max": 10
           },
           {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:33.821Z",
+        "evaluatedAt": "2026-05-05T23:45:47.057Z",
         "evaluatedVersion": "3.1.1"
       },
       "evalSummaries": {
@@ -73,7 +73,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 70,
+          "overallScore": 69,
           "grade": "C",
           "categories": [
             {
@@ -91,13 +91,13 @@
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 7,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
@@ -109,7 +109,7 @@
             {
               "id": "testability",
               "name": "Testability",
-              "score": 5,
+              "score": 7,
               "max": 10
             },
             {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:33.821Z",
+          "evaluatedAt": "2026-05-05T23:45:47.057Z",
           "evaluatedVersion": "3.1.1"
         },
         "skill-best-practice": {
@@ -137,7 +137,144 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:33.821Z",
+          "evaluatedAt": "2026-05-05T23:45:47.057Z",
+          "evaluatedVersion": "3.1.1"
+        }
+      }
+    },
+    {
+      "name": "academic-paper",
+      "description": "12-agent academic paper writing pipeline. 10 modes (full/plan/outline/revision/revision-coach/abstract/lit-review/format-convert/citation-check/disclosure). 6 paper types, 5 citation formats, bilingual abstracts, LaTeX/DOCX-via-Pandoc/PDF output. Style Calibration + Writing Quality Check + Anti-Patterns with IRON RULE markers. Triggers: write paper, academic paper, guide my paper, parse reviews, AI disclosure, 寫論文, 學術論文, 引導我寫論文, 審查意見.",
+      "version": "3.1.1",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper",
+      "relPath": "skills/academic-paper",
+      "verified": true,
+      "tokenCount": 8429,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:47.061Z",
+        "evaluatedVersion": "3.1.1"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:47.061Z",
+          "evaluatedVersion": "3.1.1"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 11,
+              "max": 14
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:47.061Z",
           "evaluatedVersion": "3.1.1"
         }
       }
@@ -201,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:33.824Z",
+        "evaluatedAt": "2026-05-05T23:45:47.065Z",
         "evaluatedVersion": "1.9.0"
       },
       "evalSummaries": {
@@ -256,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:33.824Z",
+          "evaluatedAt": "2026-05-05T23:45:47.066Z",
           "evaluatedVersion": "1.9.0"
         },
         "skill-best-practice": {
@@ -274,7 +411,144 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:33.824Z",
+          "evaluatedAt": "2026-05-05T23:45:47.066Z",
+          "evaluatedVersion": "1.9.0"
+        }
+      }
+    },
+    {
+      "name": "academic-paper-reviewer",
+      "description": "Multi-perspective academic paper review with dynamic reviewer personas. Simulates 5 independent reviewers (EIC + 3 peer reviewers + Devil's Advocate) with field-specific expertise. Supports full review, re-review (verification), quick assessment, methodology focus, Socratic guided, and calibration modes. Triggers on: review paper, peer review, manuscript review, referee report, review my paper, critique paper, simulate review, editorial review, calibrate reviewer, reviewer calibration, measure reviewer accuracy.",
+      "version": "1.9.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-paper-reviewer",
+      "relPath": "skills/academic-paper-reviewer",
+      "verified": true,
+      "tokenCount": 5989,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:47.069Z",
+        "evaluatedVersion": "1.9.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 64,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:47.070Z",
+          "evaluatedVersion": "1.9.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 11,
+              "max": 14
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:47.070Z",
           "evaluatedVersion": "1.9.0"
         }
       }
@@ -282,7 +556,7 @@
     {
       "name": "academic-pipeline",
       "description": "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow.",
-      "version": "3.6.7",
+      "version": "3.7.0",
       "license": "",
       "creator": "",
       "compatibility": "",
@@ -338,8 +612,8 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:33.828Z",
-        "evaluatedVersion": "3.6.7"
+        "evaluatedAt": "2026-05-05T23:45:47.074Z",
+        "evaluatedVersion": "3.7.0"
       },
       "evalSummaries": {
         "quality": {
@@ -393,8 +667,8 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:33.828Z",
-          "evaluatedVersion": "3.6.7"
+          "evaluatedAt": "2026-05-05T23:45:47.074Z",
+          "evaluatedVersion": "3.7.0"
         },
         "skill-best-practice": {
           "providerId": "skill-best-practice",
@@ -411,8 +685,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:33.828Z",
-          "evaluatedVersion": "3.6.7"
+          "evaluatedAt": "2026-05-05T23:45:47.074Z",
+          "evaluatedVersion": "3.7.0"
+        }
+      }
+    },
+    {
+      "name": "academic-pipeline",
+      "description": "Orchestrator for the full academic research pipeline: research -> write -> integrity check -> review -> revise -> re-review -> re-revise -> final integrity check -> finalize. Coordinates deep-research, academic-paper, and academic-paper-reviewer into a seamless 10-stage workflow with mandatory integrity verification, two-stage peer review, and reproducible quality gates. Triggers on: academic pipeline, research to paper, full paper workflow, paper pipeline, end-to-end paper, research-to-publication, complete paper workflow.",
+      "version": "3.7.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:Imbad0202/academic-research-skills:skills/academic-pipeline",
+      "relPath": "skills/academic-pipeline",
+      "verified": true,
+      "tokenCount": 8877,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:47.079Z",
+        "evaluatedVersion": "3.7.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 74,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:47.079Z",
+          "evaluatedVersion": "3.7.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 71,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 14
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:47.079Z",
+          "evaluatedVersion": "3.7.0"
         }
       }
     },
@@ -475,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:33.832Z",
+        "evaluatedAt": "2026-05-05T23:45:47.083Z",
         "evaluatedVersion": "2.9.3"
       },
       "evalSummaries": {
@@ -530,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:33.832Z",
+          "evaluatedAt": "2026-05-05T23:45:47.083Z",
           "evaluatedVersion": "2.9.3"
         },
         "skill-best-practice": {
@@ -548,7 +959,144 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:33.832Z",
+          "evaluatedAt": "2026-05-05T23:45:47.083Z",
+          "evaluatedVersion": "2.9.3"
+        }
+      }
+    },
+    {
+      "name": "deep-research",
+      "description": "Universal deep research agent team. 13-agent pipeline for rigorous academic research on any topic. 7 modes: full research, quick brief, paper review, lit-review, fact-check, Socratic guided research dialogue, and systematic review with optional meta-analysis. Covers research question formulation, Socratic mentoring, methodology design, systematic literature search, source verification, cross-source synthesis, risk of bias assessment, meta-analysis, APA 7.0 report compilation, editorial review, devil's advocate challenges, ethics review, and post-research literature monitoring. Triggers on: research, deep research, literature review, systematic review, meta-analysis, PRISMA, evidence synthesis, fact-check, guide my research, help me think through, 研究, 深度研究, 文獻回顧, 文獻探討, 系統性回顧, 後設分析, 事實查核, 引導我的研究, 幫我釐清, 幫我想想, 我不確定要研究什麼, 研究方向, 研究主題.",
+      "version": "2.9.3",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:Imbad0202/academic-research-skills:skills/deep-research",
+      "relPath": "skills/deep-research",
+      "verified": true,
+      "tokenCount": 7111,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:47.086Z",
+        "evaluatedVersion": "2.9.3"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 67,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:47.086Z",
+          "evaluatedVersion": "2.9.3"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 11,
+              "max": 14
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:47.087Z",
           "evaluatedVersion": "2.9.3"
         }
       }

--- a/data/skill-index/K-Dense-AI_claude-scientific-skills.json
+++ b/data/skill-index/K-Dense-AI_claude-scientific-skills.json
@@ -2,8 +2,8 @@
   "repoUrl": "https://github.com/K-Dense-AI/claude-scientific-skills.git",
   "owner": "K-Dense-AI",
   "repo": "claude-scientific-skills",
-  "updatedAt": "2026-04-30T23:05:26.106Z",
-  "skillCount": 134,
+  "updatedAt": "2026-05-05T23:45:38.840Z",
+  "skillCount": 136,
   "skills": [
     {
       "name": "adaptyv",
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.771Z",
+        "evaluatedAt": "2026-05-05T23:45:38.474Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.771Z",
+          "evaluatedAt": "2026-05-05T23:45:38.474Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.771Z",
+          "evaluatedAt": "2026-05-05T23:45:38.474Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.773Z",
+        "evaluatedAt": "2026-05-05T23:45:38.476Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.773Z",
+          "evaluatedAt": "2026-05-05T23:45:38.476Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.773Z",
+          "evaluatedAt": "2026-05-05T23:45:38.476Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.775Z",
+        "evaluatedAt": "2026-05-05T23:45:38.478Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.775Z",
+          "evaluatedAt": "2026-05-05T23:45:38.478Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.775Z",
+          "evaluatedAt": "2026-05-05T23:45:38.478Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.776Z",
+        "evaluatedAt": "2026-05-05T23:45:38.480Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.776Z",
+          "evaluatedAt": "2026-05-05T23:45:38.480Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.776Z",
+          "evaluatedAt": "2026-05-05T23:45:38.480Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.778Z",
+        "evaluatedAt": "2026-05-05T23:45:38.482Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.778Z",
+          "evaluatedAt": "2026-05-05T23:45:38.482Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.778Z",
+          "evaluatedAt": "2026-05-05T23:45:38.482Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "autoskill",
+      "description": "Observe the user's screen via screenpipe, detect repeated research workflows, match them against existing scientific-agent-skills, and draft new skills (or composition recipes that chain existing ones) for the patterns not yet covered. Use when the user asks to analyze their recent work and propose skills based on what they actually do. Requires the screenpipe daemon (https://github.com/screenpipe/screenpipe) running locally on port 3030 — the skill has no other data source and will refuse to run if screenpipe is unreachable. All detection runs locally; only redacted cluster summaries reach the LLM.",
+      "version": "0.0.0",
+      "license": "MIT license",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": ["Read", "Write", "Edit", "Bash"],
+      "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/autoskill",
+      "relPath": "scientific-skills/autoskill",
+      "verified": true,
+      "tokenCount": 2987,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:38.484Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:38.484Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:38.484Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.780Z",
+        "evaluatedAt": "2026-05-05T23:45:38.486Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.780Z",
+          "evaluatedAt": "2026-05-05T23:45:38.486Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +959,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.780Z",
+          "evaluatedAt": "2026-05-05T23:45:38.486Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.782Z",
+        "evaluatedAt": "2026-05-05T23:45:38.488Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.782Z",
+          "evaluatedAt": "2026-05-05T23:45:38.488Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.782Z",
+          "evaluatedAt": "2026-05-05T23:45:38.488Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.784Z",
+        "evaluatedAt": "2026-05-05T23:45:38.489Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.784Z",
+          "evaluatedAt": "2026-05-05T23:45:38.489Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.784Z",
+          "evaluatedAt": "2026-05-05T23:45:38.489Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.788Z",
+        "evaluatedAt": "2026-05-05T23:45:38.491Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.788Z",
+          "evaluatedAt": "2026-05-05T23:45:38.491Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.788Z",
+          "evaluatedAt": "2026-05-05T23:45:38.491Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.790Z",
+        "evaluatedAt": "2026-05-05T23:45:38.494Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.790Z",
+          "evaluatedAt": "2026-05-05T23:45:38.494Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.790Z",
+          "evaluatedAt": "2026-05-05T23:45:38.494Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.793Z",
+        "evaluatedAt": "2026-05-05T23:45:38.496Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.793Z",
+          "evaluatedAt": "2026-05-05T23:45:38.496Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.793Z",
+          "evaluatedAt": "2026-05-05T23:45:38.496Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.796Z",
+        "evaluatedAt": "2026-05-05T23:45:38.500Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.796Z",
+          "evaluatedAt": "2026-05-05T23:45:38.500Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.796Z",
+          "evaluatedAt": "2026-05-05T23:45:38.500Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1708,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.801Z",
+        "evaluatedAt": "2026-05-05T23:45:38.506Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.801Z",
+          "evaluatedAt": "2026-05-05T23:45:38.508Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.801Z",
+          "evaluatedAt": "2026-05-05T23:45:38.507Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.805Z",
+        "evaluatedAt": "2026-05-05T23:45:38.513Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.805Z",
+          "evaluatedAt": "2026-05-05T23:45:38.513Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.805Z",
+          "evaluatedAt": "2026-05-05T23:45:38.513Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1982,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.809Z",
+        "evaluatedAt": "2026-05-05T23:45:38.516Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.809Z",
+          "evaluatedAt": "2026-05-05T23:45:38.516Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.809Z",
+          "evaluatedAt": "2026-05-05T23:45:38.517Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2119,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.811Z",
+        "evaluatedAt": "2026-05-05T23:45:38.519Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.811Z",
+          "evaluatedAt": "2026-05-05T23:45:38.519Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.811Z",
+          "evaluatedAt": "2026-05-05T23:45:38.519Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2256,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.813Z",
+        "evaluatedAt": "2026-05-05T23:45:38.521Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.813Z",
+          "evaluatedAt": "2026-05-05T23:45:38.521Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2466,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.813Z",
+          "evaluatedAt": "2026-05-05T23:45:38.521Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2393,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.816Z",
+        "evaluatedAt": "2026-05-05T23:45:38.525Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.816Z",
+          "evaluatedAt": "2026-05-05T23:45:38.525Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2603,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.816Z",
+          "evaluatedAt": "2026-05-05T23:45:38.525Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2530,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.819Z",
+        "evaluatedAt": "2026-05-05T23:45:38.529Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.820Z",
+          "evaluatedAt": "2026-05-05T23:45:38.529Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2740,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.820Z",
+          "evaluatedAt": "2026-05-05T23:45:38.529Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2667,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.822Z",
+        "evaluatedAt": "2026-05-05T23:45:38.532Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.822Z",
+          "evaluatedAt": "2026-05-05T23:45:38.532Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2877,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.822Z",
+          "evaluatedAt": "2026-05-05T23:45:38.532Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2804,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.825Z",
+        "evaluatedAt": "2026-05-05T23:45:38.535Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.825Z",
+          "evaluatedAt": "2026-05-05T23:45:38.535Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +3014,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.825Z",
+          "evaluatedAt": "2026-05-05T23:45:38.535Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2941,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.828Z",
+        "evaluatedAt": "2026-05-05T23:45:38.538Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2996,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.828Z",
+          "evaluatedAt": "2026-05-05T23:45:38.538Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3151,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.828Z",
+          "evaluatedAt": "2026-05-05T23:45:38.538Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3078,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.830Z",
+        "evaluatedAt": "2026-05-05T23:45:38.540Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3133,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.830Z",
+          "evaluatedAt": "2026-05-05T23:45:38.540Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3288,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.830Z",
+          "evaluatedAt": "2026-05-05T23:45:38.540Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3215,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.832Z",
+        "evaluatedAt": "2026-05-05T23:45:38.542Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3270,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.832Z",
+          "evaluatedAt": "2026-05-05T23:45:38.542Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3288,7 +3425,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.832Z",
+          "evaluatedAt": "2026-05-05T23:45:38.542Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3352,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.834Z",
+        "evaluatedAt": "2026-05-05T23:45:38.544Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3407,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.834Z",
+          "evaluatedAt": "2026-05-05T23:45:38.545Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3562,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.834Z",
+          "evaluatedAt": "2026-05-05T23:45:38.545Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3489,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.836Z",
+        "evaluatedAt": "2026-05-05T23:45:38.547Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3544,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.836Z",
+          "evaluatedAt": "2026-05-05T23:45:38.547Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3562,7 +3699,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.836Z",
+          "evaluatedAt": "2026-05-05T23:45:38.547Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3626,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.838Z",
+        "evaluatedAt": "2026-05-05T23:45:38.549Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3681,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.838Z",
+          "evaluatedAt": "2026-05-05T23:45:38.550Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3699,7 +3836,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.839Z",
+          "evaluatedAt": "2026-05-05T23:45:38.550Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3763,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.841Z",
+        "evaluatedAt": "2026-05-05T23:45:38.552Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3818,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.841Z",
+          "evaluatedAt": "2026-05-05T23:45:38.552Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3973,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.841Z",
+          "evaluatedAt": "2026-05-05T23:45:38.552Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3900,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.844Z",
+        "evaluatedAt": "2026-05-05T23:45:38.554Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3955,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.844Z",
+          "evaluatedAt": "2026-05-05T23:45:38.554Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3973,7 +4110,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.844Z",
+          "evaluatedAt": "2026-05-05T23:45:38.554Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4037,7 +4174,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.846Z",
+        "evaluatedAt": "2026-05-05T23:45:38.557Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4092,7 +4229,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.846Z",
+          "evaluatedAt": "2026-05-05T23:45:38.557Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4110,7 +4247,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.846Z",
+          "evaluatedAt": "2026-05-05T23:45:38.557Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4126,7 +4263,7 @@
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/fluidsim",
       "relPath": "scientific-skills/fluidsim",
       "verified": true,
-      "tokenCount": 1806,
+      "tokenCount": 1800,
       "evalSummary": {
         "overallScore": 71,
         "grade": "C",
@@ -4174,7 +4311,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.848Z",
+        "evaluatedAt": "2026-05-05T23:45:38.559Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4229,7 +4366,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.848Z",
+          "evaluatedAt": "2026-05-05T23:45:38.559Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4247,7 +4384,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.848Z",
+          "evaluatedAt": "2026-05-05T23:45:38.559Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4311,7 +4448,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.850Z",
+        "evaluatedAt": "2026-05-05T23:45:38.561Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4366,7 +4503,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.850Z",
+          "evaluatedAt": "2026-05-05T23:45:38.561Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4384,7 +4521,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.850Z",
+          "evaluatedAt": "2026-05-05T23:45:38.561Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4400,7 +4537,7 @@
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/geniml",
       "relPath": "scientific-skills/geniml",
       "verified": true,
-      "tokenCount": 2313,
+      "tokenCount": 2307,
       "evalSummary": {
         "overallScore": 73,
         "grade": "C",
@@ -4448,7 +4585,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.851Z",
+        "evaluatedAt": "2026-05-05T23:45:38.562Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4503,7 +4640,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.851Z",
+          "evaluatedAt": "2026-05-05T23:45:38.562Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4521,7 +4658,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.851Z",
+          "evaluatedAt": "2026-05-05T23:45:38.562Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4585,7 +4722,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.853Z",
+        "evaluatedAt": "2026-05-05T23:45:38.564Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4640,7 +4777,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.853Z",
+          "evaluatedAt": "2026-05-05T23:45:38.564Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4658,7 +4795,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.853Z",
+          "evaluatedAt": "2026-05-05T23:45:38.565Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4722,7 +4859,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.855Z",
+        "evaluatedAt": "2026-05-05T23:45:38.566Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4777,7 +4914,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.855Z",
+          "evaluatedAt": "2026-05-05T23:45:38.566Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4795,7 +4932,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.855Z",
+          "evaluatedAt": "2026-05-05T23:45:38.566Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4859,7 +4996,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.857Z",
+        "evaluatedAt": "2026-05-05T23:45:38.568Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4914,7 +5051,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.857Z",
+          "evaluatedAt": "2026-05-05T23:45:38.568Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4932,7 +5069,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.857Z",
+          "evaluatedAt": "2026-05-05T23:45:38.568Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4996,7 +5133,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.860Z",
+        "evaluatedAt": "2026-05-05T23:45:38.571Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5051,7 +5188,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.860Z",
+          "evaluatedAt": "2026-05-05T23:45:38.571Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5069,7 +5206,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.860Z",
+          "evaluatedAt": "2026-05-05T23:45:38.571Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5133,7 +5270,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.862Z",
+        "evaluatedAt": "2026-05-05T23:45:38.573Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5188,7 +5325,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.862Z",
+          "evaluatedAt": "2026-05-05T23:45:38.573Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5206,7 +5343,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.862Z",
+          "evaluatedAt": "2026-05-05T23:45:38.573Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5270,7 +5407,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.864Z",
+        "evaluatedAt": "2026-05-05T23:45:38.575Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5325,7 +5462,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.864Z",
+          "evaluatedAt": "2026-05-05T23:45:38.575Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5343,7 +5480,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.864Z",
+          "evaluatedAt": "2026-05-05T23:45:38.575Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5359,7 +5496,7 @@
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/gtars",
       "relPath": "scientific-skills/gtars",
       "verified": true,
-      "tokenCount": 1760,
+      "tokenCount": 1758,
       "evalSummary": {
         "overallScore": 74,
         "grade": "C",
@@ -5407,7 +5544,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.866Z",
+        "evaluatedAt": "2026-05-05T23:45:38.577Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5462,7 +5599,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.866Z",
+          "evaluatedAt": "2026-05-05T23:45:38.577Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5480,7 +5617,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.866Z",
+          "evaluatedAt": "2026-05-05T23:45:38.577Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5544,7 +5681,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.868Z",
+        "evaluatedAt": "2026-05-05T23:45:38.579Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5599,7 +5736,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.868Z",
+          "evaluatedAt": "2026-05-05T23:45:38.579Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5617,7 +5754,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.868Z",
+          "evaluatedAt": "2026-05-05T23:45:38.579Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "hugging-science",
+      "description": "Use when the user is doing AI/ML work in a scientific domain — biology, chemistry, physics, astronomy, climate, genomics, materials science, medicine, ecology, energy, conservation, engineering, mathematics, scientific reasoning, drug discovery, protein design, weather modeling, theorem proving, single-cell, PDE solving, or anything similar. Hugging Science (huggingscience.co) is a curated catalog of scientific datasets, models, blog posts, and interactive Spaces; the `hugging-science` org on Hugging Face hosts community datasets, models, and demo Spaces. This skill helps you discover the right resource AND actually use it — loading datasets via `datasets`, running models via `transformers` or the HF Inference API, calling Spaces like BoltzGen via `gradio_client`, and citing blog posts for methodology. Trigger this skill whenever a user mentions a scientific ML task, asks for \"a dataset/model for X\" where X is a scientific topic, wants to fine-tune on scientific data, asks about protein / molecule / genome / climate / materials / astronomy / pathology / weather ML, or needs AI tools for research — even if they never say \"Hugging Science\" explicitly. The catalog is purpose-built for LLM agents (it ships an `llms-full.txt`); prefer it over generic web search for these tasks.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/hugging-science",
+      "relPath": "scientific-skills/hugging-science",
+      "verified": true,
+      "tokenCount": 3005,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:38.581Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:38.581Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:38.581Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5681,7 +5955,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.871Z",
+        "evaluatedAt": "2026-05-05T23:45:38.584Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5736,7 +6010,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.871Z",
+          "evaluatedAt": "2026-05-05T23:45:38.584Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5754,7 +6028,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.871Z",
+          "evaluatedAt": "2026-05-05T23:45:38.584Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5818,7 +6092,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.874Z",
+        "evaluatedAt": "2026-05-05T23:45:38.587Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5873,7 +6147,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.874Z",
+          "evaluatedAt": "2026-05-05T23:45:38.587Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5891,7 +6165,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.874Z",
+          "evaluatedAt": "2026-05-05T23:45:38.587Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5955,7 +6229,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.878Z",
+        "evaluatedAt": "2026-05-05T23:45:38.591Z",
         "evaluatedVersion": "1.4.0"
       },
       "evalSummaries": {
@@ -6010,7 +6284,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.878Z",
+          "evaluatedAt": "2026-05-05T23:45:38.591Z",
           "evaluatedVersion": "1.4.0"
         },
         "skill-best-practice": {
@@ -6028,7 +6302,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.878Z",
+          "evaluatedAt": "2026-05-05T23:45:38.591Z",
           "evaluatedVersion": "1.4.0"
         }
       }
@@ -6092,7 +6366,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.882Z",
+        "evaluatedAt": "2026-05-05T23:45:38.595Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6147,7 +6421,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.882Z",
+          "evaluatedAt": "2026-05-05T23:45:38.595Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6165,7 +6439,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.882Z",
+          "evaluatedAt": "2026-05-05T23:45:38.595Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6229,7 +6503,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.885Z",
+        "evaluatedAt": "2026-05-05T23:45:38.598Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6284,7 +6558,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.885Z",
+          "evaluatedAt": "2026-05-05T23:45:38.599Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6302,7 +6576,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.885Z",
+          "evaluatedAt": "2026-05-05T23:45:38.599Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6366,7 +6640,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.888Z",
+        "evaluatedAt": "2026-05-05T23:45:38.601Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6421,7 +6695,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.888Z",
+          "evaluatedAt": "2026-05-05T23:45:38.601Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6439,7 +6713,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.888Z",
+          "evaluatedAt": "2026-05-05T23:45:38.601Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6503,7 +6777,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.890Z",
+        "evaluatedAt": "2026-05-05T23:45:38.603Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6558,7 +6832,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.890Z",
+          "evaluatedAt": "2026-05-05T23:45:38.604Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6576,7 +6850,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.890Z",
+          "evaluatedAt": "2026-05-05T23:45:38.604Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6592,7 +6866,7 @@
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/latchbio-integration",
       "relPath": "scientific-skills/latchbio-integration",
       "verified": true,
-      "tokenCount": 2352,
+      "tokenCount": 2348,
       "evalSummary": {
         "overallScore": 80,
         "grade": "B",
@@ -6640,7 +6914,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.892Z",
+        "evaluatedAt": "2026-05-05T23:45:38.606Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6695,7 +6969,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.892Z",
+          "evaluatedAt": "2026-05-05T23:45:38.606Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6713,7 +6987,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.892Z",
+          "evaluatedAt": "2026-05-05T23:45:38.606Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6777,7 +7051,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.897Z",
+        "evaluatedAt": "2026-05-05T23:45:38.611Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6832,7 +7106,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.897Z",
+          "evaluatedAt": "2026-05-05T23:45:38.611Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6850,7 +7124,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.897Z",
+          "evaluatedAt": "2026-05-05T23:45:38.611Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6914,7 +7188,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.903Z",
+        "evaluatedAt": "2026-05-05T23:45:38.617Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6969,7 +7243,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.903Z",
+          "evaluatedAt": "2026-05-05T23:45:38.617Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6987,7 +7261,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.903Z",
+          "evaluatedAt": "2026-05-05T23:45:38.617Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7051,7 +7325,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.906Z",
+        "evaluatedAt": "2026-05-05T23:45:38.621Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7106,7 +7380,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.906Z",
+          "evaluatedAt": "2026-05-05T23:45:38.621Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7124,7 +7398,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.906Z",
+          "evaluatedAt": "2026-05-05T23:45:38.621Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7188,7 +7462,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.910Z",
+        "evaluatedAt": "2026-05-05T23:45:38.625Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7243,7 +7517,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.910Z",
+          "evaluatedAt": "2026-05-05T23:45:38.625Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7261,7 +7535,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.910Z",
+          "evaluatedAt": "2026-05-05T23:45:38.625Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7325,7 +7599,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.913Z",
+        "evaluatedAt": "2026-05-05T23:45:38.628Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7380,7 +7654,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.913Z",
+          "evaluatedAt": "2026-05-05T23:45:38.628Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7398,7 +7672,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.913Z",
+          "evaluatedAt": "2026-05-05T23:45:38.628Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7462,7 +7736,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.914Z",
+        "evaluatedAt": "2026-05-05T23:45:38.630Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7517,7 +7791,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.914Z",
+          "evaluatedAt": "2026-05-05T23:45:38.630Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7535,7 +7809,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.914Z",
+          "evaluatedAt": "2026-05-05T23:45:38.630Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7599,7 +7873,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.916Z",
+        "evaluatedAt": "2026-05-05T23:45:38.632Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7654,7 +7928,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.916Z",
+          "evaluatedAt": "2026-05-05T23:45:38.632Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7672,7 +7946,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.916Z",
+          "evaluatedAt": "2026-05-05T23:45:38.632Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7736,7 +8010,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.917Z",
+        "evaluatedAt": "2026-05-05T23:45:38.634Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7791,7 +8065,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.917Z",
+          "evaluatedAt": "2026-05-05T23:45:38.634Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7809,7 +8083,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.917Z",
+          "evaluatedAt": "2026-05-05T23:45:38.634Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7873,7 +8147,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.919Z",
+        "evaluatedAt": "2026-05-05T23:45:38.636Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7928,7 +8202,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.919Z",
+          "evaluatedAt": "2026-05-05T23:45:38.636Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7946,7 +8220,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.919Z",
+          "evaluatedAt": "2026-05-05T23:45:38.636Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8010,7 +8284,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.921Z",
+        "evaluatedAt": "2026-05-05T23:45:38.638Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8065,7 +8339,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.921Z",
+          "evaluatedAt": "2026-05-05T23:45:38.639Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8083,7 +8357,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.921Z",
+          "evaluatedAt": "2026-05-05T23:45:38.639Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8147,7 +8421,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.924Z",
+        "evaluatedAt": "2026-05-05T23:45:38.641Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8202,7 +8476,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.924Z",
+          "evaluatedAt": "2026-05-05T23:45:38.641Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8220,7 +8494,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.924Z",
+          "evaluatedAt": "2026-05-05T23:45:38.641Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8284,7 +8558,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.926Z",
+        "evaluatedAt": "2026-05-05T23:45:38.644Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8339,7 +8613,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.926Z",
+          "evaluatedAt": "2026-05-05T23:45:38.644Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8357,7 +8631,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.926Z",
+          "evaluatedAt": "2026-05-05T23:45:38.644Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8421,7 +8695,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.928Z",
+        "evaluatedAt": "2026-05-05T23:45:38.647Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8476,7 +8750,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.928Z",
+          "evaluatedAt": "2026-05-05T23:45:38.647Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8494,7 +8768,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.928Z",
+          "evaluatedAt": "2026-05-05T23:45:38.647Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8558,7 +8832,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.930Z",
+        "evaluatedAt": "2026-05-05T23:45:38.649Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8613,7 +8887,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.930Z",
+          "evaluatedAt": "2026-05-05T23:45:38.649Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8631,7 +8905,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.930Z",
+          "evaluatedAt": "2026-05-05T23:45:38.649Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8695,7 +8969,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.932Z",
+        "evaluatedAt": "2026-05-05T23:45:38.652Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8750,7 +9024,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.932Z",
+          "evaluatedAt": "2026-05-05T23:45:38.652Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8768,7 +9042,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.932Z",
+          "evaluatedAt": "2026-05-05T23:45:38.652Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8832,7 +9106,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.934Z",
+        "evaluatedAt": "2026-05-05T23:45:38.653Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8887,7 +9161,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.934Z",
+          "evaluatedAt": "2026-05-05T23:45:38.653Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8905,7 +9179,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.934Z",
+          "evaluatedAt": "2026-05-05T23:45:38.653Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8969,7 +9243,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.935Z",
+        "evaluatedAt": "2026-05-05T23:45:38.655Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9024,7 +9298,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.935Z",
+          "evaluatedAt": "2026-05-05T23:45:38.655Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9042,7 +9316,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.935Z",
+          "evaluatedAt": "2026-05-05T23:45:38.655Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9106,7 +9380,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.937Z",
+        "evaluatedAt": "2026-05-05T23:45:38.658Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9161,7 +9435,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.937Z",
+          "evaluatedAt": "2026-05-05T23:45:38.658Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9179,7 +9453,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.937Z",
+          "evaluatedAt": "2026-05-05T23:45:38.658Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9243,7 +9517,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.941Z",
+        "evaluatedAt": "2026-05-05T23:45:38.661Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9298,7 +9572,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.941Z",
+          "evaluatedAt": "2026-05-05T23:45:38.662Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9316,7 +9590,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.941Z",
+          "evaluatedAt": "2026-05-05T23:45:38.662Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9380,7 +9654,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.944Z",
+        "evaluatedAt": "2026-05-05T23:45:38.665Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9435,7 +9709,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.944Z",
+          "evaluatedAt": "2026-05-05T23:45:38.665Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9453,7 +9727,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.944Z",
+          "evaluatedAt": "2026-05-05T23:45:38.665Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9517,7 +9791,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.945Z",
+        "evaluatedAt": "2026-05-05T23:45:38.667Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9572,7 +9846,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.945Z",
+          "evaluatedAt": "2026-05-05T23:45:38.667Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9590,7 +9864,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.945Z",
+          "evaluatedAt": "2026-05-05T23:45:38.667Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9654,7 +9928,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.946Z",
+        "evaluatedAt": "2026-05-05T23:45:38.668Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9709,7 +9983,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.946Z",
+          "evaluatedAt": "2026-05-05T23:45:38.668Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9727,7 +10001,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.946Z",
+          "evaluatedAt": "2026-05-05T23:45:38.668Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9791,7 +10065,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.948Z",
+        "evaluatedAt": "2026-05-05T23:45:38.670Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9846,7 +10120,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.948Z",
+          "evaluatedAt": "2026-05-05T23:45:38.670Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9864,7 +10138,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.948Z",
+          "evaluatedAt": "2026-05-05T23:45:38.670Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9928,7 +10202,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.949Z",
+        "evaluatedAt": "2026-05-05T23:45:38.671Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9983,7 +10257,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.949Z",
+          "evaluatedAt": "2026-05-05T23:45:38.671Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10001,7 +10275,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.949Z",
+          "evaluatedAt": "2026-05-05T23:45:38.671Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10065,7 +10339,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.951Z",
+        "evaluatedAt": "2026-05-05T23:45:38.674Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10120,7 +10394,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.951Z",
+          "evaluatedAt": "2026-05-05T23:45:38.674Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10138,7 +10412,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.951Z",
+          "evaluatedAt": "2026-05-05T23:45:38.674Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10202,7 +10476,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.955Z",
+        "evaluatedAt": "2026-05-05T23:45:38.676Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10257,7 +10531,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.955Z",
+          "evaluatedAt": "2026-05-05T23:45:38.676Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10275,7 +10549,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.955Z",
+          "evaluatedAt": "2026-05-05T23:45:38.676Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10339,7 +10613,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.957Z",
+        "evaluatedAt": "2026-05-05T23:45:38.678Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10394,7 +10668,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.957Z",
+          "evaluatedAt": "2026-05-05T23:45:38.678Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10412,7 +10686,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.957Z",
+          "evaluatedAt": "2026-05-05T23:45:38.678Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10476,7 +10750,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.958Z",
+        "evaluatedAt": "2026-05-05T23:45:38.680Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10531,7 +10805,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.958Z",
+          "evaluatedAt": "2026-05-05T23:45:38.680Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10549,7 +10823,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.958Z",
+          "evaluatedAt": "2026-05-05T23:45:38.680Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10613,7 +10887,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.960Z",
+        "evaluatedAt": "2026-05-05T23:45:38.682Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10668,7 +10942,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.960Z",
+          "evaluatedAt": "2026-05-05T23:45:38.682Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10686,7 +10960,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.960Z",
+          "evaluatedAt": "2026-05-05T23:45:38.682Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10750,7 +11024,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.962Z",
+        "evaluatedAt": "2026-05-05T23:45:38.685Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10805,7 +11079,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.962Z",
+          "evaluatedAt": "2026-05-05T23:45:38.685Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10823,7 +11097,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.962Z",
+          "evaluatedAt": "2026-05-05T23:45:38.685Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10887,7 +11161,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.964Z",
+        "evaluatedAt": "2026-05-05T23:45:38.687Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10942,7 +11216,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.964Z",
+          "evaluatedAt": "2026-05-05T23:45:38.687Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10960,7 +11234,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.964Z",
+          "evaluatedAt": "2026-05-05T23:45:38.687Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11024,7 +11298,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.966Z",
+        "evaluatedAt": "2026-05-05T23:45:38.689Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11079,7 +11353,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.966Z",
+          "evaluatedAt": "2026-05-05T23:45:38.689Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11097,7 +11371,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.966Z",
+          "evaluatedAt": "2026-05-05T23:45:38.689Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11161,7 +11435,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.967Z",
+        "evaluatedAt": "2026-05-05T23:45:38.691Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11216,7 +11490,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.967Z",
+          "evaluatedAt": "2026-05-05T23:45:38.691Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11234,7 +11508,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.967Z",
+          "evaluatedAt": "2026-05-05T23:45:38.691Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11298,7 +11572,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.970Z",
+        "evaluatedAt": "2026-05-05T23:45:38.693Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11353,7 +11627,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.970Z",
+          "evaluatedAt": "2026-05-05T23:45:38.693Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11371,7 +11645,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.970Z",
+          "evaluatedAt": "2026-05-05T23:45:38.693Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11435,7 +11709,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.972Z",
+        "evaluatedAt": "2026-05-05T23:45:38.696Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11490,7 +11764,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.972Z",
+          "evaluatedAt": "2026-05-05T23:45:38.696Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11508,7 +11782,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.972Z",
+          "evaluatedAt": "2026-05-05T23:45:38.696Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11572,7 +11846,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.974Z",
+        "evaluatedAt": "2026-05-05T23:45:38.698Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11627,7 +11901,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.974Z",
+          "evaluatedAt": "2026-05-05T23:45:38.698Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11645,31 +11919,31 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.974Z",
+          "evaluatedAt": "2026-05-05T23:45:38.698Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "pyhealth",
-      "description": "Comprehensive healthcare AI toolkit for developing, testing, and deploying machine learning models with clinical data. This skill should be used when working with electronic health records (EHR), clinical prediction tasks (mortality, readmission, drug recommendation), medical coding systems (ICD, NDC, ATC), physiological signals (EEG, ECG), healthcare datasets (MIMIC-III/IV, eICU, OMOP), or implementing deep learning models for healthcare applications (RETAIN, SafeDrug, Transformer, GNN).",
+      "description": "Build clinical/healthcare deep-learning pipelines with PyHealth — loading EHR/signal/imaging datasets (MIMIC-III/IV, eICU, OMOP, SleepEDF, ChestXray14, EHRShot), defining tasks (mortality, readmission, length-of-stay, drug recommendation, sleep staging, ICD coding, EEG events), instantiating models (Transformer, RETAIN, GAMENet, SafeDrug, MICRON, StageNet, AdaCare, CNN/RNN/MLP), training with the PyHealth Trainer, computing clinical metrics, and using medical code utilities (ICD/ATC/NDC/RxNorm lookup and cross-mapping). Use this skill whenever the user mentions PyHealth, MIMIC, eICU, OMOP, EHR modeling, clinical prediction, drug recommendation, sleep staging, medical code mapping, ICD/ATC codes, or any healthcare ML pipeline that fits the dataset → task → model → trainer → metrics pattern, even if \"PyHealth\" isn't named explicitly.",
       "version": "0.0.0",
-      "license": "MIT license",
+      "license": "",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyhealth",
       "relPath": "scientific-skills/pyhealth",
       "verified": true,
-      "tokenCount": 3907,
+      "tokenCount": 1889,
       "evalSummary": {
-        "overallScore": 71,
-        "grade": "C",
+        "overallScore": 64,
+        "grade": "D",
         "categories": [
           {
             "id": "structure",
             "name": "Structure & completeness",
-            "score": 8,
+            "score": 7,
             "max": 10
           },
           {
@@ -11681,25 +11955,25 @@
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 10,
+            "score": 8,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 5,
+            "score": 9,
             "max": 10
           },
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 9,
+            "score": 7,
             "max": 10
           },
           {
             "id": "testability",
             "name": "Testability",
-            "score": 5,
+            "score": 1,
             "max": 10
           },
           {
@@ -11709,7 +11983,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.977Z",
+        "evaluatedAt": "2026-05-05T23:45:38.700Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11718,13 +11992,13 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 71,
-          "grade": "C",
+          "overallScore": 64,
+          "grade": "D",
           "categories": [
             {
               "id": "structure",
               "name": "Structure & completeness",
-              "score": 8,
+              "score": 7,
               "max": 10
             },
             {
@@ -11736,25 +12010,25 @@
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 10,
+              "score": 8,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 5,
+              "score": 9,
               "max": 10
             },
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 9,
+              "score": 7,
               "max": 10
             },
             {
               "id": "testability",
               "name": "Testability",
-              "score": 5,
+              "score": 1,
               "max": 10
             },
             {
@@ -11764,7 +12038,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.977Z",
+          "evaluatedAt": "2026-05-05T23:45:38.700Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11782,7 +12056,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.977Z",
+          "evaluatedAt": "2026-05-05T23:45:38.700Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11846,7 +12120,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.979Z",
+        "evaluatedAt": "2026-05-05T23:45:38.702Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11901,7 +12175,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.979Z",
+          "evaluatedAt": "2026-05-05T23:45:38.702Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11919,7 +12193,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.979Z",
+          "evaluatedAt": "2026-05-05T23:45:38.702Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11983,7 +12257,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.981Z",
+        "evaluatedAt": "2026-05-05T23:45:38.704Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12038,7 +12312,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.982Z",
+          "evaluatedAt": "2026-05-05T23:45:38.704Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12056,7 +12330,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.982Z",
+          "evaluatedAt": "2026-05-05T23:45:38.704Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12120,7 +12394,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.984Z",
+        "evaluatedAt": "2026-05-05T23:45:38.707Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12175,7 +12449,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.984Z",
+          "evaluatedAt": "2026-05-05T23:45:38.707Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12193,7 +12467,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.984Z",
+          "evaluatedAt": "2026-05-05T23:45:38.708Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12257,7 +12531,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.988Z",
+        "evaluatedAt": "2026-05-05T23:45:38.710Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12312,7 +12586,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.988Z",
+          "evaluatedAt": "2026-05-05T23:45:38.710Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12330,7 +12604,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.988Z",
+          "evaluatedAt": "2026-05-05T23:45:38.710Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12346,7 +12620,7 @@
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/pyopenms",
       "relPath": "scientific-skills/pyopenms",
       "verified": true,
-      "tokenCount": 1148,
+      "tokenCount": 1146,
       "evalSummary": {
         "overallScore": 60,
         "grade": "D",
@@ -12394,7 +12668,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.990Z",
+        "evaluatedAt": "2026-05-05T23:45:38.712Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12449,7 +12723,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.990Z",
+          "evaluatedAt": "2026-05-05T23:45:38.712Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12467,7 +12741,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.990Z",
+          "evaluatedAt": "2026-05-05T23:45:38.712Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12531,7 +12805,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.991Z",
+        "evaluatedAt": "2026-05-05T23:45:38.714Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12586,7 +12860,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.991Z",
+          "evaluatedAt": "2026-05-05T23:45:38.714Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12604,7 +12878,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.991Z",
+          "evaluatedAt": "2026-05-05T23:45:38.714Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12668,7 +12942,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.993Z",
+        "evaluatedAt": "2026-05-05T23:45:38.716Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12723,7 +12997,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.993Z",
+          "evaluatedAt": "2026-05-05T23:45:38.716Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12741,7 +13015,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.993Z",
+          "evaluatedAt": "2026-05-05T23:45:38.716Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12805,7 +13079,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.995Z",
+        "evaluatedAt": "2026-05-05T23:45:38.717Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12860,7 +13134,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.995Z",
+          "evaluatedAt": "2026-05-05T23:45:38.718Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12878,7 +13152,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.995Z",
+          "evaluatedAt": "2026-05-05T23:45:38.718Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12942,7 +13216,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.996Z",
+        "evaluatedAt": "2026-05-05T23:45:38.719Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12997,7 +13271,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.996Z",
+          "evaluatedAt": "2026-05-05T23:45:38.719Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13015,7 +13289,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.996Z",
+          "evaluatedAt": "2026-05-05T23:45:38.719Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13079,7 +13353,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.998Z",
+        "evaluatedAt": "2026-05-05T23:45:38.720Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13134,7 +13408,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.998Z",
+          "evaluatedAt": "2026-05-05T23:45:38.720Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13152,7 +13426,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.998Z",
+          "evaluatedAt": "2026-05-05T23:45:38.720Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13216,7 +13490,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:25.999Z",
+        "evaluatedAt": "2026-05-05T23:45:38.722Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13271,7 +13545,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.999Z",
+          "evaluatedAt": "2026-05-05T23:45:38.722Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13289,7 +13563,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:25.999Z",
+          "evaluatedAt": "2026-05-05T23:45:38.722Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13353,7 +13627,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.002Z",
+        "evaluatedAt": "2026-05-05T23:45:38.725Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13408,7 +13682,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.002Z",
+          "evaluatedAt": "2026-05-05T23:45:38.725Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13426,7 +13700,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.002Z",
+          "evaluatedAt": "2026-05-05T23:45:38.725Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13490,7 +13764,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.006Z",
+        "evaluatedAt": "2026-05-05T23:45:38.730Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13545,7 +13819,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.006Z",
+          "evaluatedAt": "2026-05-05T23:45:38.730Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13563,7 +13837,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.006Z",
+          "evaluatedAt": "2026-05-05T23:45:38.730Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13627,7 +13901,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.011Z",
+        "evaluatedAt": "2026-05-05T23:45:38.734Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13682,7 +13956,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.011Z",
+          "evaluatedAt": "2026-05-05T23:45:38.734Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13700,7 +13974,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.011Z",
+          "evaluatedAt": "2026-05-05T23:45:38.735Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13764,7 +14038,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.015Z",
+        "evaluatedAt": "2026-05-05T23:45:38.739Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13819,7 +14093,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.015Z",
+          "evaluatedAt": "2026-05-05T23:45:38.739Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13837,7 +14111,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.015Z",
+          "evaluatedAt": "2026-05-05T23:45:38.739Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13901,7 +14175,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.018Z",
+        "evaluatedAt": "2026-05-05T23:45:38.743Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13956,7 +14230,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.018Z",
+          "evaluatedAt": "2026-05-05T23:45:38.743Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13974,7 +14248,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.018Z",
+          "evaluatedAt": "2026-05-05T23:45:38.743Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14038,7 +14312,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.020Z",
+        "evaluatedAt": "2026-05-05T23:45:38.745Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14093,7 +14367,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.020Z",
+          "evaluatedAt": "2026-05-05T23:45:38.745Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14111,7 +14385,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.020Z",
+          "evaluatedAt": "2026-05-05T23:45:38.745Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14175,7 +14449,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.022Z",
+        "evaluatedAt": "2026-05-05T23:45:38.747Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14230,7 +14504,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.022Z",
+          "evaluatedAt": "2026-05-05T23:45:38.747Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14248,7 +14522,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.022Z",
+          "evaluatedAt": "2026-05-05T23:45:38.747Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14312,7 +14586,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.025Z",
+        "evaluatedAt": "2026-05-05T23:45:38.750Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14367,7 +14641,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.025Z",
+          "evaluatedAt": "2026-05-05T23:45:38.750Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14385,7 +14659,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.025Z",
+          "evaluatedAt": "2026-05-05T23:45:38.750Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14449,7 +14723,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.028Z",
+        "evaluatedAt": "2026-05-05T23:45:38.754Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14504,7 +14778,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.028Z",
+          "evaluatedAt": "2026-05-05T23:45:38.754Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14522,7 +14796,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.028Z",
+          "evaluatedAt": "2026-05-05T23:45:38.754Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14586,7 +14860,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.033Z",
+        "evaluatedAt": "2026-05-05T23:45:38.759Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14641,7 +14915,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.033Z",
+          "evaluatedAt": "2026-05-05T23:45:38.759Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14659,7 +14933,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.033Z",
+          "evaluatedAt": "2026-05-05T23:45:38.760Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14723,7 +14997,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.038Z",
+        "evaluatedAt": "2026-05-05T23:45:38.765Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14778,7 +15052,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.038Z",
+          "evaluatedAt": "2026-05-05T23:45:38.765Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14796,7 +15070,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.038Z",
+          "evaluatedAt": "2026-05-05T23:45:38.765Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14860,7 +15134,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.042Z",
+        "evaluatedAt": "2026-05-05T23:45:38.770Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14915,7 +15189,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.042Z",
+          "evaluatedAt": "2026-05-05T23:45:38.770Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14933,7 +15207,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.042Z",
+          "evaluatedAt": "2026-05-05T23:45:38.770Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14997,7 +15271,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.046Z",
+        "evaluatedAt": "2026-05-05T23:45:38.773Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15052,7 +15326,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.046Z",
+          "evaluatedAt": "2026-05-05T23:45:38.773Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15070,7 +15344,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.046Z",
+          "evaluatedAt": "2026-05-05T23:45:38.774Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15086,7 +15360,7 @@
       "installUrl": "github:K-Dense-AI/claude-scientific-skills:scientific-skills/scikit-learn",
       "relPath": "scientific-skills/scikit-learn",
       "verified": true,
-      "tokenCount": 3264,
+      "tokenCount": 3258,
       "evalSummary": {
         "overallScore": 74,
         "grade": "C",
@@ -15134,7 +15408,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.048Z",
+        "evaluatedAt": "2026-05-05T23:45:38.776Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15189,7 +15463,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.048Z",
+          "evaluatedAt": "2026-05-05T23:45:38.776Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15207,7 +15481,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.048Z",
+          "evaluatedAt": "2026-05-05T23:45:38.776Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15271,7 +15545,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.050Z",
+        "evaluatedAt": "2026-05-05T23:45:38.779Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15326,7 +15600,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.050Z",
+          "evaluatedAt": "2026-05-05T23:45:38.779Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15344,7 +15618,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.050Z",
+          "evaluatedAt": "2026-05-05T23:45:38.779Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15408,7 +15682,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.052Z",
+        "evaluatedAt": "2026-05-05T23:45:38.781Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15463,7 +15737,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.052Z",
+          "evaluatedAt": "2026-05-05T23:45:38.781Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15481,7 +15755,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.052Z",
+          "evaluatedAt": "2026-05-05T23:45:38.781Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15545,7 +15819,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.054Z",
+        "evaluatedAt": "2026-05-05T23:45:38.783Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15600,7 +15874,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.054Z",
+          "evaluatedAt": "2026-05-05T23:45:38.783Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15618,7 +15892,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.054Z",
+          "evaluatedAt": "2026-05-05T23:45:38.783Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15682,7 +15956,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.056Z",
+        "evaluatedAt": "2026-05-05T23:45:38.786Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15737,7 +16011,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.056Z",
+          "evaluatedAt": "2026-05-05T23:45:38.786Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15755,7 +16029,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.056Z",
+          "evaluatedAt": "2026-05-05T23:45:38.786Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15819,7 +16093,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.059Z",
+        "evaluatedAt": "2026-05-05T23:45:38.789Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15874,7 +16148,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.059Z",
+          "evaluatedAt": "2026-05-05T23:45:38.789Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15892,7 +16166,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.059Z",
+          "evaluatedAt": "2026-05-05T23:45:38.789Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15956,7 +16230,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.061Z",
+        "evaluatedAt": "2026-05-05T23:45:38.791Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16011,7 +16285,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.061Z",
+          "evaluatedAt": "2026-05-05T23:45:38.791Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16029,7 +16303,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.061Z",
+          "evaluatedAt": "2026-05-05T23:45:38.792Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16093,7 +16367,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.063Z",
+        "evaluatedAt": "2026-05-05T23:45:38.794Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16148,7 +16422,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.063Z",
+          "evaluatedAt": "2026-05-05T23:45:38.794Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16166,7 +16440,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.063Z",
+          "evaluatedAt": "2026-05-05T23:45:38.794Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16230,7 +16504,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.065Z",
+        "evaluatedAt": "2026-05-05T23:45:38.796Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16285,7 +16559,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.066Z",
+          "evaluatedAt": "2026-05-05T23:45:38.796Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16303,7 +16577,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.066Z",
+          "evaluatedAt": "2026-05-05T23:45:38.796Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16367,7 +16641,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.068Z",
+        "evaluatedAt": "2026-05-05T23:45:38.799Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16422,7 +16696,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.068Z",
+          "evaluatedAt": "2026-05-05T23:45:38.799Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16440,7 +16714,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.068Z",
+          "evaluatedAt": "2026-05-05T23:45:38.799Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16504,7 +16778,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.071Z",
+        "evaluatedAt": "2026-05-05T23:45:38.802Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16559,7 +16833,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.071Z",
+          "evaluatedAt": "2026-05-05T23:45:38.802Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16577,7 +16851,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.071Z",
+          "evaluatedAt": "2026-05-05T23:45:38.802Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16641,7 +16915,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.073Z",
+        "evaluatedAt": "2026-05-05T23:45:38.804Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16696,7 +16970,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.073Z",
+          "evaluatedAt": "2026-05-05T23:45:38.804Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16714,7 +16988,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.073Z",
+          "evaluatedAt": "2026-05-05T23:45:38.804Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16778,7 +17052,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.076Z",
+        "evaluatedAt": "2026-05-05T23:45:38.808Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16833,7 +17107,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.077Z",
+          "evaluatedAt": "2026-05-05T23:45:38.808Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16851,7 +17125,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.077Z",
+          "evaluatedAt": "2026-05-05T23:45:38.808Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16915,7 +17189,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.080Z",
+        "evaluatedAt": "2026-05-05T23:45:38.812Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16970,7 +17244,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.080Z",
+          "evaluatedAt": "2026-05-05T23:45:38.812Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16988,7 +17262,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.080Z",
+          "evaluatedAt": "2026-05-05T23:45:38.812Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17052,7 +17326,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.082Z",
+        "evaluatedAt": "2026-05-05T23:45:38.814Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17107,7 +17381,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.083Z",
+          "evaluatedAt": "2026-05-05T23:45:38.814Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17125,7 +17399,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.083Z",
+          "evaluatedAt": "2026-05-05T23:45:38.814Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17189,7 +17463,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.084Z",
+        "evaluatedAt": "2026-05-05T23:45:38.816Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17244,7 +17518,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.084Z",
+          "evaluatedAt": "2026-05-05T23:45:38.816Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17262,7 +17536,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.084Z",
+          "evaluatedAt": "2026-05-05T23:45:38.816Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17326,7 +17600,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.088Z",
+        "evaluatedAt": "2026-05-05T23:45:38.820Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17381,7 +17655,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.088Z",
+          "evaluatedAt": "2026-05-05T23:45:38.820Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17399,7 +17673,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.088Z",
+          "evaluatedAt": "2026-05-05T23:45:38.820Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17463,7 +17737,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.093Z",
+        "evaluatedAt": "2026-05-05T23:45:38.825Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17518,7 +17792,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.093Z",
+          "evaluatedAt": "2026-05-05T23:45:38.825Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17536,7 +17810,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.093Z",
+          "evaluatedAt": "2026-05-05T23:45:38.825Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17600,7 +17874,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.094Z",
+        "evaluatedAt": "2026-05-05T23:45:38.827Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17655,7 +17929,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.094Z",
+          "evaluatedAt": "2026-05-05T23:45:38.827Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17673,7 +17947,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.094Z",
+          "evaluatedAt": "2026-05-05T23:45:38.827Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17737,7 +18011,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.096Z",
+        "evaluatedAt": "2026-05-05T23:45:38.828Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17792,7 +18066,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.096Z",
+          "evaluatedAt": "2026-05-05T23:45:38.828Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17810,7 +18084,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.096Z",
+          "evaluatedAt": "2026-05-05T23:45:38.828Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17874,7 +18148,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.098Z",
+        "evaluatedAt": "2026-05-05T23:45:38.831Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17929,7 +18203,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.098Z",
+          "evaluatedAt": "2026-05-05T23:45:38.831Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17947,7 +18221,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.098Z",
+          "evaluatedAt": "2026-05-05T23:45:38.831Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18011,7 +18285,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.100Z",
+        "evaluatedAt": "2026-05-05T23:45:38.834Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18066,7 +18340,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.100Z",
+          "evaluatedAt": "2026-05-05T23:45:38.834Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18084,7 +18358,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.100Z",
+          "evaluatedAt": "2026-05-05T23:45:38.834Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18148,7 +18422,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.102Z",
+        "evaluatedAt": "2026-05-05T23:45:38.836Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18203,7 +18477,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.102Z",
+          "evaluatedAt": "2026-05-05T23:45:38.836Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18221,7 +18495,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.102Z",
+          "evaluatedAt": "2026-05-05T23:45:38.836Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18285,7 +18559,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:26.105Z",
+        "evaluatedAt": "2026-05-05T23:45:38.838Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18340,7 +18614,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.105Z",
+          "evaluatedAt": "2026-05-05T23:45:38.838Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18358,7 +18632,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:26.105Z",
+          "evaluatedAt": "2026-05-05T23:45:38.838Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/Leonxlnx_taste-skill.json
+++ b/data/skill-index/Leonxlnx_taste-skill.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Leonxlnx/taste-skill.git",
   "owner": "Leonxlnx",
   "repo": "taste-skill",
-  "updatedAt": "2026-04-30T23:05:11.416Z",
+  "updatedAt": "2026-05-05T23:45:24.103Z",
   "skillCount": 12,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.381Z",
+        "evaluatedAt": "2026-05-05T23:45:24.063Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.381Z",
+          "evaluatedAt": "2026-05-05T23:45:24.063Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.381Z",
+          "evaluatedAt": "2026-05-05T23:45:24.063Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.385Z",
+        "evaluatedAt": "2026-05-05T23:45:24.067Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.385Z",
+          "evaluatedAt": "2026-05-05T23:45:24.067Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.385Z",
+          "evaluatedAt": "2026-05-05T23:45:24.067Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.387Z",
+        "evaluatedAt": "2026-05-05T23:45:24.069Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.387Z",
+          "evaluatedAt": "2026-05-05T23:45:24.069Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.387Z",
+          "evaluatedAt": "2026-05-05T23:45:24.069Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.388Z",
+        "evaluatedAt": "2026-05-05T23:45:24.071Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.388Z",
+          "evaluatedAt": "2026-05-05T23:45:24.071Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.388Z",
+          "evaluatedAt": "2026-05-05T23:45:24.071Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.390Z",
+        "evaluatedAt": "2026-05-05T23:45:24.073Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.390Z",
+          "evaluatedAt": "2026-05-05T23:45:24.073Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.390Z",
+          "evaluatedAt": "2026-05-05T23:45:24.073Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.394Z",
+        "evaluatedAt": "2026-05-05T23:45:24.077Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.394Z",
+          "evaluatedAt": "2026-05-05T23:45:24.078Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.394Z",
+          "evaluatedAt": "2026-05-05T23:45:24.078Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.401Z",
+        "evaluatedAt": "2026-05-05T23:45:24.084Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.401Z",
+          "evaluatedAt": "2026-05-05T23:45:24.084Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,14 +959,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.401Z",
+          "evaluatedAt": "2026-05-05T23:45:24.084Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "imagegen-frontend-web",
-      "description": "Elite frontend image-direction skill for generating premium, artistic, implementation-friendly website design references. Uses combinatorial variation to avoid repetitive AI aesthetics, enforces cinematic hero minimalism, strong hierarchy, generous spacing, image-led composition, and anti-slop visual discipline. Optimized for hero sections, landing pages, and multi-section site comps that developers or coding models can accurately recreate.",
+      "description": "Elite frontend image-direction skill for generating premium, conversion-aware website design references. CRITICAL OUTPUT RULE — generate ONE separate horizontal image FOR EVERY section. A landing page with 8 sections produces 8 images. Never compress multiple sections into one image. Enforces composition variety (not always left-text / right-image), background-image freedom, varied CTAs, varied hero scales (giant / mid / mini minimalist), narrative concept spine, second-read moments, and a single consistent palette across all images. Optimized for landing pages, marketing sites, and product comps that developers or coding models can accurately recreate.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -975,9 +975,9 @@
       "installUrl": "github:Leonxlnx/taste-skill:skills/imagegen-frontend-web",
       "relPath": "skills/imagegen-frontend-web",
       "verified": true,
-      "tokenCount": 5363,
+      "tokenCount": 10869,
       "evalSummary": {
-        "overallScore": 64,
+        "overallScore": 59,
         "grade": "D",
         "categories": [
           {
@@ -989,25 +989,25 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 5,
+            "score": 3,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 9,
+            "score": 8,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 4,
+            "score": 5,
             "max": 10
           },
           {
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.406Z",
+        "evaluatedAt": "2026-05-05T23:45:24.091Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1032,7 +1032,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 64,
+          "overallScore": 59,
           "grade": "D",
           "categories": [
             {
@@ -1044,25 +1044,25 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 5,
+              "score": 3,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 9,
+              "score": 8,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 4,
+              "score": 5,
               "max": 10
             },
             {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.406Z",
+          "evaluatedAt": "2026-05-05T23:45:24.091Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.406Z",
+          "evaluatedAt": "2026-05-05T23:45:24.091Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.409Z",
+        "evaluatedAt": "2026-05-05T23:45:24.095Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.409Z",
+          "evaluatedAt": "2026-05-05T23:45:24.095Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.409Z",
+          "evaluatedAt": "2026-05-05T23:45:24.095Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.410Z",
+        "evaluatedAt": "2026-05-05T23:45:24.097Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.410Z",
+          "evaluatedAt": "2026-05-05T23:45:24.097Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.410Z",
+          "evaluatedAt": "2026-05-05T23:45:24.097Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.412Z",
+        "evaluatedAt": "2026-05-05T23:45:24.099Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.412Z",
+          "evaluatedAt": "2026-05-05T23:45:24.099Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.412Z",
+          "evaluatedAt": "2026-05-05T23:45:24.099Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:11.415Z",
+        "evaluatedAt": "2026-05-05T23:45:24.102Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.415Z",
+          "evaluatedAt": "2026-05-05T23:45:24.102Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:11.415Z",
+          "evaluatedAt": "2026-05-05T23:45:24.102Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/Master-cai_Research-Paper-Writing-Skills.json
+++ b/data/skill-index/Master-cai_Research-Paper-Writing-Skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Master-cai/Research-Paper-Writing-Skills.git",
   "owner": "Master-cai",
   "repo": "Research-Paper-Writing-Skills",
-  "updatedAt": "2026-04-30T23:05:19.886Z",
+  "updatedAt": "2026-05-05T23:45:32.705Z",
   "skillCount": 1,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.885Z",
+        "evaluatedAt": "2026-05-05T23:45:32.705Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.885Z",
+          "evaluatedAt": "2026-05-05T23:45:32.705Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.885Z",
+          "evaluatedAt": "2026-05-05T23:45:32.705Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/MiniMax-AI_skills.json
+++ b/data/skill-index/MiniMax-AI_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/MiniMax-AI/skills.git",
   "owner": "MiniMax-AI",
   "repo": "skills",
-  "updatedAt": "2026-04-30T23:05:14.164Z",
+  "updatedAt": "2026-05-05T23:45:27.008Z",
   "skillCount": 23,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.121Z",
+        "evaluatedAt": "2026-05-05T23:45:26.963Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.121Z",
+          "evaluatedAt": "2026-05-05T23:45:26.963Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.121Z",
+          "evaluatedAt": "2026-05-05T23:45:26.963Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.125Z",
+        "evaluatedAt": "2026-05-05T23:45:26.966Z",
         "evaluatedVersion": "1.1"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.125Z",
+          "evaluatedAt": "2026-05-05T23:45:26.967Z",
           "evaluatedVersion": "1.1"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.125Z",
+          "evaluatedAt": "2026-05-05T23:45:26.967Z",
           "evaluatedVersion": "1.1"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.127Z",
+        "evaluatedAt": "2026-05-05T23:45:26.968Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.127Z",
+          "evaluatedAt": "2026-05-05T23:45:26.968Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.127Z",
+          "evaluatedAt": "2026-05-05T23:45:26.968Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.128Z",
+        "evaluatedAt": "2026-05-05T23:45:26.969Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.128Z",
+          "evaluatedAt": "2026-05-05T23:45:26.969Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.128Z",
+          "evaluatedAt": "2026-05-05T23:45:26.969Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.129Z",
+        "evaluatedAt": "2026-05-05T23:45:26.970Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.129Z",
+          "evaluatedAt": "2026-05-05T23:45:26.970Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.129Z",
+          "evaluatedAt": "2026-05-05T23:45:26.970Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.131Z",
+        "evaluatedAt": "2026-05-05T23:45:26.973Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.131Z",
+          "evaluatedAt": "2026-05-05T23:45:26.973Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.131Z",
+          "evaluatedAt": "2026-05-05T23:45:26.973Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.135Z",
+        "evaluatedAt": "2026-05-05T23:45:26.976Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.135Z",
+          "evaluatedAt": "2026-05-05T23:45:26.976Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.135Z",
+          "evaluatedAt": "2026-05-05T23:45:26.976Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.139Z",
+        "evaluatedAt": "2026-05-05T23:45:26.980Z",
         "evaluatedVersion": "1.2"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.139Z",
+          "evaluatedAt": "2026-05-05T23:45:26.980Z",
           "evaluatedVersion": "1.2"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.139Z",
+          "evaluatedAt": "2026-05-05T23:45:26.980Z",
           "evaluatedVersion": "1.2"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.140Z",
+        "evaluatedAt": "2026-05-05T23:45:26.981Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.140Z",
+          "evaluatedAt": "2026-05-05T23:45:26.981Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.140Z",
+          "evaluatedAt": "2026-05-05T23:45:26.981Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.142Z",
+        "evaluatedAt": "2026-05-05T23:45:26.983Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.142Z",
+          "evaluatedAt": "2026-05-05T23:45:26.983Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.142Z",
+          "evaluatedAt": "2026-05-05T23:45:26.983Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.144Z",
+        "evaluatedAt": "2026-05-05T23:45:26.986Z",
         "evaluatedVersion": "1.1"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.145Z",
+          "evaluatedAt": "2026-05-05T23:45:26.986Z",
           "evaluatedVersion": "1.1"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.145Z",
+          "evaluatedAt": "2026-05-05T23:45:26.986Z",
           "evaluatedVersion": "1.1"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.147Z",
+        "evaluatedAt": "2026-05-05T23:45:26.988Z",
         "evaluatedVersion": "2.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.147Z",
+          "evaluatedAt": "2026-05-05T23:45:26.988Z",
           "evaluatedVersion": "2.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.147Z",
+          "evaluatedAt": "2026-05-05T23:45:26.988Z",
           "evaluatedVersion": "2.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.149Z",
+        "evaluatedAt": "2026-05-05T23:45:26.990Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.149Z",
+          "evaluatedAt": "2026-05-05T23:45:26.990Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.149Z",
+          "evaluatedAt": "2026-05-05T23:45:26.990Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.150Z",
+        "evaluatedAt": "2026-05-05T23:45:26.992Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.150Z",
+          "evaluatedAt": "2026-05-05T23:45:26.992Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.150Z",
+          "evaluatedAt": "2026-05-05T23:45:26.992Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.152Z",
+        "evaluatedAt": "2026-05-05T23:45:26.994Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.152Z",
+          "evaluatedAt": "2026-05-05T23:45:26.994Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.152Z",
+          "evaluatedAt": "2026-05-05T23:45:26.994Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.153Z",
+        "evaluatedAt": "2026-05-05T23:45:26.996Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.153Z",
+          "evaluatedAt": "2026-05-05T23:45:26.996Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.153Z",
+          "evaluatedAt": "2026-05-05T23:45:26.996Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.155Z",
+        "evaluatedAt": "2026-05-05T23:45:26.998Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.155Z",
+          "evaluatedAt": "2026-05-05T23:45:26.998Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.155Z",
+          "evaluatedAt": "2026-05-05T23:45:26.998Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.156Z",
+        "evaluatedAt": "2026-05-05T23:45:26.999Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.156Z",
+          "evaluatedAt": "2026-05-05T23:45:26.999Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.156Z",
+          "evaluatedAt": "2026-05-05T23:45:26.999Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.157Z",
+        "evaluatedAt": "2026-05-05T23:45:27.000Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.157Z",
+          "evaluatedAt": "2026-05-05T23:45:27.000Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.157Z",
+          "evaluatedAt": "2026-05-05T23:45:27.000Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.158Z",
+        "evaluatedAt": "2026-05-05T23:45:27.001Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.158Z",
+          "evaluatedAt": "2026-05-05T23:45:27.001Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.158Z",
+          "evaluatedAt": "2026-05-05T23:45:27.001Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.160Z",
+        "evaluatedAt": "2026-05-05T23:45:27.004Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.160Z",
+          "evaluatedAt": "2026-05-05T23:45:27.004Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.160Z",
+          "evaluatedAt": "2026-05-05T23:45:27.004Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.162Z",
+        "evaluatedAt": "2026-05-05T23:45:27.006Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.162Z",
+          "evaluatedAt": "2026-05-05T23:45:27.006Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.162Z",
+          "evaluatedAt": "2026-05-05T23:45:27.006Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3078,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.164Z",
+        "evaluatedAt": "2026-05-05T23:45:27.007Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -3133,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.164Z",
+          "evaluatedAt": "2026-05-05T23:45:27.007Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3151,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.164Z",
+          "evaluatedAt": "2026-05-05T23:45:27.007Z",
           "evaluatedVersion": "1.0"
         }
       }

--- a/data/skill-index/Paramchoudhary_ResumeSkills.json
+++ b/data/skill-index/Paramchoudhary_ResumeSkills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/Paramchoudhary/ResumeSkills.git",
   "owner": "Paramchoudhary",
   "repo": "ResumeSkills",
-  "updatedAt": "2026-04-30T22:42:51.191Z",
+  "updatedAt": "2026-05-05T23:45:59.092Z",
   "skillCount": 76,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.036Z",
+        "evaluatedAt": "2026-05-05T23:45:58.930Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.036Z",
+          "evaluatedAt": "2026-05-05T23:45:58.930Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.036Z",
+          "evaluatedAt": "2026-05-05T23:45:58.930Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.038Z",
+        "evaluatedAt": "2026-05-05T23:45:58.933Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.038Z",
+          "evaluatedAt": "2026-05-05T23:45:58.933Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.039Z",
+          "evaluatedAt": "2026-05-05T23:45:58.933Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.041Z",
+        "evaluatedAt": "2026-05-05T23:45:58.935Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.041Z",
+          "evaluatedAt": "2026-05-05T23:45:58.935Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.041Z",
+          "evaluatedAt": "2026-05-05T23:45:58.935Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.043Z",
+        "evaluatedAt": "2026-05-05T23:45:58.937Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.043Z",
+          "evaluatedAt": "2026-05-05T23:45:58.937Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.043Z",
+          "evaluatedAt": "2026-05-05T23:45:58.937Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.044Z",
+        "evaluatedAt": "2026-05-05T23:45:58.939Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.044Z",
+          "evaluatedAt": "2026-05-05T23:45:58.939Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.044Z",
+          "evaluatedAt": "2026-05-05T23:45:58.939Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.046Z",
+        "evaluatedAt": "2026-05-05T23:45:58.941Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.046Z",
+          "evaluatedAt": "2026-05-05T23:45:58.941Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.046Z",
+          "evaluatedAt": "2026-05-05T23:45:58.941Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.048Z",
+        "evaluatedAt": "2026-05-05T23:45:58.943Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.048Z",
+          "evaluatedAt": "2026-05-05T23:45:58.943Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.048Z",
+          "evaluatedAt": "2026-05-05T23:45:58.943Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.050Z",
+        "evaluatedAt": "2026-05-05T23:45:58.946Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.050Z",
+          "evaluatedAt": "2026-05-05T23:45:58.946Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.050Z",
+          "evaluatedAt": "2026-05-05T23:45:58.946Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.052Z",
+        "evaluatedAt": "2026-05-05T23:45:58.948Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.052Z",
+          "evaluatedAt": "2026-05-05T23:45:58.948Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.052Z",
+          "evaluatedAt": "2026-05-05T23:45:58.948Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.054Z",
+        "evaluatedAt": "2026-05-05T23:45:58.950Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.054Z",
+          "evaluatedAt": "2026-05-05T23:45:58.950Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.054Z",
+          "evaluatedAt": "2026-05-05T23:45:58.950Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.056Z",
+        "evaluatedAt": "2026-05-05T23:45:58.952Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.056Z",
+          "evaluatedAt": "2026-05-05T23:45:58.952Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.056Z",
+          "evaluatedAt": "2026-05-05T23:45:58.952Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.057Z",
+        "evaluatedAt": "2026-05-05T23:45:58.954Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.057Z",
+          "evaluatedAt": "2026-05-05T23:45:58.954Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.057Z",
+          "evaluatedAt": "2026-05-05T23:45:58.954Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.059Z",
+        "evaluatedAt": "2026-05-05T23:45:58.956Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.059Z",
+          "evaluatedAt": "2026-05-05T23:45:58.956Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.059Z",
+          "evaluatedAt": "2026-05-05T23:45:58.956Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.061Z",
+        "evaluatedAt": "2026-05-05T23:45:58.958Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.061Z",
+          "evaluatedAt": "2026-05-05T23:45:58.958Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.061Z",
+          "evaluatedAt": "2026-05-05T23:45:58.958Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.063Z",
+        "evaluatedAt": "2026-05-05T23:45:58.960Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.063Z",
+          "evaluatedAt": "2026-05-05T23:45:58.960Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.063Z",
+          "evaluatedAt": "2026-05-05T23:45:58.960Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.065Z",
+        "evaluatedAt": "2026-05-05T23:45:58.963Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.065Z",
+          "evaluatedAt": "2026-05-05T23:45:58.963Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.065Z",
+          "evaluatedAt": "2026-05-05T23:45:58.963Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.067Z",
+        "evaluatedAt": "2026-05-05T23:45:58.965Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.067Z",
+          "evaluatedAt": "2026-05-05T23:45:58.965Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.067Z",
+          "evaluatedAt": "2026-05-05T23:45:58.965Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.070Z",
+        "evaluatedAt": "2026-05-05T23:45:58.967Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.070Z",
+          "evaluatedAt": "2026-05-05T23:45:58.967Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.070Z",
+          "evaluatedAt": "2026-05-05T23:45:58.968Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.072Z",
+        "evaluatedAt": "2026-05-05T23:45:58.970Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.072Z",
+          "evaluatedAt": "2026-05-05T23:45:58.970Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.072Z",
+          "evaluatedAt": "2026-05-05T23:45:58.970Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.074Z",
+        "evaluatedAt": "2026-05-05T23:45:58.972Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.074Z",
+          "evaluatedAt": "2026-05-05T23:45:58.972Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.074Z",
+          "evaluatedAt": "2026-05-05T23:45:58.972Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.076Z",
+        "evaluatedAt": "2026-05-05T23:45:58.974Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.076Z",
+          "evaluatedAt": "2026-05-05T23:45:58.974Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.076Z",
+          "evaluatedAt": "2026-05-05T23:45:58.975Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.078Z",
+        "evaluatedAt": "2026-05-05T23:45:58.977Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.078Z",
+          "evaluatedAt": "2026-05-05T23:45:58.977Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.078Z",
+          "evaluatedAt": "2026-05-05T23:45:58.977Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3078,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.080Z",
+        "evaluatedAt": "2026-05-05T23:45:58.979Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3133,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.080Z",
+          "evaluatedAt": "2026-05-05T23:45:58.979Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3151,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.080Z",
+          "evaluatedAt": "2026-05-05T23:45:58.979Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3215,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.083Z",
+        "evaluatedAt": "2026-05-05T23:45:58.982Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3270,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.083Z",
+          "evaluatedAt": "2026-05-05T23:45:58.982Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3288,7 +3288,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.083Z",
+          "evaluatedAt": "2026-05-05T23:45:58.982Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3352,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.086Z",
+        "evaluatedAt": "2026-05-05T23:45:58.985Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3407,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.086Z",
+          "evaluatedAt": "2026-05-05T23:45:58.985Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3425,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.086Z",
+          "evaluatedAt": "2026-05-05T23:45:58.985Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3489,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.088Z",
+        "evaluatedAt": "2026-05-05T23:45:58.988Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3544,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.088Z",
+          "evaluatedAt": "2026-05-05T23:45:58.988Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3562,7 +3562,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.088Z",
+          "evaluatedAt": "2026-05-05T23:45:58.988Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3626,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.091Z",
+        "evaluatedAt": "2026-05-05T23:45:58.991Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3681,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.091Z",
+          "evaluatedAt": "2026-05-05T23:45:58.991Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3699,7 +3699,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.091Z",
+          "evaluatedAt": "2026-05-05T23:45:58.991Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3763,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.093Z",
+        "evaluatedAt": "2026-05-05T23:45:58.993Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3818,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.093Z",
+          "evaluatedAt": "2026-05-05T23:45:58.993Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3836,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.093Z",
+          "evaluatedAt": "2026-05-05T23:45:58.993Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3900,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.096Z",
+        "evaluatedAt": "2026-05-05T23:45:58.996Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3955,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.096Z",
+          "evaluatedAt": "2026-05-05T23:45:58.996Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3973,7 +3973,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.096Z",
+          "evaluatedAt": "2026-05-05T23:45:58.996Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4037,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.099Z",
+        "evaluatedAt": "2026-05-05T23:45:58.999Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4092,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.099Z",
+          "evaluatedAt": "2026-05-05T23:45:58.999Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4110,7 +4110,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.099Z",
+          "evaluatedAt": "2026-05-05T23:45:58.999Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4174,7 +4174,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.101Z",
+        "evaluatedAt": "2026-05-05T23:45:59.001Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4229,7 +4229,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.101Z",
+          "evaluatedAt": "2026-05-05T23:45:59.001Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4247,7 +4247,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.101Z",
+          "evaluatedAt": "2026-05-05T23:45:59.001Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4311,7 +4311,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.104Z",
+        "evaluatedAt": "2026-05-05T23:45:59.004Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4366,7 +4366,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.104Z",
+          "evaluatedAt": "2026-05-05T23:45:59.004Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4384,7 +4384,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.104Z",
+          "evaluatedAt": "2026-05-05T23:45:59.004Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4448,7 +4448,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.105Z",
+        "evaluatedAt": "2026-05-05T23:45:59.006Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4503,7 +4503,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.106Z",
+          "evaluatedAt": "2026-05-05T23:45:59.006Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4521,7 +4521,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.106Z",
+          "evaluatedAt": "2026-05-05T23:45:59.006Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4585,7 +4585,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.108Z",
+        "evaluatedAt": "2026-05-05T23:45:59.008Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4640,7 +4640,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.108Z",
+          "evaluatedAt": "2026-05-05T23:45:59.009Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4658,7 +4658,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.108Z",
+          "evaluatedAt": "2026-05-05T23:45:59.009Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4722,7 +4722,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.109Z",
+        "evaluatedAt": "2026-05-05T23:45:59.011Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4777,7 +4777,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.109Z",
+          "evaluatedAt": "2026-05-05T23:45:59.011Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4795,7 +4795,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.110Z",
+          "evaluatedAt": "2026-05-05T23:45:59.011Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4859,7 +4859,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.111Z",
+        "evaluatedAt": "2026-05-05T23:45:59.013Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4914,7 +4914,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.111Z",
+          "evaluatedAt": "2026-05-05T23:45:59.013Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4932,7 +4932,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.111Z",
+          "evaluatedAt": "2026-05-05T23:45:59.013Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4996,7 +4996,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.113Z",
+        "evaluatedAt": "2026-05-05T23:45:59.015Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5051,7 +5051,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.113Z",
+          "evaluatedAt": "2026-05-05T23:45:59.015Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5069,7 +5069,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.113Z",
+          "evaluatedAt": "2026-05-05T23:45:59.015Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5133,7 +5133,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.115Z",
+        "evaluatedAt": "2026-05-05T23:45:59.017Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5188,7 +5188,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.115Z",
+          "evaluatedAt": "2026-05-05T23:45:59.017Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5206,7 +5206,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.115Z",
+          "evaluatedAt": "2026-05-05T23:45:59.017Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5270,7 +5270,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.117Z",
+        "evaluatedAt": "2026-05-05T23:45:59.019Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5325,7 +5325,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.118Z",
+          "evaluatedAt": "2026-05-05T23:45:59.019Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5343,7 +5343,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.118Z",
+          "evaluatedAt": "2026-05-05T23:45:59.020Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5407,7 +5407,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.119Z",
+        "evaluatedAt": "2026-05-05T23:45:59.022Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5462,7 +5462,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.119Z",
+          "evaluatedAt": "2026-05-05T23:45:59.022Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5480,7 +5480,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.120Z",
+          "evaluatedAt": "2026-05-05T23:45:59.022Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5544,7 +5544,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.121Z",
+        "evaluatedAt": "2026-05-05T23:45:59.024Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5599,7 +5599,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.121Z",
+          "evaluatedAt": "2026-05-05T23:45:59.024Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5617,7 +5617,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.121Z",
+          "evaluatedAt": "2026-05-05T23:45:59.024Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5681,7 +5681,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.123Z",
+        "evaluatedAt": "2026-05-05T23:45:59.025Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5736,7 +5736,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.123Z",
+          "evaluatedAt": "2026-05-05T23:45:59.025Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5754,7 +5754,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.123Z",
+          "evaluatedAt": "2026-05-05T23:45:59.025Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5818,7 +5818,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.125Z",
+        "evaluatedAt": "2026-05-05T23:45:59.027Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5873,7 +5873,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.125Z",
+          "evaluatedAt": "2026-05-05T23:45:59.027Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5891,7 +5891,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.125Z",
+          "evaluatedAt": "2026-05-05T23:45:59.027Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5955,7 +5955,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.126Z",
+        "evaluatedAt": "2026-05-05T23:45:59.029Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6010,7 +6010,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.126Z",
+          "evaluatedAt": "2026-05-05T23:45:59.029Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6028,7 +6028,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.126Z",
+          "evaluatedAt": "2026-05-05T23:45:59.029Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6092,7 +6092,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.128Z",
+        "evaluatedAt": "2026-05-05T23:45:59.031Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6147,7 +6147,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.128Z",
+          "evaluatedAt": "2026-05-05T23:45:59.031Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6165,7 +6165,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.128Z",
+          "evaluatedAt": "2026-05-05T23:45:59.031Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6229,7 +6229,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.130Z",
+        "evaluatedAt": "2026-05-05T23:45:59.033Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6284,7 +6284,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.130Z",
+          "evaluatedAt": "2026-05-05T23:45:59.033Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6302,7 +6302,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.130Z",
+          "evaluatedAt": "2026-05-05T23:45:59.033Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6366,7 +6366,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.131Z",
+        "evaluatedAt": "2026-05-05T23:45:59.035Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6421,7 +6421,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.131Z",
+          "evaluatedAt": "2026-05-05T23:45:59.035Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6439,7 +6439,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.131Z",
+          "evaluatedAt": "2026-05-05T23:45:59.035Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6503,7 +6503,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.133Z",
+        "evaluatedAt": "2026-05-05T23:45:59.036Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6558,7 +6558,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.133Z",
+          "evaluatedAt": "2026-05-05T23:45:59.036Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6576,7 +6576,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.133Z",
+          "evaluatedAt": "2026-05-05T23:45:59.036Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6640,7 +6640,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.135Z",
+        "evaluatedAt": "2026-05-05T23:45:59.038Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6695,7 +6695,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.135Z",
+          "evaluatedAt": "2026-05-05T23:45:59.039Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6713,7 +6713,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.135Z",
+          "evaluatedAt": "2026-05-05T23:45:59.039Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6777,7 +6777,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.137Z",
+        "evaluatedAt": "2026-05-05T23:45:59.041Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6832,7 +6832,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.137Z",
+          "evaluatedAt": "2026-05-05T23:45:59.041Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6850,7 +6850,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.137Z",
+          "evaluatedAt": "2026-05-05T23:45:59.041Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6914,7 +6914,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.139Z",
+        "evaluatedAt": "2026-05-05T23:45:59.043Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6969,7 +6969,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.139Z",
+          "evaluatedAt": "2026-05-05T23:45:59.043Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6987,7 +6987,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.139Z",
+          "evaluatedAt": "2026-05-05T23:45:59.043Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7051,7 +7051,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.140Z",
+        "evaluatedAt": "2026-05-05T23:45:59.045Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7106,7 +7106,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.141Z",
+          "evaluatedAt": "2026-05-05T23:45:59.045Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7124,7 +7124,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.141Z",
+          "evaluatedAt": "2026-05-05T23:45:59.045Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7188,7 +7188,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.142Z",
+        "evaluatedAt": "2026-05-05T23:45:59.047Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7243,7 +7243,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.143Z",
+          "evaluatedAt": "2026-05-05T23:45:59.047Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7261,7 +7261,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.143Z",
+          "evaluatedAt": "2026-05-05T23:45:59.047Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7325,7 +7325,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.144Z",
+        "evaluatedAt": "2026-05-05T23:45:59.049Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7380,7 +7380,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.145Z",
+          "evaluatedAt": "2026-05-05T23:45:59.049Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7398,7 +7398,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.145Z",
+          "evaluatedAt": "2026-05-05T23:45:59.049Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7462,7 +7462,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.146Z",
+        "evaluatedAt": "2026-05-05T23:45:59.051Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7517,7 +7517,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.146Z",
+          "evaluatedAt": "2026-05-05T23:45:59.051Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7535,7 +7535,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.146Z",
+          "evaluatedAt": "2026-05-05T23:45:59.051Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7599,7 +7599,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.148Z",
+        "evaluatedAt": "2026-05-05T23:45:59.053Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7654,7 +7654,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.148Z",
+          "evaluatedAt": "2026-05-05T23:45:59.053Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7672,7 +7672,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.148Z",
+          "evaluatedAt": "2026-05-05T23:45:59.053Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7736,7 +7736,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.150Z",
+        "evaluatedAt": "2026-05-05T23:45:59.054Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7791,7 +7791,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.150Z",
+          "evaluatedAt": "2026-05-05T23:45:59.054Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7809,7 +7809,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.150Z",
+          "evaluatedAt": "2026-05-05T23:45:59.054Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7873,7 +7873,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.152Z",
+        "evaluatedAt": "2026-05-05T23:45:59.056Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7928,7 +7928,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.152Z",
+          "evaluatedAt": "2026-05-05T23:45:59.056Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7946,7 +7946,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.152Z",
+          "evaluatedAt": "2026-05-05T23:45:59.056Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8010,7 +8010,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.154Z",
+        "evaluatedAt": "2026-05-05T23:45:59.058Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8065,7 +8065,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.154Z",
+          "evaluatedAt": "2026-05-05T23:45:59.058Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8083,7 +8083,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.154Z",
+          "evaluatedAt": "2026-05-05T23:45:59.058Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8147,7 +8147,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.156Z",
+        "evaluatedAt": "2026-05-05T23:45:59.060Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8202,7 +8202,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.156Z",
+          "evaluatedAt": "2026-05-05T23:45:59.060Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8220,7 +8220,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.156Z",
+          "evaluatedAt": "2026-05-05T23:45:59.060Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8284,7 +8284,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.158Z",
+        "evaluatedAt": "2026-05-05T23:45:59.062Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8339,7 +8339,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.159Z",
+          "evaluatedAt": "2026-05-05T23:45:59.062Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8357,7 +8357,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.159Z",
+          "evaluatedAt": "2026-05-05T23:45:59.062Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8421,7 +8421,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.160Z",
+        "evaluatedAt": "2026-05-05T23:45:59.064Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8476,7 +8476,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.160Z",
+          "evaluatedAt": "2026-05-05T23:45:59.064Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8494,7 +8494,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.160Z",
+          "evaluatedAt": "2026-05-05T23:45:59.064Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8558,7 +8558,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.162Z",
+        "evaluatedAt": "2026-05-05T23:45:59.066Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8613,7 +8613,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.162Z",
+          "evaluatedAt": "2026-05-05T23:45:59.066Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8631,7 +8631,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.162Z",
+          "evaluatedAt": "2026-05-05T23:45:59.066Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8695,7 +8695,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.164Z",
+        "evaluatedAt": "2026-05-05T23:45:59.067Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8750,7 +8750,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.164Z",
+          "evaluatedAt": "2026-05-05T23:45:59.067Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8768,7 +8768,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.164Z",
+          "evaluatedAt": "2026-05-05T23:45:59.067Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8832,7 +8832,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.166Z",
+        "evaluatedAt": "2026-05-05T23:45:59.069Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8887,7 +8887,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.166Z",
+          "evaluatedAt": "2026-05-05T23:45:59.069Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8905,7 +8905,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.166Z",
+          "evaluatedAt": "2026-05-05T23:45:59.069Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8969,7 +8969,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.168Z",
+        "evaluatedAt": "2026-05-05T23:45:59.071Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9024,7 +9024,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.168Z",
+          "evaluatedAt": "2026-05-05T23:45:59.071Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9042,7 +9042,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.168Z",
+          "evaluatedAt": "2026-05-05T23:45:59.071Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9106,7 +9106,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.170Z",
+        "evaluatedAt": "2026-05-05T23:45:59.073Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9161,7 +9161,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.170Z",
+          "evaluatedAt": "2026-05-05T23:45:59.073Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9179,7 +9179,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.170Z",
+          "evaluatedAt": "2026-05-05T23:45:59.073Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9243,7 +9243,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.172Z",
+        "evaluatedAt": "2026-05-05T23:45:59.075Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9298,7 +9298,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.172Z",
+          "evaluatedAt": "2026-05-05T23:45:59.075Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9316,7 +9316,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.172Z",
+          "evaluatedAt": "2026-05-05T23:45:59.075Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9380,7 +9380,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.174Z",
+        "evaluatedAt": "2026-05-05T23:45:59.077Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9435,7 +9435,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.174Z",
+          "evaluatedAt": "2026-05-05T23:45:59.077Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9453,7 +9453,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.174Z",
+          "evaluatedAt": "2026-05-05T23:45:59.077Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9517,7 +9517,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.177Z",
+        "evaluatedAt": "2026-05-05T23:45:59.079Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9572,7 +9572,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.177Z",
+          "evaluatedAt": "2026-05-05T23:45:59.079Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9590,7 +9590,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.177Z",
+          "evaluatedAt": "2026-05-05T23:45:59.079Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9654,7 +9654,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.179Z",
+        "evaluatedAt": "2026-05-05T23:45:59.081Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9709,7 +9709,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.179Z",
+          "evaluatedAt": "2026-05-05T23:45:59.081Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9727,7 +9727,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.179Z",
+          "evaluatedAt": "2026-05-05T23:45:59.081Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9791,7 +9791,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.181Z",
+        "evaluatedAt": "2026-05-05T23:45:59.083Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9846,7 +9846,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.181Z",
+          "evaluatedAt": "2026-05-05T23:45:59.083Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9864,7 +9864,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.181Z",
+          "evaluatedAt": "2026-05-05T23:45:59.083Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9928,7 +9928,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.183Z",
+        "evaluatedAt": "2026-05-05T23:45:59.085Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9983,7 +9983,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.183Z",
+          "evaluatedAt": "2026-05-05T23:45:59.085Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10001,7 +10001,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.183Z",
+          "evaluatedAt": "2026-05-05T23:45:59.085Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10065,7 +10065,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.185Z",
+        "evaluatedAt": "2026-05-05T23:45:59.087Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10120,7 +10120,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.185Z",
+          "evaluatedAt": "2026-05-05T23:45:59.087Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10138,7 +10138,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.185Z",
+          "evaluatedAt": "2026-05-05T23:45:59.087Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10202,7 +10202,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.187Z",
+        "evaluatedAt": "2026-05-05T23:45:59.089Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10257,7 +10257,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.187Z",
+          "evaluatedAt": "2026-05-05T23:45:59.089Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10275,7 +10275,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.187Z",
+          "evaluatedAt": "2026-05-05T23:45:59.089Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10339,7 +10339,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T22:42:51.189Z",
+        "evaluatedAt": "2026-05-05T23:45:59.091Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10394,7 +10394,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.189Z",
+          "evaluatedAt": "2026-05-05T23:45:59.091Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10412,7 +10412,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T22:42:51.189Z",
+          "evaluatedAt": "2026-05-05T23:45:59.091Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/affaan-m_everything-claude-code.json
+++ b/data/skill-index/affaan-m_everything-claude-code.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/affaan-m/everything-claude-code.git",
   "owner": "affaan-m",
   "repo": "everything-claude-code",
-  "updatedAt": "2026-04-30T23:04:54.136Z",
+  "updatedAt": "2026-05-05T23:45:07.707Z",
   "skillCount": 455,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.372Z",
+        "evaluatedAt": "2026-05-05T23:45:06.988Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.372Z",
+          "evaluatedAt": "2026-05-05T23:45:06.988Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.372Z",
+          "evaluatedAt": "2026-05-05T23:45:06.988Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.374Z",
+        "evaluatedAt": "2026-05-05T23:45:06.990Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.374Z",
+          "evaluatedAt": "2026-05-05T23:45:06.990Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.374Z",
+          "evaluatedAt": "2026-05-05T23:45:06.990Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.375Z",
+        "evaluatedAt": "2026-05-05T23:45:06.991Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.375Z",
+          "evaluatedAt": "2026-05-05T23:45:06.991Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.375Z",
+          "evaluatedAt": "2026-05-05T23:45:06.991Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.376Z",
+        "evaluatedAt": "2026-05-05T23:45:06.992Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.376Z",
+          "evaluatedAt": "2026-05-05T23:45:06.992Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.376Z",
+          "evaluatedAt": "2026-05-05T23:45:06.992Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.377Z",
+        "evaluatedAt": "2026-05-05T23:45:06.992Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.377Z",
+          "evaluatedAt": "2026-05-05T23:45:06.992Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.377Z",
+          "evaluatedAt": "2026-05-05T23:45:06.992Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.378Z",
+        "evaluatedAt": "2026-05-05T23:45:06.993Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.378Z",
+          "evaluatedAt": "2026-05-05T23:45:06.993Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.378Z",
+          "evaluatedAt": "2026-05-05T23:45:06.993Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.380Z",
+        "evaluatedAt": "2026-05-05T23:45:06.995Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.380Z",
+          "evaluatedAt": "2026-05-05T23:45:06.995Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.380Z",
+          "evaluatedAt": "2026-05-05T23:45:06.995Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.382Z",
+        "evaluatedAt": "2026-05-05T23:45:06.996Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.382Z",
+          "evaluatedAt": "2026-05-05T23:45:06.996Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.382Z",
+          "evaluatedAt": "2026-05-05T23:45:06.996Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.383Z",
+        "evaluatedAt": "2026-05-05T23:45:06.998Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.383Z",
+          "evaluatedAt": "2026-05-05T23:45:06.998Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.383Z",
+          "evaluatedAt": "2026-05-05T23:45:06.998Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.384Z",
+        "evaluatedAt": "2026-05-05T23:45:06.999Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.384Z",
+          "evaluatedAt": "2026-05-05T23:45:06.999Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.384Z",
+          "evaluatedAt": "2026-05-05T23:45:06.999Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.386Z",
+        "evaluatedAt": "2026-05-05T23:45:07.001Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.386Z",
+          "evaluatedAt": "2026-05-05T23:45:07.001Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.386Z",
+          "evaluatedAt": "2026-05-05T23:45:07.001Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.387Z",
+        "evaluatedAt": "2026-05-05T23:45:07.002Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.387Z",
+          "evaluatedAt": "2026-05-05T23:45:07.002Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.387Z",
+          "evaluatedAt": "2026-05-05T23:45:07.002Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.388Z",
+        "evaluatedAt": "2026-05-05T23:45:07.003Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.388Z",
+          "evaluatedAt": "2026-05-05T23:45:07.003Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.388Z",
+          "evaluatedAt": "2026-05-05T23:45:07.003Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.388Z",
+        "evaluatedAt": "2026-05-05T23:45:07.003Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.388Z",
+          "evaluatedAt": "2026-05-05T23:45:07.003Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.388Z",
+          "evaluatedAt": "2026-05-05T23:45:07.003Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.389Z",
+        "evaluatedAt": "2026-05-05T23:45:07.004Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.389Z",
+          "evaluatedAt": "2026-05-05T23:45:07.004Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.389Z",
+          "evaluatedAt": "2026-05-05T23:45:07.004Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.391Z",
+        "evaluatedAt": "2026-05-05T23:45:07.005Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.391Z",
+          "evaluatedAt": "2026-05-05T23:45:07.005Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.391Z",
+          "evaluatedAt": "2026-05-05T23:45:07.005Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.393Z",
+        "evaluatedAt": "2026-05-05T23:45:07.007Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.393Z",
+          "evaluatedAt": "2026-05-05T23:45:07.007Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.393Z",
+          "evaluatedAt": "2026-05-05T23:45:07.007Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.395Z",
+        "evaluatedAt": "2026-05-05T23:45:07.009Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.395Z",
+          "evaluatedAt": "2026-05-05T23:45:07.009Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.395Z",
+          "evaluatedAt": "2026-05-05T23:45:07.009Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.396Z",
+        "evaluatedAt": "2026-05-05T23:45:07.011Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.396Z",
+          "evaluatedAt": "2026-05-05T23:45:07.011Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.396Z",
+          "evaluatedAt": "2026-05-05T23:45:07.011Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.398Z",
+        "evaluatedAt": "2026-05-05T23:45:07.012Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.398Z",
+          "evaluatedAt": "2026-05-05T23:45:07.012Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.398Z",
+          "evaluatedAt": "2026-05-05T23:45:07.012Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.399Z",
+        "evaluatedAt": "2026-05-05T23:45:07.014Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.399Z",
+          "evaluatedAt": "2026-05-05T23:45:07.014Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.399Z",
+          "evaluatedAt": "2026-05-05T23:45:07.014Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.402Z",
+        "evaluatedAt": "2026-05-05T23:45:07.017Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.402Z",
+          "evaluatedAt": "2026-05-05T23:45:07.017Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.402Z",
+          "evaluatedAt": "2026-05-05T23:45:07.017Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3078,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.405Z",
+        "evaluatedAt": "2026-05-05T23:45:07.019Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3133,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.405Z",
+          "evaluatedAt": "2026-05-05T23:45:07.019Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3151,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.405Z",
+          "evaluatedAt": "2026-05-05T23:45:07.019Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3215,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.407Z",
+        "evaluatedAt": "2026-05-05T23:45:07.021Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3270,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.407Z",
+          "evaluatedAt": "2026-05-05T23:45:07.021Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3288,7 +3288,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.407Z",
+          "evaluatedAt": "2026-05-05T23:45:07.021Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3352,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.410Z",
+        "evaluatedAt": "2026-05-05T23:45:07.024Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3407,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.410Z",
+          "evaluatedAt": "2026-05-05T23:45:07.024Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3425,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.410Z",
+          "evaluatedAt": "2026-05-05T23:45:07.024Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3489,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.411Z",
+        "evaluatedAt": "2026-05-05T23:45:07.025Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3544,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.411Z",
+          "evaluatedAt": "2026-05-05T23:45:07.025Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3562,7 +3562,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.411Z",
+          "evaluatedAt": "2026-05-05T23:45:07.025Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3626,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.413Z",
+        "evaluatedAt": "2026-05-05T23:45:07.027Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3681,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.413Z",
+          "evaluatedAt": "2026-05-05T23:45:07.027Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3699,7 +3699,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.413Z",
+          "evaluatedAt": "2026-05-05T23:45:07.027Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3763,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.414Z",
+        "evaluatedAt": "2026-05-05T23:45:07.028Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3818,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.414Z",
+          "evaluatedAt": "2026-05-05T23:45:07.028Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3836,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.414Z",
+          "evaluatedAt": "2026-05-05T23:45:07.028Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3900,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.415Z",
+        "evaluatedAt": "2026-05-05T23:45:07.029Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3955,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.415Z",
+          "evaluatedAt": "2026-05-05T23:45:07.029Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3973,7 +3973,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.415Z",
+          "evaluatedAt": "2026-05-05T23:45:07.029Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4037,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.415Z",
+        "evaluatedAt": "2026-05-05T23:45:07.029Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4092,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.415Z",
+          "evaluatedAt": "2026-05-05T23:45:07.029Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4110,7 +4110,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.415Z",
+          "evaluatedAt": "2026-05-05T23:45:07.029Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4174,7 +4174,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.416Z",
+        "evaluatedAt": "2026-05-05T23:45:07.030Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4229,7 +4229,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.416Z",
+          "evaluatedAt": "2026-05-05T23:45:07.030Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4247,7 +4247,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.416Z",
+          "evaluatedAt": "2026-05-05T23:45:07.030Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4311,7 +4311,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.417Z",
+        "evaluatedAt": "2026-05-05T23:45:07.031Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4366,7 +4366,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.417Z",
+          "evaluatedAt": "2026-05-05T23:45:07.031Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4384,7 +4384,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.417Z",
+          "evaluatedAt": "2026-05-05T23:45:07.031Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4448,7 +4448,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.418Z",
+        "evaluatedAt": "2026-05-05T23:45:07.032Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4503,7 +4503,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.418Z",
+          "evaluatedAt": "2026-05-05T23:45:07.032Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4521,7 +4521,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.418Z",
+          "evaluatedAt": "2026-05-05T23:45:07.032Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4585,7 +4585,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.421Z",
+        "evaluatedAt": "2026-05-05T23:45:07.035Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4640,7 +4640,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.421Z",
+          "evaluatedAt": "2026-05-05T23:45:07.035Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4658,7 +4658,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.421Z",
+          "evaluatedAt": "2026-05-05T23:45:07.035Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4722,7 +4722,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.424Z",
+        "evaluatedAt": "2026-05-05T23:45:07.038Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4777,7 +4777,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.424Z",
+          "evaluatedAt": "2026-05-05T23:45:07.038Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4795,7 +4795,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.424Z",
+          "evaluatedAt": "2026-05-05T23:45:07.038Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4859,7 +4859,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.427Z",
+        "evaluatedAt": "2026-05-05T23:45:07.041Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4914,7 +4914,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.427Z",
+          "evaluatedAt": "2026-05-05T23:45:07.041Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4932,7 +4932,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.427Z",
+          "evaluatedAt": "2026-05-05T23:45:07.041Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4996,7 +4996,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.429Z",
+        "evaluatedAt": "2026-05-05T23:45:07.043Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5051,7 +5051,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.429Z",
+          "evaluatedAt": "2026-05-05T23:45:07.043Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5069,7 +5069,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.429Z",
+          "evaluatedAt": "2026-05-05T23:45:07.043Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5133,7 +5133,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.432Z",
+        "evaluatedAt": "2026-05-05T23:45:07.045Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5188,7 +5188,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.432Z",
+          "evaluatedAt": "2026-05-05T23:45:07.045Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5206,7 +5206,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.432Z",
+          "evaluatedAt": "2026-05-05T23:45:07.045Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5270,7 +5270,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.434Z",
+        "evaluatedAt": "2026-05-05T23:45:07.048Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5325,7 +5325,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.434Z",
+          "evaluatedAt": "2026-05-05T23:45:07.048Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5343,7 +5343,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.434Z",
+          "evaluatedAt": "2026-05-05T23:45:07.048Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5407,7 +5407,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.437Z",
+        "evaluatedAt": "2026-05-05T23:45:07.050Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5462,7 +5462,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.437Z",
+          "evaluatedAt": "2026-05-05T23:45:07.050Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5480,7 +5480,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.437Z",
+          "evaluatedAt": "2026-05-05T23:45:07.050Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5544,7 +5544,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.440Z",
+        "evaluatedAt": "2026-05-05T23:45:07.052Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5599,7 +5599,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.440Z",
+          "evaluatedAt": "2026-05-05T23:45:07.052Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5617,7 +5617,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.440Z",
+          "evaluatedAt": "2026-05-05T23:45:07.052Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5681,7 +5681,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.443Z",
+        "evaluatedAt": "2026-05-05T23:45:07.055Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5736,7 +5736,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.443Z",
+          "evaluatedAt": "2026-05-05T23:45:07.055Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5754,7 +5754,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.443Z",
+          "evaluatedAt": "2026-05-05T23:45:07.055Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5818,7 +5818,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.445Z",
+        "evaluatedAt": "2026-05-05T23:45:07.057Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5873,7 +5873,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.445Z",
+          "evaluatedAt": "2026-05-05T23:45:07.057Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5891,7 +5891,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.445Z",
+          "evaluatedAt": "2026-05-05T23:45:07.057Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5955,7 +5955,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.447Z",
+        "evaluatedAt": "2026-05-05T23:45:07.058Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6010,7 +6010,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.447Z",
+          "evaluatedAt": "2026-05-05T23:45:07.058Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6028,7 +6028,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.447Z",
+          "evaluatedAt": "2026-05-05T23:45:07.058Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6092,7 +6092,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.448Z",
+        "evaluatedAt": "2026-05-05T23:45:07.059Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6147,7 +6147,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.448Z",
+          "evaluatedAt": "2026-05-05T23:45:07.059Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6165,7 +6165,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.448Z",
+          "evaluatedAt": "2026-05-05T23:45:07.059Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6229,7 +6229,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.449Z",
+        "evaluatedAt": "2026-05-05T23:45:07.060Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6284,7 +6284,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.449Z",
+          "evaluatedAt": "2026-05-05T23:45:07.061Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6302,7 +6302,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.449Z",
+          "evaluatedAt": "2026-05-05T23:45:07.061Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6366,7 +6366,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.450Z",
+        "evaluatedAt": "2026-05-05T23:45:07.062Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6421,7 +6421,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.450Z",
+          "evaluatedAt": "2026-05-05T23:45:07.062Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6439,7 +6439,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.450Z",
+          "evaluatedAt": "2026-05-05T23:45:07.062Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6503,7 +6503,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.451Z",
+        "evaluatedAt": "2026-05-05T23:45:07.063Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6558,7 +6558,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.451Z",
+          "evaluatedAt": "2026-05-05T23:45:07.063Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6576,7 +6576,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.451Z",
+          "evaluatedAt": "2026-05-05T23:45:07.063Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6640,7 +6640,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.452Z",
+        "evaluatedAt": "2026-05-05T23:45:07.063Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6695,7 +6695,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.452Z",
+          "evaluatedAt": "2026-05-05T23:45:07.063Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6713,7 +6713,7 @@
               "max": 1
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.452Z",
+          "evaluatedAt": "2026-05-05T23:45:07.063Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6777,7 +6777,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.453Z",
+        "evaluatedAt": "2026-05-05T23:45:07.064Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6832,7 +6832,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.453Z",
+          "evaluatedAt": "2026-05-05T23:45:07.064Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6850,7 +6850,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.453Z",
+          "evaluatedAt": "2026-05-05T23:45:07.064Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6914,7 +6914,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.454Z",
+        "evaluatedAt": "2026-05-05T23:45:07.065Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6969,7 +6969,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.454Z",
+          "evaluatedAt": "2026-05-05T23:45:07.065Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6987,7 +6987,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.454Z",
+          "evaluatedAt": "2026-05-05T23:45:07.065Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7051,7 +7051,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.454Z",
+        "evaluatedAt": "2026-05-05T23:45:07.066Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7106,7 +7106,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.455Z",
+          "evaluatedAt": "2026-05-05T23:45:07.066Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7124,7 +7124,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.455Z",
+          "evaluatedAt": "2026-05-05T23:45:07.066Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7188,7 +7188,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.455Z",
+        "evaluatedAt": "2026-05-05T23:45:07.067Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7243,7 +7243,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.455Z",
+          "evaluatedAt": "2026-05-05T23:45:07.067Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7261,7 +7261,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.455Z",
+          "evaluatedAt": "2026-05-05T23:45:07.067Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7325,7 +7325,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.456Z",
+        "evaluatedAt": "2026-05-05T23:45:07.067Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7380,7 +7380,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.456Z",
+          "evaluatedAt": "2026-05-05T23:45:07.067Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7398,7 +7398,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.456Z",
+          "evaluatedAt": "2026-05-05T23:45:07.067Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7462,7 +7462,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.457Z",
+        "evaluatedAt": "2026-05-05T23:45:07.068Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7517,7 +7517,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.457Z",
+          "evaluatedAt": "2026-05-05T23:45:07.068Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7535,7 +7535,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.457Z",
+          "evaluatedAt": "2026-05-05T23:45:07.068Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7599,7 +7599,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.458Z",
+        "evaluatedAt": "2026-05-05T23:45:07.069Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -7654,7 +7654,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.458Z",
+          "evaluatedAt": "2026-05-05T23:45:07.069Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -7672,7 +7672,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.458Z",
+          "evaluatedAt": "2026-05-05T23:45:07.069Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -7736,7 +7736,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.461Z",
+        "evaluatedAt": "2026-05-05T23:45:07.072Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -7791,7 +7791,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.461Z",
+          "evaluatedAt": "2026-05-05T23:45:07.072Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -7809,7 +7809,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.461Z",
+          "evaluatedAt": "2026-05-05T23:45:07.072Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -7873,7 +7873,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.464Z",
+        "evaluatedAt": "2026-05-05T23:45:07.074Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -7928,7 +7928,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.464Z",
+          "evaluatedAt": "2026-05-05T23:45:07.074Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -7946,7 +7946,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.464Z",
+          "evaluatedAt": "2026-05-05T23:45:07.074Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -8010,7 +8010,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.465Z",
+        "evaluatedAt": "2026-05-05T23:45:07.075Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8065,7 +8065,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.465Z",
+          "evaluatedAt": "2026-05-05T23:45:07.075Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8083,7 +8083,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.465Z",
+          "evaluatedAt": "2026-05-05T23:45:07.075Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8147,7 +8147,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.466Z",
+        "evaluatedAt": "2026-05-05T23:45:07.076Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8202,7 +8202,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.466Z",
+          "evaluatedAt": "2026-05-05T23:45:07.076Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8220,7 +8220,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.466Z",
+          "evaluatedAt": "2026-05-05T23:45:07.076Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8284,7 +8284,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.467Z",
+        "evaluatedAt": "2026-05-05T23:45:07.078Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8339,7 +8339,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.467Z",
+          "evaluatedAt": "2026-05-05T23:45:07.078Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8357,7 +8357,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.467Z",
+          "evaluatedAt": "2026-05-05T23:45:07.078Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8421,7 +8421,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.469Z",
+        "evaluatedAt": "2026-05-05T23:45:07.079Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8476,7 +8476,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.469Z",
+          "evaluatedAt": "2026-05-05T23:45:07.079Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8494,7 +8494,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.469Z",
+          "evaluatedAt": "2026-05-05T23:45:07.079Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8558,7 +8558,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.471Z",
+        "evaluatedAt": "2026-05-05T23:45:07.082Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8613,7 +8613,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.471Z",
+          "evaluatedAt": "2026-05-05T23:45:07.082Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8631,7 +8631,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.471Z",
+          "evaluatedAt": "2026-05-05T23:45:07.082Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8695,7 +8695,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.473Z",
+        "evaluatedAt": "2026-05-05T23:45:07.084Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8750,7 +8750,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.473Z",
+          "evaluatedAt": "2026-05-05T23:45:07.084Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8768,7 +8768,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.473Z",
+          "evaluatedAt": "2026-05-05T23:45:07.084Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8832,7 +8832,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.475Z",
+        "evaluatedAt": "2026-05-05T23:45:07.086Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8887,7 +8887,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.475Z",
+          "evaluatedAt": "2026-05-05T23:45:07.086Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8905,7 +8905,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.475Z",
+          "evaluatedAt": "2026-05-05T23:45:07.086Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8969,7 +8969,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.477Z",
+        "evaluatedAt": "2026-05-05T23:45:07.088Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9024,7 +9024,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.477Z",
+          "evaluatedAt": "2026-05-05T23:45:07.088Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9042,7 +9042,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.477Z",
+          "evaluatedAt": "2026-05-05T23:45:07.088Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9106,7 +9106,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.478Z",
+        "evaluatedAt": "2026-05-05T23:45:07.089Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9161,7 +9161,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.478Z",
+          "evaluatedAt": "2026-05-05T23:45:07.089Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9179,7 +9179,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.478Z",
+          "evaluatedAt": "2026-05-05T23:45:07.089Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9243,7 +9243,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.480Z",
+        "evaluatedAt": "2026-05-05T23:45:07.090Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9298,7 +9298,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.480Z",
+          "evaluatedAt": "2026-05-05T23:45:07.090Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9316,7 +9316,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.480Z",
+          "evaluatedAt": "2026-05-05T23:45:07.090Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9380,7 +9380,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.481Z",
+        "evaluatedAt": "2026-05-05T23:45:07.092Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9435,7 +9435,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.481Z",
+          "evaluatedAt": "2026-05-05T23:45:07.092Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9453,7 +9453,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.481Z",
+          "evaluatedAt": "2026-05-05T23:45:07.092Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9517,7 +9517,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.483Z",
+        "evaluatedAt": "2026-05-05T23:45:07.094Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9572,7 +9572,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.483Z",
+          "evaluatedAt": "2026-05-05T23:45:07.094Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9590,7 +9590,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.483Z",
+          "evaluatedAt": "2026-05-05T23:45:07.094Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9654,7 +9654,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.485Z",
+        "evaluatedAt": "2026-05-05T23:45:07.096Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9709,7 +9709,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.485Z",
+          "evaluatedAt": "2026-05-05T23:45:07.096Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9727,7 +9727,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.485Z",
+          "evaluatedAt": "2026-05-05T23:45:07.096Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9791,7 +9791,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.487Z",
+        "evaluatedAt": "2026-05-05T23:45:07.098Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9846,7 +9846,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.487Z",
+          "evaluatedAt": "2026-05-05T23:45:07.098Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9864,7 +9864,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.487Z",
+          "evaluatedAt": "2026-05-05T23:45:07.098Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9928,7 +9928,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.489Z",
+        "evaluatedAt": "2026-05-05T23:45:07.100Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9983,7 +9983,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.489Z",
+          "evaluatedAt": "2026-05-05T23:45:07.100Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10001,7 +10001,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.489Z",
+          "evaluatedAt": "2026-05-05T23:45:07.100Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10065,7 +10065,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.492Z",
+        "evaluatedAt": "2026-05-05T23:45:07.102Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10120,7 +10120,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.492Z",
+          "evaluatedAt": "2026-05-05T23:45:07.103Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10138,7 +10138,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.492Z",
+          "evaluatedAt": "2026-05-05T23:45:07.103Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10202,7 +10202,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.494Z",
+        "evaluatedAt": "2026-05-05T23:45:07.105Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10257,7 +10257,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.494Z",
+          "evaluatedAt": "2026-05-05T23:45:07.105Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10275,7 +10275,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.494Z",
+          "evaluatedAt": "2026-05-05T23:45:07.105Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10339,7 +10339,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.496Z",
+        "evaluatedAt": "2026-05-05T23:45:07.107Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10394,7 +10394,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.496Z",
+          "evaluatedAt": "2026-05-05T23:45:07.107Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10412,7 +10412,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.496Z",
+          "evaluatedAt": "2026-05-05T23:45:07.107Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10476,7 +10476,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.498Z",
+        "evaluatedAt": "2026-05-05T23:45:07.109Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10531,7 +10531,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.498Z",
+          "evaluatedAt": "2026-05-05T23:45:07.109Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10549,7 +10549,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.498Z",
+          "evaluatedAt": "2026-05-05T23:45:07.109Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10613,7 +10613,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.500Z",
+        "evaluatedAt": "2026-05-05T23:45:07.111Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10668,7 +10668,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.500Z",
+          "evaluatedAt": "2026-05-05T23:45:07.111Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10686,7 +10686,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.500Z",
+          "evaluatedAt": "2026-05-05T23:45:07.111Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10750,7 +10750,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.502Z",
+        "evaluatedAt": "2026-05-05T23:45:07.113Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10805,7 +10805,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.502Z",
+          "evaluatedAt": "2026-05-05T23:45:07.113Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10823,7 +10823,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.502Z",
+          "evaluatedAt": "2026-05-05T23:45:07.113Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10887,7 +10887,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.504Z",
+        "evaluatedAt": "2026-05-05T23:45:07.114Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10942,7 +10942,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.504Z",
+          "evaluatedAt": "2026-05-05T23:45:07.114Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10960,7 +10960,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.504Z",
+          "evaluatedAt": "2026-05-05T23:45:07.114Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11024,7 +11024,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.506Z",
+        "evaluatedAt": "2026-05-05T23:45:07.116Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11079,7 +11079,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.506Z",
+          "evaluatedAt": "2026-05-05T23:45:07.116Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11097,7 +11097,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.506Z",
+          "evaluatedAt": "2026-05-05T23:45:07.116Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11161,7 +11161,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.509Z",
+        "evaluatedAt": "2026-05-05T23:45:07.118Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11216,7 +11216,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.509Z",
+          "evaluatedAt": "2026-05-05T23:45:07.118Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11234,7 +11234,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.509Z",
+          "evaluatedAt": "2026-05-05T23:45:07.118Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11298,7 +11298,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.511Z",
+        "evaluatedAt": "2026-05-05T23:45:07.121Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11353,7 +11353,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.511Z",
+          "evaluatedAt": "2026-05-05T23:45:07.121Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11371,7 +11371,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.511Z",
+          "evaluatedAt": "2026-05-05T23:45:07.121Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11435,7 +11435,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.512Z",
+        "evaluatedAt": "2026-05-05T23:45:07.122Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11490,7 +11490,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.512Z",
+          "evaluatedAt": "2026-05-05T23:45:07.122Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11508,7 +11508,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.512Z",
+          "evaluatedAt": "2026-05-05T23:45:07.122Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11572,7 +11572,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.513Z",
+        "evaluatedAt": "2026-05-05T23:45:07.123Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11627,7 +11627,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.513Z",
+          "evaluatedAt": "2026-05-05T23:45:07.123Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11645,7 +11645,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.513Z",
+          "evaluatedAt": "2026-05-05T23:45:07.123Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11709,7 +11709,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.514Z",
+        "evaluatedAt": "2026-05-05T23:45:07.124Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11764,7 +11764,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.514Z",
+          "evaluatedAt": "2026-05-05T23:45:07.124Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11782,7 +11782,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.514Z",
+          "evaluatedAt": "2026-05-05T23:45:07.124Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11846,7 +11846,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.515Z",
+        "evaluatedAt": "2026-05-05T23:45:07.125Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11901,7 +11901,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.515Z",
+          "evaluatedAt": "2026-05-05T23:45:07.125Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11919,7 +11919,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.515Z",
+          "evaluatedAt": "2026-05-05T23:45:07.125Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11983,7 +11983,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.516Z",
+        "evaluatedAt": "2026-05-05T23:45:07.126Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12038,7 +12038,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.516Z",
+          "evaluatedAt": "2026-05-05T23:45:07.126Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12056,7 +12056,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.516Z",
+          "evaluatedAt": "2026-05-05T23:45:07.126Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12120,7 +12120,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.517Z",
+        "evaluatedAt": "2026-05-05T23:45:07.127Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12175,7 +12175,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.517Z",
+          "evaluatedAt": "2026-05-05T23:45:07.127Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12193,7 +12193,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.517Z",
+          "evaluatedAt": "2026-05-05T23:45:07.127Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12257,7 +12257,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.518Z",
+        "evaluatedAt": "2026-05-05T23:45:07.128Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12312,7 +12312,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.518Z",
+          "evaluatedAt": "2026-05-05T23:45:07.128Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12330,7 +12330,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.518Z",
+          "evaluatedAt": "2026-05-05T23:45:07.128Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12394,7 +12394,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.519Z",
+        "evaluatedAt": "2026-05-05T23:45:07.129Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12449,7 +12449,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.519Z",
+          "evaluatedAt": "2026-05-05T23:45:07.129Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12467,7 +12467,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.519Z",
+          "evaluatedAt": "2026-05-05T23:45:07.129Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12531,7 +12531,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.520Z",
+        "evaluatedAt": "2026-05-05T23:45:07.130Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12586,7 +12586,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.520Z",
+          "evaluatedAt": "2026-05-05T23:45:07.130Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12604,7 +12604,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.520Z",
+          "evaluatedAt": "2026-05-05T23:45:07.130Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12668,7 +12668,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.520Z",
+        "evaluatedAt": "2026-05-05T23:45:07.131Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12723,7 +12723,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.520Z",
+          "evaluatedAt": "2026-05-05T23:45:07.131Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12741,7 +12741,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.520Z",
+          "evaluatedAt": "2026-05-05T23:45:07.131Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12805,7 +12805,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.521Z",
+        "evaluatedAt": "2026-05-05T23:45:07.131Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12860,7 +12860,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.521Z",
+          "evaluatedAt": "2026-05-05T23:45:07.131Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12878,7 +12878,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.521Z",
+          "evaluatedAt": "2026-05-05T23:45:07.131Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12942,7 +12942,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.522Z",
+        "evaluatedAt": "2026-05-05T23:45:07.132Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12997,7 +12997,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.522Z",
+          "evaluatedAt": "2026-05-05T23:45:07.132Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13015,7 +13015,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.522Z",
+          "evaluatedAt": "2026-05-05T23:45:07.132Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13079,7 +13079,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.523Z",
+        "evaluatedAt": "2026-05-05T23:45:07.133Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13134,7 +13134,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.523Z",
+          "evaluatedAt": "2026-05-05T23:45:07.133Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13152,7 +13152,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.523Z",
+          "evaluatedAt": "2026-05-05T23:45:07.133Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13216,7 +13216,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.524Z",
+        "evaluatedAt": "2026-05-05T23:45:07.134Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13271,7 +13271,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.524Z",
+          "evaluatedAt": "2026-05-05T23:45:07.134Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13289,7 +13289,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.524Z",
+          "evaluatedAt": "2026-05-05T23:45:07.134Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13353,7 +13353,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.525Z",
+        "evaluatedAt": "2026-05-05T23:45:07.135Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13408,7 +13408,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.525Z",
+          "evaluatedAt": "2026-05-05T23:45:07.135Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13426,7 +13426,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.525Z",
+          "evaluatedAt": "2026-05-05T23:45:07.135Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13490,7 +13490,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.526Z",
+        "evaluatedAt": "2026-05-05T23:45:07.135Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13545,7 +13545,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.526Z",
+          "evaluatedAt": "2026-05-05T23:45:07.135Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13563,7 +13563,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.526Z",
+          "evaluatedAt": "2026-05-05T23:45:07.135Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13627,7 +13627,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.527Z",
+        "evaluatedAt": "2026-05-05T23:45:07.136Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -13682,7 +13682,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.527Z",
+          "evaluatedAt": "2026-05-05T23:45:07.136Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -13700,7 +13700,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.527Z",
+          "evaluatedAt": "2026-05-05T23:45:07.137Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -13764,7 +13764,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.528Z",
+        "evaluatedAt": "2026-05-05T23:45:07.138Z",
         "evaluatedVersion": "2.1.0"
       },
       "evalSummaries": {
@@ -13819,7 +13819,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.528Z",
+          "evaluatedAt": "2026-05-05T23:45:07.138Z",
           "evaluatedVersion": "2.1.0"
         },
         "skill-best-practice": {
@@ -13837,7 +13837,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.528Z",
+          "evaluatedAt": "2026-05-05T23:45:07.138Z",
           "evaluatedVersion": "2.1.0"
         }
       }
@@ -13901,7 +13901,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.531Z",
+        "evaluatedAt": "2026-05-05T23:45:07.140Z",
         "evaluatedVersion": "2.1.0"
       },
       "evalSummaries": {
@@ -13956,7 +13956,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.531Z",
+          "evaluatedAt": "2026-05-05T23:45:07.140Z",
           "evaluatedVersion": "2.1.0"
         },
         "skill-best-practice": {
@@ -13974,7 +13974,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.531Z",
+          "evaluatedAt": "2026-05-05T23:45:07.140Z",
           "evaluatedVersion": "2.1.0"
         }
       }
@@ -14038,7 +14038,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.533Z",
+        "evaluatedAt": "2026-05-05T23:45:07.142Z",
         "evaluatedVersion": "2.1.0"
       },
       "evalSummaries": {
@@ -14093,7 +14093,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.533Z",
+          "evaluatedAt": "2026-05-05T23:45:07.142Z",
           "evaluatedVersion": "2.1.0"
         },
         "skill-best-practice": {
@@ -14111,7 +14111,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.533Z",
+          "evaluatedAt": "2026-05-05T23:45:07.142Z",
           "evaluatedVersion": "2.1.0"
         }
       }
@@ -14175,7 +14175,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.534Z",
+        "evaluatedAt": "2026-05-05T23:45:07.143Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -14230,7 +14230,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.534Z",
+          "evaluatedAt": "2026-05-05T23:45:07.144Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -14248,7 +14248,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.534Z",
+          "evaluatedAt": "2026-05-05T23:45:07.144Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -14312,7 +14312,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.536Z",
+        "evaluatedAt": "2026-05-05T23:45:07.145Z",
         "evaluatedVersion": "2.1.0"
       },
       "evalSummaries": {
@@ -14367,7 +14367,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.536Z",
+          "evaluatedAt": "2026-05-05T23:45:07.145Z",
           "evaluatedVersion": "2.1.0"
         },
         "skill-best-practice": {
@@ -14385,7 +14385,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.536Z",
+          "evaluatedAt": "2026-05-05T23:45:07.145Z",
           "evaluatedVersion": "2.1.0"
         }
       }
@@ -14449,7 +14449,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.537Z",
+        "evaluatedAt": "2026-05-05T23:45:07.147Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14504,7 +14504,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.537Z",
+          "evaluatedAt": "2026-05-05T23:45:07.147Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14522,7 +14522,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.537Z",
+          "evaluatedAt": "2026-05-05T23:45:07.147Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14586,7 +14586,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.538Z",
+        "evaluatedAt": "2026-05-05T23:45:07.148Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14641,7 +14641,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.538Z",
+          "evaluatedAt": "2026-05-05T23:45:07.148Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14659,7 +14659,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.538Z",
+          "evaluatedAt": "2026-05-05T23:45:07.148Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14723,7 +14723,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.540Z",
+        "evaluatedAt": "2026-05-05T23:45:07.149Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14778,7 +14778,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.540Z",
+          "evaluatedAt": "2026-05-05T23:45:07.150Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14796,7 +14796,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.540Z",
+          "evaluatedAt": "2026-05-05T23:45:07.150Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14860,7 +14860,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.542Z",
+        "evaluatedAt": "2026-05-05T23:45:07.152Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14915,7 +14915,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.542Z",
+          "evaluatedAt": "2026-05-05T23:45:07.152Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14933,7 +14933,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.542Z",
+          "evaluatedAt": "2026-05-05T23:45:07.152Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14997,7 +14997,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.545Z",
+        "evaluatedAt": "2026-05-05T23:45:07.155Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15052,7 +15052,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.545Z",
+          "evaluatedAt": "2026-05-05T23:45:07.155Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15070,7 +15070,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.545Z",
+          "evaluatedAt": "2026-05-05T23:45:07.155Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15134,7 +15134,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.547Z",
+        "evaluatedAt": "2026-05-05T23:45:07.157Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15189,7 +15189,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.547Z",
+          "evaluatedAt": "2026-05-05T23:45:07.157Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15207,7 +15207,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.547Z",
+          "evaluatedAt": "2026-05-05T23:45:07.157Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15271,7 +15271,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.549Z",
+        "evaluatedAt": "2026-05-05T23:45:07.158Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15326,7 +15326,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.549Z",
+          "evaluatedAt": "2026-05-05T23:45:07.158Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15344,7 +15344,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.549Z",
+          "evaluatedAt": "2026-05-05T23:45:07.158Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15408,7 +15408,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.550Z",
+        "evaluatedAt": "2026-05-05T23:45:07.160Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15463,7 +15463,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.551Z",
+          "evaluatedAt": "2026-05-05T23:45:07.160Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15481,7 +15481,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.551Z",
+          "evaluatedAt": "2026-05-05T23:45:07.160Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15545,7 +15545,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.552Z",
+        "evaluatedAt": "2026-05-05T23:45:07.161Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15600,7 +15600,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.552Z",
+          "evaluatedAt": "2026-05-05T23:45:07.161Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15618,7 +15618,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.552Z",
+          "evaluatedAt": "2026-05-05T23:45:07.161Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15682,7 +15682,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.553Z",
+        "evaluatedAt": "2026-05-05T23:45:07.162Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15737,7 +15737,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.553Z",
+          "evaluatedAt": "2026-05-05T23:45:07.162Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15755,7 +15755,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.553Z",
+          "evaluatedAt": "2026-05-05T23:45:07.162Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15819,7 +15819,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.553Z",
+        "evaluatedAt": "2026-05-05T23:45:07.163Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15874,7 +15874,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.553Z",
+          "evaluatedAt": "2026-05-05T23:45:07.163Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15892,7 +15892,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.553Z",
+          "evaluatedAt": "2026-05-05T23:45:07.163Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15956,7 +15956,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.555Z",
+        "evaluatedAt": "2026-05-05T23:45:07.164Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16011,7 +16011,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.555Z",
+          "evaluatedAt": "2026-05-05T23:45:07.164Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16029,7 +16029,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.555Z",
+          "evaluatedAt": "2026-05-05T23:45:07.164Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16093,7 +16093,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.556Z",
+        "evaluatedAt": "2026-05-05T23:45:07.165Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16148,7 +16148,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.556Z",
+          "evaluatedAt": "2026-05-05T23:45:07.165Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16166,7 +16166,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.556Z",
+          "evaluatedAt": "2026-05-05T23:45:07.165Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16230,7 +16230,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.559Z",
+        "evaluatedAt": "2026-05-05T23:45:07.167Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -16285,7 +16285,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.559Z",
+          "evaluatedAt": "2026-05-05T23:45:07.167Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -16303,7 +16303,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.559Z",
+          "evaluatedAt": "2026-05-05T23:45:07.167Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -16367,7 +16367,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.562Z",
+        "evaluatedAt": "2026-05-05T23:45:07.170Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -16422,7 +16422,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.562Z",
+          "evaluatedAt": "2026-05-05T23:45:07.170Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -16440,7 +16440,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.562Z",
+          "evaluatedAt": "2026-05-05T23:45:07.171Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -16504,7 +16504,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.566Z",
+        "evaluatedAt": "2026-05-05T23:45:07.174Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16559,7 +16559,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.566Z",
+          "evaluatedAt": "2026-05-05T23:45:07.174Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16577,7 +16577,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.566Z",
+          "evaluatedAt": "2026-05-05T23:45:07.174Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16641,7 +16641,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.567Z",
+        "evaluatedAt": "2026-05-05T23:45:07.176Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -16696,7 +16696,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.567Z",
+          "evaluatedAt": "2026-05-05T23:45:07.176Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -16714,7 +16714,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.567Z",
+          "evaluatedAt": "2026-05-05T23:45:07.176Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -16778,7 +16778,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.569Z",
+        "evaluatedAt": "2026-05-05T23:45:07.178Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16833,7 +16833,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.569Z",
+          "evaluatedAt": "2026-05-05T23:45:07.178Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16851,7 +16851,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.569Z",
+          "evaluatedAt": "2026-05-05T23:45:07.178Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16915,7 +16915,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.573Z",
+        "evaluatedAt": "2026-05-05T23:45:07.181Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16970,7 +16970,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.573Z",
+          "evaluatedAt": "2026-05-05T23:45:07.181Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16988,7 +16988,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.573Z",
+          "evaluatedAt": "2026-05-05T23:45:07.181Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17052,7 +17052,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.576Z",
+        "evaluatedAt": "2026-05-05T23:45:07.184Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17107,7 +17107,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.576Z",
+          "evaluatedAt": "2026-05-05T23:45:07.184Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17125,7 +17125,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.576Z",
+          "evaluatedAt": "2026-05-05T23:45:07.184Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17189,7 +17189,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.578Z",
+        "evaluatedAt": "2026-05-05T23:45:07.186Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17244,7 +17244,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.578Z",
+          "evaluatedAt": "2026-05-05T23:45:07.186Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17262,7 +17262,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.578Z",
+          "evaluatedAt": "2026-05-05T23:45:07.186Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17326,7 +17326,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.580Z",
+        "evaluatedAt": "2026-05-05T23:45:07.188Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17381,7 +17381,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.580Z",
+          "evaluatedAt": "2026-05-05T23:45:07.188Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17399,7 +17399,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.580Z",
+          "evaluatedAt": "2026-05-05T23:45:07.188Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17463,7 +17463,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.582Z",
+        "evaluatedAt": "2026-05-05T23:45:07.190Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17518,7 +17518,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.582Z",
+          "evaluatedAt": "2026-05-05T23:45:07.190Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17536,7 +17536,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.582Z",
+          "evaluatedAt": "2026-05-05T23:45:07.190Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17600,7 +17600,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.584Z",
+        "evaluatedAt": "2026-05-05T23:45:07.191Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17655,7 +17655,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.584Z",
+          "evaluatedAt": "2026-05-05T23:45:07.191Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17673,7 +17673,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.584Z",
+          "evaluatedAt": "2026-05-05T23:45:07.191Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17737,7 +17737,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.585Z",
+        "evaluatedAt": "2026-05-05T23:45:07.192Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17792,7 +17792,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.585Z",
+          "evaluatedAt": "2026-05-05T23:45:07.192Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17810,7 +17810,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.585Z",
+          "evaluatedAt": "2026-05-05T23:45:07.192Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17874,7 +17874,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.586Z",
+        "evaluatedAt": "2026-05-05T23:45:07.193Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17929,7 +17929,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.586Z",
+          "evaluatedAt": "2026-05-05T23:45:07.193Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17947,7 +17947,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.586Z",
+          "evaluatedAt": "2026-05-05T23:45:07.193Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18011,7 +18011,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.587Z",
+        "evaluatedAt": "2026-05-05T23:45:07.194Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -18066,7 +18066,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.587Z",
+          "evaluatedAt": "2026-05-05T23:45:07.194Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -18084,7 +18084,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.587Z",
+          "evaluatedAt": "2026-05-05T23:45:07.194Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -18148,7 +18148,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.589Z",
+        "evaluatedAt": "2026-05-05T23:45:07.196Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18203,7 +18203,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.589Z",
+          "evaluatedAt": "2026-05-05T23:45:07.196Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18221,7 +18221,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.589Z",
+          "evaluatedAt": "2026-05-05T23:45:07.196Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18285,7 +18285,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.591Z",
+        "evaluatedAt": "2026-05-05T23:45:07.198Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18340,7 +18340,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.591Z",
+          "evaluatedAt": "2026-05-05T23:45:07.198Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18358,7 +18358,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.591Z",
+          "evaluatedAt": "2026-05-05T23:45:07.198Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18422,7 +18422,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.593Z",
+        "evaluatedAt": "2026-05-05T23:45:07.200Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18477,7 +18477,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.593Z",
+          "evaluatedAt": "2026-05-05T23:45:07.200Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18495,7 +18495,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.593Z",
+          "evaluatedAt": "2026-05-05T23:45:07.200Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18559,7 +18559,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.595Z",
+        "evaluatedAt": "2026-05-05T23:45:07.202Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18614,7 +18614,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.595Z",
+          "evaluatedAt": "2026-05-05T23:45:07.202Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18632,7 +18632,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.595Z",
+          "evaluatedAt": "2026-05-05T23:45:07.202Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18696,7 +18696,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.596Z",
+        "evaluatedAt": "2026-05-05T23:45:07.203Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18751,7 +18751,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.596Z",
+          "evaluatedAt": "2026-05-05T23:45:07.203Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18769,7 +18769,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.596Z",
+          "evaluatedAt": "2026-05-05T23:45:07.203Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18833,7 +18833,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.598Z",
+        "evaluatedAt": "2026-05-05T23:45:07.205Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18888,7 +18888,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.598Z",
+          "evaluatedAt": "2026-05-05T23:45:07.205Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18906,7 +18906,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.598Z",
+          "evaluatedAt": "2026-05-05T23:45:07.205Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18970,7 +18970,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.601Z",
+        "evaluatedAt": "2026-05-05T23:45:07.209Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19025,7 +19025,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.601Z",
+          "evaluatedAt": "2026-05-05T23:45:07.209Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19043,7 +19043,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.601Z",
+          "evaluatedAt": "2026-05-05T23:45:07.209Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19107,7 +19107,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.605Z",
+        "evaluatedAt": "2026-05-05T23:45:07.212Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19162,7 +19162,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.605Z",
+          "evaluatedAt": "2026-05-05T23:45:07.212Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19180,7 +19180,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.605Z",
+          "evaluatedAt": "2026-05-05T23:45:07.212Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19244,7 +19244,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.608Z",
+        "evaluatedAt": "2026-05-05T23:45:07.215Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19299,7 +19299,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.608Z",
+          "evaluatedAt": "2026-05-05T23:45:07.215Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19317,7 +19317,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.608Z",
+          "evaluatedAt": "2026-05-05T23:45:07.215Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19381,7 +19381,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.611Z",
+        "evaluatedAt": "2026-05-05T23:45:07.218Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19436,7 +19436,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.611Z",
+          "evaluatedAt": "2026-05-05T23:45:07.218Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19454,7 +19454,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.611Z",
+          "evaluatedAt": "2026-05-05T23:45:07.218Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19518,7 +19518,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.614Z",
+        "evaluatedAt": "2026-05-05T23:45:07.221Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19573,7 +19573,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.614Z",
+          "evaluatedAt": "2026-05-05T23:45:07.221Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19591,7 +19591,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.614Z",
+          "evaluatedAt": "2026-05-05T23:45:07.221Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19655,7 +19655,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.616Z",
+        "evaluatedAt": "2026-05-05T23:45:07.223Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19710,7 +19710,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.617Z",
+          "evaluatedAt": "2026-05-05T23:45:07.223Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19728,7 +19728,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.617Z",
+          "evaluatedAt": "2026-05-05T23:45:07.223Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19792,7 +19792,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.619Z",
+        "evaluatedAt": "2026-05-05T23:45:07.226Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19847,7 +19847,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.619Z",
+          "evaluatedAt": "2026-05-05T23:45:07.226Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19865,7 +19865,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.619Z",
+          "evaluatedAt": "2026-05-05T23:45:07.226Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19929,7 +19929,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.622Z",
+        "evaluatedAt": "2026-05-05T23:45:07.229Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19984,7 +19984,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.622Z",
+          "evaluatedAt": "2026-05-05T23:45:07.229Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20002,7 +20002,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.622Z",
+          "evaluatedAt": "2026-05-05T23:45:07.229Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20066,7 +20066,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.625Z",
+        "evaluatedAt": "2026-05-05T23:45:07.232Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20121,7 +20121,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.625Z",
+          "evaluatedAt": "2026-05-05T23:45:07.232Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20139,7 +20139,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.625Z",
+          "evaluatedAt": "2026-05-05T23:45:07.232Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20203,7 +20203,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.628Z",
+        "evaluatedAt": "2026-05-05T23:45:07.235Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20258,7 +20258,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.628Z",
+          "evaluatedAt": "2026-05-05T23:45:07.235Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20276,7 +20276,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.628Z",
+          "evaluatedAt": "2026-05-05T23:45:07.235Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20340,7 +20340,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.630Z",
+        "evaluatedAt": "2026-05-05T23:45:07.236Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20395,7 +20395,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.630Z",
+          "evaluatedAt": "2026-05-05T23:45:07.237Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20413,7 +20413,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.630Z",
+          "evaluatedAt": "2026-05-05T23:45:07.237Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20477,7 +20477,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.632Z",
+        "evaluatedAt": "2026-05-05T23:45:07.238Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20532,7 +20532,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.632Z",
+          "evaluatedAt": "2026-05-05T23:45:07.238Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20550,7 +20550,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.632Z",
+          "evaluatedAt": "2026-05-05T23:45:07.239Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20614,7 +20614,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.633Z",
+        "evaluatedAt": "2026-05-05T23:45:07.240Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20669,7 +20669,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.633Z",
+          "evaluatedAt": "2026-05-05T23:45:07.240Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20687,7 +20687,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.633Z",
+          "evaluatedAt": "2026-05-05T23:45:07.240Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20751,7 +20751,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.634Z",
+        "evaluatedAt": "2026-05-05T23:45:07.241Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20806,7 +20806,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.634Z",
+          "evaluatedAt": "2026-05-05T23:45:07.241Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20824,7 +20824,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.634Z",
+          "evaluatedAt": "2026-05-05T23:45:07.241Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20888,7 +20888,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.636Z",
+        "evaluatedAt": "2026-05-05T23:45:07.242Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20943,7 +20943,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.636Z",
+          "evaluatedAt": "2026-05-05T23:45:07.243Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20961,7 +20961,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.636Z",
+          "evaluatedAt": "2026-05-05T23:45:07.243Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21025,7 +21025,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.637Z",
+        "evaluatedAt": "2026-05-05T23:45:07.244Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21080,7 +21080,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.638Z",
+          "evaluatedAt": "2026-05-05T23:45:07.244Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21098,7 +21098,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.638Z",
+          "evaluatedAt": "2026-05-05T23:45:07.244Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21162,7 +21162,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.639Z",
+        "evaluatedAt": "2026-05-05T23:45:07.246Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21217,7 +21217,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.639Z",
+          "evaluatedAt": "2026-05-05T23:45:07.246Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21235,7 +21235,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.639Z",
+          "evaluatedAt": "2026-05-05T23:45:07.246Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21299,7 +21299,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.641Z",
+        "evaluatedAt": "2026-05-05T23:45:07.247Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21354,7 +21354,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.641Z",
+          "evaluatedAt": "2026-05-05T23:45:07.247Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21372,7 +21372,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.641Z",
+          "evaluatedAt": "2026-05-05T23:45:07.247Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21436,7 +21436,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.642Z",
+        "evaluatedAt": "2026-05-05T23:45:07.249Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21491,7 +21491,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.643Z",
+          "evaluatedAt": "2026-05-05T23:45:07.249Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21509,7 +21509,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.643Z",
+          "evaluatedAt": "2026-05-05T23:45:07.249Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21573,7 +21573,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.644Z",
+        "evaluatedAt": "2026-05-05T23:45:07.251Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21628,7 +21628,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.644Z",
+          "evaluatedAt": "2026-05-05T23:45:07.251Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21646,7 +21646,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.644Z",
+          "evaluatedAt": "2026-05-05T23:45:07.251Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21710,7 +21710,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.645Z",
+        "evaluatedAt": "2026-05-05T23:45:07.252Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21765,7 +21765,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.645Z",
+          "evaluatedAt": "2026-05-05T23:45:07.252Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21783,7 +21783,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.645Z",
+          "evaluatedAt": "2026-05-05T23:45:07.252Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21847,7 +21847,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.646Z",
+        "evaluatedAt": "2026-05-05T23:45:07.253Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21902,7 +21902,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.646Z",
+          "evaluatedAt": "2026-05-05T23:45:07.253Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21920,7 +21920,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.646Z",
+          "evaluatedAt": "2026-05-05T23:45:07.253Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21984,7 +21984,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.647Z",
+        "evaluatedAt": "2026-05-05T23:45:07.254Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22039,7 +22039,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.647Z",
+          "evaluatedAt": "2026-05-05T23:45:07.254Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22057,7 +22057,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.647Z",
+          "evaluatedAt": "2026-05-05T23:45:07.254Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22121,7 +22121,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.648Z",
+        "evaluatedAt": "2026-05-05T23:45:07.255Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22176,7 +22176,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.648Z",
+          "evaluatedAt": "2026-05-05T23:45:07.255Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22194,7 +22194,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.648Z",
+          "evaluatedAt": "2026-05-05T23:45:07.255Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22258,7 +22258,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.650Z",
+        "evaluatedAt": "2026-05-05T23:45:07.257Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22313,7 +22313,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.650Z",
+          "evaluatedAt": "2026-05-05T23:45:07.257Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22331,7 +22331,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.650Z",
+          "evaluatedAt": "2026-05-05T23:45:07.257Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22395,7 +22395,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.651Z",
+        "evaluatedAt": "2026-05-05T23:45:07.258Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22450,7 +22450,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.651Z",
+          "evaluatedAt": "2026-05-05T23:45:07.258Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22468,7 +22468,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.651Z",
+          "evaluatedAt": "2026-05-05T23:45:07.258Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22532,7 +22532,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.653Z",
+        "evaluatedAt": "2026-05-05T23:45:07.260Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22587,7 +22587,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.653Z",
+          "evaluatedAt": "2026-05-05T23:45:07.260Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22605,7 +22605,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.653Z",
+          "evaluatedAt": "2026-05-05T23:45:07.260Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22669,7 +22669,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.654Z",
+        "evaluatedAt": "2026-05-05T23:45:07.261Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22724,7 +22724,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.654Z",
+          "evaluatedAt": "2026-05-05T23:45:07.261Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22742,7 +22742,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.654Z",
+          "evaluatedAt": "2026-05-05T23:45:07.261Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22806,7 +22806,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.656Z",
+        "evaluatedAt": "2026-05-05T23:45:07.263Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22861,7 +22861,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.656Z",
+          "evaluatedAt": "2026-05-05T23:45:07.263Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22879,7 +22879,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.656Z",
+          "evaluatedAt": "2026-05-05T23:45:07.263Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22943,7 +22943,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.657Z",
+        "evaluatedAt": "2026-05-05T23:45:07.264Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22998,7 +22998,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.657Z",
+          "evaluatedAt": "2026-05-05T23:45:07.264Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23016,7 +23016,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.657Z",
+          "evaluatedAt": "2026-05-05T23:45:07.264Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23080,7 +23080,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.658Z",
+        "evaluatedAt": "2026-05-05T23:45:07.265Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23135,7 +23135,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.658Z",
+          "evaluatedAt": "2026-05-05T23:45:07.265Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23153,7 +23153,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.658Z",
+          "evaluatedAt": "2026-05-05T23:45:07.265Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23217,7 +23217,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.660Z",
+        "evaluatedAt": "2026-05-05T23:45:07.266Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -23272,7 +23272,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.660Z",
+          "evaluatedAt": "2026-05-05T23:45:07.266Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -23290,7 +23290,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.660Z",
+          "evaluatedAt": "2026-05-05T23:45:07.267Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -23354,7 +23354,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.663Z",
+        "evaluatedAt": "2026-05-05T23:45:07.270Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -23409,7 +23409,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.663Z",
+          "evaluatedAt": "2026-05-05T23:45:07.270Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -23427,7 +23427,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.663Z",
+          "evaluatedAt": "2026-05-05T23:45:07.270Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -23491,7 +23491,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.666Z",
+        "evaluatedAt": "2026-05-05T23:45:07.273Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23546,7 +23546,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.666Z",
+          "evaluatedAt": "2026-05-05T23:45:07.273Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23564,7 +23564,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.666Z",
+          "evaluatedAt": "2026-05-05T23:45:07.273Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23628,7 +23628,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.666Z",
+        "evaluatedAt": "2026-05-05T23:45:07.273Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23683,7 +23683,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.666Z",
+          "evaluatedAt": "2026-05-05T23:45:07.273Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23701,7 +23701,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.666Z",
+          "evaluatedAt": "2026-05-05T23:45:07.273Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23765,7 +23765,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.667Z",
+        "evaluatedAt": "2026-05-05T23:45:07.274Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23820,7 +23820,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.667Z",
+          "evaluatedAt": "2026-05-05T23:45:07.274Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23838,7 +23838,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.667Z",
+          "evaluatedAt": "2026-05-05T23:45:07.274Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23902,7 +23902,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.668Z",
+        "evaluatedAt": "2026-05-05T23:45:07.275Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23957,7 +23957,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.668Z",
+          "evaluatedAt": "2026-05-05T23:45:07.275Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23975,7 +23975,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.668Z",
+          "evaluatedAt": "2026-05-05T23:45:07.275Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24039,7 +24039,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.669Z",
+        "evaluatedAt": "2026-05-05T23:45:07.276Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24094,7 +24094,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.669Z",
+          "evaluatedAt": "2026-05-05T23:45:07.276Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24112,7 +24112,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.669Z",
+          "evaluatedAt": "2026-05-05T23:45:07.276Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24176,7 +24176,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.671Z",
+        "evaluatedAt": "2026-05-05T23:45:07.278Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24231,7 +24231,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.671Z",
+          "evaluatedAt": "2026-05-05T23:45:07.278Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24249,7 +24249,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.671Z",
+          "evaluatedAt": "2026-05-05T23:45:07.278Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24313,7 +24313,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.672Z",
+        "evaluatedAt": "2026-05-05T23:45:07.279Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24368,7 +24368,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.672Z",
+          "evaluatedAt": "2026-05-05T23:45:07.279Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24386,7 +24386,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.672Z",
+          "evaluatedAt": "2026-05-05T23:45:07.279Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24450,7 +24450,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.673Z",
+        "evaluatedAt": "2026-05-05T23:45:07.280Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24505,7 +24505,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.673Z",
+          "evaluatedAt": "2026-05-05T23:45:07.280Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24523,7 +24523,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.673Z",
+          "evaluatedAt": "2026-05-05T23:45:07.280Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24587,7 +24587,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.674Z",
+        "evaluatedAt": "2026-05-05T23:45:07.282Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24642,7 +24642,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.674Z",
+          "evaluatedAt": "2026-05-05T23:45:07.282Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24660,7 +24660,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.674Z",
+          "evaluatedAt": "2026-05-05T23:45:07.282Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24724,7 +24724,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.676Z",
+        "evaluatedAt": "2026-05-05T23:45:07.284Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24779,7 +24779,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.676Z",
+          "evaluatedAt": "2026-05-05T23:45:07.284Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24797,7 +24797,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.676Z",
+          "evaluatedAt": "2026-05-05T23:45:07.284Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24861,7 +24861,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.678Z",
+        "evaluatedAt": "2026-05-05T23:45:07.286Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24916,7 +24916,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.678Z",
+          "evaluatedAt": "2026-05-05T23:45:07.286Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24934,7 +24934,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.678Z",
+          "evaluatedAt": "2026-05-05T23:45:07.286Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24998,7 +24998,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.679Z",
+        "evaluatedAt": "2026-05-05T23:45:07.288Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -25053,7 +25053,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.679Z",
+          "evaluatedAt": "2026-05-05T23:45:07.288Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -25071,7 +25071,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.679Z",
+          "evaluatedAt": "2026-05-05T23:45:07.288Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -25135,7 +25135,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.681Z",
+        "evaluatedAt": "2026-05-05T23:45:07.288Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25190,7 +25190,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.681Z",
+          "evaluatedAt": "2026-05-05T23:45:07.289Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25208,7 +25208,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.681Z",
+          "evaluatedAt": "2026-05-05T23:45:07.289Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25272,7 +25272,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.682Z",
+        "evaluatedAt": "2026-05-05T23:45:07.289Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25327,7 +25327,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.682Z",
+          "evaluatedAt": "2026-05-05T23:45:07.289Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25345,7 +25345,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.682Z",
+          "evaluatedAt": "2026-05-05T23:45:07.289Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25409,7 +25409,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.683Z",
+        "evaluatedAt": "2026-05-05T23:45:07.290Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25464,7 +25464,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.683Z",
+          "evaluatedAt": "2026-05-05T23:45:07.290Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25482,7 +25482,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.683Z",
+          "evaluatedAt": "2026-05-05T23:45:07.290Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25546,7 +25546,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.684Z",
+        "evaluatedAt": "2026-05-05T23:45:07.291Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25601,7 +25601,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.684Z",
+          "evaluatedAt": "2026-05-05T23:45:07.292Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25619,7 +25619,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.684Z",
+          "evaluatedAt": "2026-05-05T23:45:07.292Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25683,7 +25683,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.686Z",
+        "evaluatedAt": "2026-05-05T23:45:07.293Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25738,7 +25738,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.686Z",
+          "evaluatedAt": "2026-05-05T23:45:07.293Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25756,7 +25756,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.686Z",
+          "evaluatedAt": "2026-05-05T23:45:07.293Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25820,7 +25820,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.687Z",
+        "evaluatedAt": "2026-05-05T23:45:07.294Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25875,7 +25875,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.687Z",
+          "evaluatedAt": "2026-05-05T23:45:07.294Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25893,7 +25893,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.687Z",
+          "evaluatedAt": "2026-05-05T23:45:07.294Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25957,7 +25957,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.688Z",
+        "evaluatedAt": "2026-05-05T23:45:07.295Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26012,7 +26012,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.688Z",
+          "evaluatedAt": "2026-05-05T23:45:07.295Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26030,7 +26030,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.688Z",
+          "evaluatedAt": "2026-05-05T23:45:07.295Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26094,7 +26094,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.690Z",
+        "evaluatedAt": "2026-05-05T23:45:07.297Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26149,7 +26149,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.690Z",
+          "evaluatedAt": "2026-05-05T23:45:07.297Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26167,7 +26167,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.690Z",
+          "evaluatedAt": "2026-05-05T23:45:07.297Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26231,7 +26231,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.693Z",
+        "evaluatedAt": "2026-05-05T23:45:07.300Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26286,7 +26286,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.693Z",
+          "evaluatedAt": "2026-05-05T23:45:07.300Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26304,7 +26304,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.693Z",
+          "evaluatedAt": "2026-05-05T23:45:07.300Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26368,7 +26368,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.696Z",
+        "evaluatedAt": "2026-05-05T23:45:07.302Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26423,7 +26423,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.696Z",
+          "evaluatedAt": "2026-05-05T23:45:07.302Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26441,7 +26441,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.696Z",
+          "evaluatedAt": "2026-05-05T23:45:07.302Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26505,7 +26505,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.697Z",
+        "evaluatedAt": "2026-05-05T23:45:07.304Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26560,7 +26560,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.697Z",
+          "evaluatedAt": "2026-05-05T23:45:07.304Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26578,7 +26578,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.697Z",
+          "evaluatedAt": "2026-05-05T23:45:07.304Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26642,7 +26642,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.699Z",
+        "evaluatedAt": "2026-05-05T23:45:07.306Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26697,7 +26697,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.699Z",
+          "evaluatedAt": "2026-05-05T23:45:07.306Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26715,7 +26715,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.699Z",
+          "evaluatedAt": "2026-05-05T23:45:07.306Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26779,7 +26779,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.702Z",
+        "evaluatedAt": "2026-05-05T23:45:07.308Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26834,7 +26834,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.702Z",
+          "evaluatedAt": "2026-05-05T23:45:07.308Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26852,7 +26852,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.702Z",
+          "evaluatedAt": "2026-05-05T23:45:07.308Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26916,7 +26916,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.704Z",
+        "evaluatedAt": "2026-05-05T23:45:07.311Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26971,7 +26971,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.704Z",
+          "evaluatedAt": "2026-05-05T23:45:07.311Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26989,7 +26989,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.704Z",
+          "evaluatedAt": "2026-05-05T23:45:07.311Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27053,7 +27053,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.707Z",
+        "evaluatedAt": "2026-05-05T23:45:07.314Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27108,7 +27108,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.707Z",
+          "evaluatedAt": "2026-05-05T23:45:07.314Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27126,7 +27126,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.707Z",
+          "evaluatedAt": "2026-05-05T23:45:07.314Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27190,7 +27190,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.709Z",
+        "evaluatedAt": "2026-05-05T23:45:07.316Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27245,7 +27245,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.709Z",
+          "evaluatedAt": "2026-05-05T23:45:07.316Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27263,7 +27263,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.710Z",
+          "evaluatedAt": "2026-05-05T23:45:07.316Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27327,7 +27327,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.712Z",
+        "evaluatedAt": "2026-05-05T23:45:07.319Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27382,7 +27382,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.712Z",
+          "evaluatedAt": "2026-05-05T23:45:07.319Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27400,7 +27400,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.712Z",
+          "evaluatedAt": "2026-05-05T23:45:07.319Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27464,7 +27464,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.715Z",
+        "evaluatedAt": "2026-05-05T23:45:07.321Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27519,7 +27519,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.715Z",
+          "evaluatedAt": "2026-05-05T23:45:07.321Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27537,7 +27537,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.715Z",
+          "evaluatedAt": "2026-05-05T23:45:07.321Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27601,7 +27601,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.717Z",
+        "evaluatedAt": "2026-05-05T23:45:07.324Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27656,7 +27656,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.717Z",
+          "evaluatedAt": "2026-05-05T23:45:07.324Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27674,7 +27674,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.717Z",
+          "evaluatedAt": "2026-05-05T23:45:07.324Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27738,7 +27738,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.719Z",
+        "evaluatedAt": "2026-05-05T23:45:07.325Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27793,7 +27793,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.719Z",
+          "evaluatedAt": "2026-05-05T23:45:07.325Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27811,7 +27811,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.719Z",
+          "evaluatedAt": "2026-05-05T23:45:07.325Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27875,7 +27875,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.720Z",
+        "evaluatedAt": "2026-05-05T23:45:07.326Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27930,7 +27930,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.720Z",
+          "evaluatedAt": "2026-05-05T23:45:07.326Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27948,7 +27948,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.720Z",
+          "evaluatedAt": "2026-05-05T23:45:07.326Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28012,7 +28012,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.721Z",
+        "evaluatedAt": "2026-05-05T23:45:07.327Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28067,7 +28067,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.721Z",
+          "evaluatedAt": "2026-05-05T23:45:07.327Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28085,7 +28085,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.721Z",
+          "evaluatedAt": "2026-05-05T23:45:07.327Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28149,7 +28149,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.722Z",
+        "evaluatedAt": "2026-05-05T23:45:07.329Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28204,7 +28204,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.722Z",
+          "evaluatedAt": "2026-05-05T23:45:07.329Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28222,7 +28222,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.722Z",
+          "evaluatedAt": "2026-05-05T23:45:07.329Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28286,7 +28286,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.724Z",
+        "evaluatedAt": "2026-05-05T23:45:07.330Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28341,7 +28341,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.724Z",
+          "evaluatedAt": "2026-05-05T23:45:07.330Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28359,7 +28359,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.724Z",
+          "evaluatedAt": "2026-05-05T23:45:07.330Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28423,7 +28423,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.726Z",
+        "evaluatedAt": "2026-05-05T23:45:07.332Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28478,7 +28478,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.726Z",
+          "evaluatedAt": "2026-05-05T23:45:07.332Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28496,7 +28496,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.726Z",
+          "evaluatedAt": "2026-05-05T23:45:07.332Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28560,7 +28560,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.727Z",
+        "evaluatedAt": "2026-05-05T23:45:07.334Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28615,7 +28615,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.728Z",
+          "evaluatedAt": "2026-05-05T23:45:07.334Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28633,7 +28633,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.728Z",
+          "evaluatedAt": "2026-05-05T23:45:07.334Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28697,7 +28697,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.729Z",
+        "evaluatedAt": "2026-05-05T23:45:07.335Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28752,7 +28752,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.729Z",
+          "evaluatedAt": "2026-05-05T23:45:07.335Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28770,7 +28770,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.729Z",
+          "evaluatedAt": "2026-05-05T23:45:07.335Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28834,7 +28834,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.730Z",
+        "evaluatedAt": "2026-05-05T23:45:07.336Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28889,7 +28889,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.730Z",
+          "evaluatedAt": "2026-05-05T23:45:07.337Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28907,7 +28907,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.730Z",
+          "evaluatedAt": "2026-05-05T23:45:07.337Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28971,7 +28971,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.733Z",
+        "evaluatedAt": "2026-05-05T23:45:07.339Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29026,7 +29026,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.733Z",
+          "evaluatedAt": "2026-05-05T23:45:07.339Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29044,7 +29044,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.733Z",
+          "evaluatedAt": "2026-05-05T23:45:07.339Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29108,7 +29108,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.736Z",
+        "evaluatedAt": "2026-05-05T23:45:07.342Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29163,7 +29163,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.736Z",
+          "evaluatedAt": "2026-05-05T23:45:07.342Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29181,7 +29181,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.736Z",
+          "evaluatedAt": "2026-05-05T23:45:07.342Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29245,7 +29245,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.738Z",
+        "evaluatedAt": "2026-05-05T23:45:07.344Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29300,7 +29300,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.738Z",
+          "evaluatedAt": "2026-05-05T23:45:07.344Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29318,7 +29318,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.738Z",
+          "evaluatedAt": "2026-05-05T23:45:07.344Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29382,7 +29382,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.741Z",
+        "evaluatedAt": "2026-05-05T23:45:07.347Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29437,7 +29437,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.741Z",
+          "evaluatedAt": "2026-05-05T23:45:07.347Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29455,7 +29455,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.741Z",
+          "evaluatedAt": "2026-05-05T23:45:07.347Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29519,7 +29519,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.743Z",
+        "evaluatedAt": "2026-05-05T23:45:07.349Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29574,7 +29574,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.743Z",
+          "evaluatedAt": "2026-05-05T23:45:07.349Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29592,7 +29592,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.743Z",
+          "evaluatedAt": "2026-05-05T23:45:07.349Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29656,7 +29656,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.746Z",
+        "evaluatedAt": "2026-05-05T23:45:07.351Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29711,7 +29711,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.746Z",
+          "evaluatedAt": "2026-05-05T23:45:07.351Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29729,7 +29729,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.746Z",
+          "evaluatedAt": "2026-05-05T23:45:07.351Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29793,7 +29793,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.748Z",
+        "evaluatedAt": "2026-05-05T23:45:07.353Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29848,7 +29848,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.748Z",
+          "evaluatedAt": "2026-05-05T23:45:07.353Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29866,7 +29866,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.748Z",
+          "evaluatedAt": "2026-05-05T23:45:07.353Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29930,7 +29930,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.750Z",
+        "evaluatedAt": "2026-05-05T23:45:07.356Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29985,7 +29985,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.750Z",
+          "evaluatedAt": "2026-05-05T23:45:07.356Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30003,7 +30003,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.750Z",
+          "evaluatedAt": "2026-05-05T23:45:07.356Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30067,7 +30067,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.753Z",
+        "evaluatedAt": "2026-05-05T23:45:07.359Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30122,7 +30122,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.753Z",
+          "evaluatedAt": "2026-05-05T23:45:07.359Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30140,7 +30140,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.753Z",
+          "evaluatedAt": "2026-05-05T23:45:07.359Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30204,7 +30204,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.756Z",
+        "evaluatedAt": "2026-05-05T23:45:07.362Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30259,7 +30259,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.756Z",
+          "evaluatedAt": "2026-05-05T23:45:07.362Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30277,7 +30277,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.756Z",
+          "evaluatedAt": "2026-05-05T23:45:07.362Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30341,7 +30341,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.759Z",
+        "evaluatedAt": "2026-05-05T23:45:07.365Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30396,7 +30396,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.759Z",
+          "evaluatedAt": "2026-05-05T23:45:07.365Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30414,7 +30414,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.759Z",
+          "evaluatedAt": "2026-05-05T23:45:07.365Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30478,7 +30478,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.762Z",
+        "evaluatedAt": "2026-05-05T23:45:07.367Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30533,7 +30533,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.762Z",
+          "evaluatedAt": "2026-05-05T23:45:07.367Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30551,7 +30551,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.762Z",
+          "evaluatedAt": "2026-05-05T23:45:07.367Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30615,7 +30615,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.765Z",
+        "evaluatedAt": "2026-05-05T23:45:07.370Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30670,7 +30670,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.765Z",
+          "evaluatedAt": "2026-05-05T23:45:07.370Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30688,7 +30688,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.765Z",
+          "evaluatedAt": "2026-05-05T23:45:07.370Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30752,7 +30752,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.767Z",
+        "evaluatedAt": "2026-05-05T23:45:07.372Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30807,7 +30807,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.767Z",
+          "evaluatedAt": "2026-05-05T23:45:07.372Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30825,7 +30825,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.767Z",
+          "evaluatedAt": "2026-05-05T23:45:07.372Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30889,7 +30889,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.768Z",
+        "evaluatedAt": "2026-05-05T23:45:07.373Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -30944,7 +30944,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.768Z",
+          "evaluatedAt": "2026-05-05T23:45:07.373Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -30962,7 +30962,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.768Z",
+          "evaluatedAt": "2026-05-05T23:45:07.373Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -31026,7 +31026,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.770Z",
+        "evaluatedAt": "2026-05-05T23:45:07.375Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -31081,7 +31081,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.770Z",
+          "evaluatedAt": "2026-05-05T23:45:07.375Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -31099,7 +31099,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.770Z",
+          "evaluatedAt": "2026-05-05T23:45:07.375Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -31163,7 +31163,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.771Z",
+        "evaluatedAt": "2026-05-05T23:45:07.376Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -31218,7 +31218,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.771Z",
+          "evaluatedAt": "2026-05-05T23:45:07.376Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -31236,7 +31236,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.771Z",
+          "evaluatedAt": "2026-05-05T23:45:07.376Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -31300,7 +31300,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.773Z",
+        "evaluatedAt": "2026-05-05T23:45:07.377Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -31355,7 +31355,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.773Z",
+          "evaluatedAt": "2026-05-05T23:45:07.377Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -31373,7 +31373,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.773Z",
+          "evaluatedAt": "2026-05-05T23:45:07.377Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -31437,7 +31437,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.774Z",
+        "evaluatedAt": "2026-05-05T23:45:07.378Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31492,7 +31492,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.774Z",
+          "evaluatedAt": "2026-05-05T23:45:07.379Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31510,7 +31510,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.774Z",
+          "evaluatedAt": "2026-05-05T23:45:07.379Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31574,7 +31574,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.775Z",
+        "evaluatedAt": "2026-05-05T23:45:07.380Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31629,7 +31629,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.775Z",
+          "evaluatedAt": "2026-05-05T23:45:07.380Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31647,7 +31647,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.775Z",
+          "evaluatedAt": "2026-05-05T23:45:07.380Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31711,7 +31711,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.776Z",
+        "evaluatedAt": "2026-05-05T23:45:07.381Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -31766,7 +31766,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.776Z",
+          "evaluatedAt": "2026-05-05T23:45:07.381Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -31784,7 +31784,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.776Z",
+          "evaluatedAt": "2026-05-05T23:45:07.381Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -31848,7 +31848,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.778Z",
+        "evaluatedAt": "2026-05-05T23:45:07.382Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31903,7 +31903,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.778Z",
+          "evaluatedAt": "2026-05-05T23:45:07.382Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31921,7 +31921,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.778Z",
+          "evaluatedAt": "2026-05-05T23:45:07.382Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31985,7 +31985,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.779Z",
+        "evaluatedAt": "2026-05-05T23:45:07.384Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -32040,7 +32040,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.779Z",
+          "evaluatedAt": "2026-05-05T23:45:07.384Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -32058,7 +32058,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.779Z",
+          "evaluatedAt": "2026-05-05T23:45:07.384Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -32122,7 +32122,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.782Z",
+        "evaluatedAt": "2026-05-05T23:45:07.386Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -32177,7 +32177,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.782Z",
+          "evaluatedAt": "2026-05-05T23:45:07.386Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -32195,7 +32195,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.782Z",
+          "evaluatedAt": "2026-05-05T23:45:07.386Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -32259,7 +32259,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.784Z",
+        "evaluatedAt": "2026-05-05T23:45:07.389Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32314,7 +32314,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.784Z",
+          "evaluatedAt": "2026-05-05T23:45:07.389Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32332,7 +32332,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.784Z",
+          "evaluatedAt": "2026-05-05T23:45:07.389Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32396,7 +32396,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.785Z",
+        "evaluatedAt": "2026-05-05T23:45:07.389Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32451,7 +32451,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.785Z",
+          "evaluatedAt": "2026-05-05T23:45:07.389Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32469,7 +32469,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.785Z",
+          "evaluatedAt": "2026-05-05T23:45:07.389Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32533,7 +32533,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.786Z",
+        "evaluatedAt": "2026-05-05T23:45:07.390Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32588,7 +32588,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.786Z",
+          "evaluatedAt": "2026-05-05T23:45:07.390Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32606,7 +32606,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.786Z",
+          "evaluatedAt": "2026-05-05T23:45:07.390Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32670,7 +32670,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.786Z",
+        "evaluatedAt": "2026-05-05T23:45:07.391Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32725,7 +32725,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.786Z",
+          "evaluatedAt": "2026-05-05T23:45:07.391Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32743,7 +32743,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.786Z",
+          "evaluatedAt": "2026-05-05T23:45:07.391Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32807,7 +32807,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.787Z",
+        "evaluatedAt": "2026-05-05T23:45:07.391Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32862,7 +32862,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.787Z",
+          "evaluatedAt": "2026-05-05T23:45:07.391Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32880,7 +32880,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.787Z",
+          "evaluatedAt": "2026-05-05T23:45:07.391Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32944,7 +32944,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.788Z",
+        "evaluatedAt": "2026-05-05T23:45:07.392Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32999,7 +32999,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.788Z",
+          "evaluatedAt": "2026-05-05T23:45:07.392Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33017,7 +33017,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.788Z",
+          "evaluatedAt": "2026-05-05T23:45:07.392Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33081,7 +33081,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.788Z",
+        "evaluatedAt": "2026-05-05T23:45:07.392Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33136,7 +33136,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.788Z",
+          "evaluatedAt": "2026-05-05T23:45:07.393Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33154,7 +33154,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.788Z",
+          "evaluatedAt": "2026-05-05T23:45:07.393Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33218,7 +33218,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.789Z",
+        "evaluatedAt": "2026-05-05T23:45:07.393Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33273,7 +33273,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.789Z",
+          "evaluatedAt": "2026-05-05T23:45:07.393Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33291,7 +33291,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.789Z",
+          "evaluatedAt": "2026-05-05T23:45:07.393Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33355,7 +33355,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.790Z",
+        "evaluatedAt": "2026-05-05T23:45:07.394Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33410,7 +33410,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.790Z",
+          "evaluatedAt": "2026-05-05T23:45:07.394Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33428,7 +33428,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.790Z",
+          "evaluatedAt": "2026-05-05T23:45:07.394Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33492,7 +33492,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.791Z",
+        "evaluatedAt": "2026-05-05T23:45:07.395Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33547,7 +33547,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.791Z",
+          "evaluatedAt": "2026-05-05T23:45:07.395Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33565,7 +33565,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.791Z",
+          "evaluatedAt": "2026-05-05T23:45:07.395Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33629,7 +33629,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.792Z",
+        "evaluatedAt": "2026-05-05T23:45:07.396Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33684,7 +33684,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.792Z",
+          "evaluatedAt": "2026-05-05T23:45:07.396Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33702,7 +33702,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.792Z",
+          "evaluatedAt": "2026-05-05T23:45:07.396Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33766,7 +33766,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.793Z",
+        "evaluatedAt": "2026-05-05T23:45:07.397Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33821,7 +33821,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.793Z",
+          "evaluatedAt": "2026-05-05T23:45:07.397Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33839,7 +33839,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.793Z",
+          "evaluatedAt": "2026-05-05T23:45:07.397Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33903,7 +33903,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.794Z",
+        "evaluatedAt": "2026-05-05T23:45:07.398Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33958,7 +33958,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.794Z",
+          "evaluatedAt": "2026-05-05T23:45:07.398Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33976,7 +33976,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.794Z",
+          "evaluatedAt": "2026-05-05T23:45:07.398Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34040,7 +34040,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.795Z",
+        "evaluatedAt": "2026-05-05T23:45:07.399Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34095,7 +34095,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.795Z",
+          "evaluatedAt": "2026-05-05T23:45:07.399Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34113,7 +34113,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.795Z",
+          "evaluatedAt": "2026-05-05T23:45:07.399Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34177,7 +34177,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.796Z",
+        "evaluatedAt": "2026-05-05T23:45:07.400Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34232,7 +34232,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.796Z",
+          "evaluatedAt": "2026-05-05T23:45:07.400Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34250,7 +34250,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.796Z",
+          "evaluatedAt": "2026-05-05T23:45:07.400Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34314,7 +34314,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.797Z",
+        "evaluatedAt": "2026-05-05T23:45:07.401Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34369,7 +34369,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.797Z",
+          "evaluatedAt": "2026-05-05T23:45:07.401Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34387,7 +34387,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.797Z",
+          "evaluatedAt": "2026-05-05T23:45:07.401Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34451,7 +34451,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.799Z",
+        "evaluatedAt": "2026-05-05T23:45:07.402Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34506,7 +34506,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.799Z",
+          "evaluatedAt": "2026-05-05T23:45:07.402Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34524,7 +34524,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.799Z",
+          "evaluatedAt": "2026-05-05T23:45:07.402Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34588,7 +34588,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.800Z",
+        "evaluatedAt": "2026-05-05T23:45:07.404Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34643,7 +34643,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.800Z",
+          "evaluatedAt": "2026-05-05T23:45:07.404Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34661,7 +34661,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.800Z",
+          "evaluatedAt": "2026-05-05T23:45:07.404Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34725,7 +34725,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.801Z",
+        "evaluatedAt": "2026-05-05T23:45:07.405Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34780,7 +34780,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.801Z",
+          "evaluatedAt": "2026-05-05T23:45:07.405Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34798,7 +34798,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.801Z",
+          "evaluatedAt": "2026-05-05T23:45:07.405Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34862,7 +34862,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.802Z",
+        "evaluatedAt": "2026-05-05T23:45:07.406Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34917,7 +34917,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.802Z",
+          "evaluatedAt": "2026-05-05T23:45:07.406Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34935,7 +34935,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.802Z",
+          "evaluatedAt": "2026-05-05T23:45:07.406Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34999,7 +34999,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.804Z",
+        "evaluatedAt": "2026-05-05T23:45:07.407Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35054,7 +35054,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.804Z",
+          "evaluatedAt": "2026-05-05T23:45:07.407Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35072,7 +35072,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.804Z",
+          "evaluatedAt": "2026-05-05T23:45:07.407Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35136,7 +35136,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.805Z",
+        "evaluatedAt": "2026-05-05T23:45:07.408Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35191,7 +35191,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.805Z",
+          "evaluatedAt": "2026-05-05T23:45:07.408Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35209,7 +35209,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.805Z",
+          "evaluatedAt": "2026-05-05T23:45:07.408Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35273,7 +35273,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.806Z",
+        "evaluatedAt": "2026-05-05T23:45:07.409Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35328,7 +35328,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.806Z",
+          "evaluatedAt": "2026-05-05T23:45:07.409Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35346,7 +35346,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.806Z",
+          "evaluatedAt": "2026-05-05T23:45:07.409Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35410,7 +35410,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.808Z",
+        "evaluatedAt": "2026-05-05T23:45:07.411Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35465,7 +35465,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.808Z",
+          "evaluatedAt": "2026-05-05T23:45:07.411Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35483,7 +35483,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.808Z",
+          "evaluatedAt": "2026-05-05T23:45:07.411Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35547,7 +35547,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.811Z",
+        "evaluatedAt": "2026-05-05T23:45:07.413Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35602,7 +35602,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.811Z",
+          "evaluatedAt": "2026-05-05T23:45:07.413Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35620,7 +35620,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.811Z",
+          "evaluatedAt": "2026-05-05T23:45:07.413Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35684,7 +35684,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.814Z",
+        "evaluatedAt": "2026-05-05T23:45:07.417Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35739,7 +35739,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.814Z",
+          "evaluatedAt": "2026-05-05T23:45:07.417Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35757,7 +35757,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.814Z",
+          "evaluatedAt": "2026-05-05T23:45:07.417Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35821,7 +35821,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.817Z",
+        "evaluatedAt": "2026-05-05T23:45:07.420Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35876,7 +35876,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.817Z",
+          "evaluatedAt": "2026-05-05T23:45:07.421Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35894,7 +35894,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.817Z",
+          "evaluatedAt": "2026-05-05T23:45:07.421Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35958,7 +35958,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.821Z",
+        "evaluatedAt": "2026-05-05T23:45:07.423Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36013,7 +36013,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.821Z",
+          "evaluatedAt": "2026-05-05T23:45:07.424Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36031,7 +36031,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.821Z",
+          "evaluatedAt": "2026-05-05T23:45:07.424Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36095,7 +36095,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.824Z",
+        "evaluatedAt": "2026-05-05T23:45:07.426Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36150,7 +36150,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.824Z",
+          "evaluatedAt": "2026-05-05T23:45:07.426Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36168,7 +36168,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.824Z",
+          "evaluatedAt": "2026-05-05T23:45:07.426Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36232,7 +36232,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.827Z",
+        "evaluatedAt": "2026-05-05T23:45:07.429Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36287,7 +36287,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.827Z",
+          "evaluatedAt": "2026-05-05T23:45:07.429Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36305,7 +36305,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.827Z",
+          "evaluatedAt": "2026-05-05T23:45:07.429Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36369,7 +36369,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.830Z",
+        "evaluatedAt": "2026-05-05T23:45:07.432Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36424,7 +36424,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.830Z",
+          "evaluatedAt": "2026-05-05T23:45:07.432Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36442,7 +36442,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.830Z",
+          "evaluatedAt": "2026-05-05T23:45:07.432Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36506,7 +36506,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.833Z",
+        "evaluatedAt": "2026-05-05T23:45:07.435Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36561,7 +36561,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.833Z",
+          "evaluatedAt": "2026-05-05T23:45:07.435Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36579,7 +36579,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.833Z",
+          "evaluatedAt": "2026-05-05T23:45:07.435Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36643,7 +36643,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.836Z",
+        "evaluatedAt": "2026-05-05T23:45:07.438Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36698,7 +36698,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.836Z",
+          "evaluatedAt": "2026-05-05T23:45:07.438Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36716,7 +36716,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.836Z",
+          "evaluatedAt": "2026-05-05T23:45:07.438Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36780,7 +36780,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.839Z",
+        "evaluatedAt": "2026-05-05T23:45:07.441Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36835,7 +36835,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.839Z",
+          "evaluatedAt": "2026-05-05T23:45:07.441Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36853,7 +36853,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.839Z",
+          "evaluatedAt": "2026-05-05T23:45:07.441Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36917,7 +36917,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.842Z",
+        "evaluatedAt": "2026-05-05T23:45:07.444Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36972,7 +36972,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.842Z",
+          "evaluatedAt": "2026-05-05T23:45:07.444Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36990,7 +36990,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.842Z",
+          "evaluatedAt": "2026-05-05T23:45:07.444Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37054,7 +37054,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.844Z",
+        "evaluatedAt": "2026-05-05T23:45:07.446Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37109,7 +37109,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.844Z",
+          "evaluatedAt": "2026-05-05T23:45:07.446Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37127,7 +37127,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.844Z",
+          "evaluatedAt": "2026-05-05T23:45:07.446Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37191,7 +37191,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.846Z",
+        "evaluatedAt": "2026-05-05T23:45:07.448Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37246,7 +37246,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.846Z",
+          "evaluatedAt": "2026-05-05T23:45:07.448Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37264,7 +37264,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.846Z",
+          "evaluatedAt": "2026-05-05T23:45:07.448Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37328,7 +37328,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.848Z",
+        "evaluatedAt": "2026-05-05T23:45:07.449Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37383,7 +37383,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.848Z",
+          "evaluatedAt": "2026-05-05T23:45:07.449Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37401,7 +37401,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.848Z",
+          "evaluatedAt": "2026-05-05T23:45:07.449Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37465,7 +37465,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.849Z",
+        "evaluatedAt": "2026-05-05T23:45:07.451Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37520,7 +37520,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.849Z",
+          "evaluatedAt": "2026-05-05T23:45:07.451Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37538,7 +37538,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.849Z",
+          "evaluatedAt": "2026-05-05T23:45:07.451Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37602,7 +37602,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.851Z",
+        "evaluatedAt": "2026-05-05T23:45:07.452Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37657,7 +37657,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.851Z",
+          "evaluatedAt": "2026-05-05T23:45:07.452Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37675,7 +37675,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.851Z",
+          "evaluatedAt": "2026-05-05T23:45:07.452Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37739,7 +37739,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.852Z",
+        "evaluatedAt": "2026-05-05T23:45:07.454Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37794,7 +37794,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.852Z",
+          "evaluatedAt": "2026-05-05T23:45:07.454Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37812,7 +37812,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.852Z",
+          "evaluatedAt": "2026-05-05T23:45:07.454Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37876,7 +37876,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.854Z",
+        "evaluatedAt": "2026-05-05T23:45:07.455Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37931,7 +37931,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.854Z",
+          "evaluatedAt": "2026-05-05T23:45:07.455Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37949,7 +37949,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.854Z",
+          "evaluatedAt": "2026-05-05T23:45:07.455Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38013,7 +38013,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.855Z",
+        "evaluatedAt": "2026-05-05T23:45:07.457Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38068,7 +38068,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.855Z",
+          "evaluatedAt": "2026-05-05T23:45:07.457Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38086,7 +38086,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.855Z",
+          "evaluatedAt": "2026-05-05T23:45:07.457Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38150,7 +38150,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.857Z",
+        "evaluatedAt": "2026-05-05T23:45:07.458Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38205,7 +38205,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.857Z",
+          "evaluatedAt": "2026-05-05T23:45:07.458Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38223,7 +38223,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.857Z",
+          "evaluatedAt": "2026-05-05T23:45:07.458Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38287,7 +38287,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.858Z",
+        "evaluatedAt": "2026-05-05T23:45:07.459Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38342,7 +38342,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.858Z",
+          "evaluatedAt": "2026-05-05T23:45:07.459Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38360,7 +38360,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.858Z",
+          "evaluatedAt": "2026-05-05T23:45:07.459Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38424,7 +38424,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.859Z",
+        "evaluatedAt": "2026-05-05T23:45:07.460Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38479,7 +38479,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.859Z",
+          "evaluatedAt": "2026-05-05T23:45:07.460Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38497,7 +38497,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.859Z",
+          "evaluatedAt": "2026-05-05T23:45:07.460Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38561,7 +38561,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.860Z",
+        "evaluatedAt": "2026-05-05T23:45:07.461Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38616,7 +38616,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.860Z",
+          "evaluatedAt": "2026-05-05T23:45:07.461Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38634,7 +38634,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.860Z",
+          "evaluatedAt": "2026-05-05T23:45:07.461Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38698,7 +38698,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.861Z",
+        "evaluatedAt": "2026-05-05T23:45:07.462Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38753,7 +38753,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.861Z",
+          "evaluatedAt": "2026-05-05T23:45:07.462Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38771,7 +38771,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.861Z",
+          "evaluatedAt": "2026-05-05T23:45:07.462Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38835,7 +38835,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.863Z",
+        "evaluatedAt": "2026-05-05T23:45:07.464Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38890,7 +38890,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.863Z",
+          "evaluatedAt": "2026-05-05T23:45:07.464Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38908,7 +38908,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.863Z",
+          "evaluatedAt": "2026-05-05T23:45:07.464Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38972,7 +38972,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.865Z",
+        "evaluatedAt": "2026-05-05T23:45:07.466Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39027,7 +39027,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.865Z",
+          "evaluatedAt": "2026-05-05T23:45:07.466Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39045,7 +39045,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.865Z",
+          "evaluatedAt": "2026-05-05T23:45:07.466Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39109,7 +39109,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.866Z",
+        "evaluatedAt": "2026-05-05T23:45:07.467Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -39164,7 +39164,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.866Z",
+          "evaluatedAt": "2026-05-05T23:45:07.467Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -39182,7 +39182,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.866Z",
+          "evaluatedAt": "2026-05-05T23:45:07.467Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -39246,7 +39246,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.867Z",
+        "evaluatedAt": "2026-05-05T23:45:07.468Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -39301,7 +39301,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.867Z",
+          "evaluatedAt": "2026-05-05T23:45:07.469Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -39319,7 +39319,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.867Z",
+          "evaluatedAt": "2026-05-05T23:45:07.469Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -39383,7 +39383,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.869Z",
+        "evaluatedAt": "2026-05-05T23:45:07.471Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -39438,7 +39438,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.870Z",
+          "evaluatedAt": "2026-05-05T23:45:07.471Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -39456,7 +39456,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.870Z",
+          "evaluatedAt": "2026-05-05T23:45:07.471Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -39520,7 +39520,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.871Z",
+        "evaluatedAt": "2026-05-05T23:45:07.473Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39575,7 +39575,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.871Z",
+          "evaluatedAt": "2026-05-05T23:45:07.473Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39593,7 +39593,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.871Z",
+          "evaluatedAt": "2026-05-05T23:45:07.473Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39657,7 +39657,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.872Z",
+        "evaluatedAt": "2026-05-05T23:45:07.473Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39712,7 +39712,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.872Z",
+          "evaluatedAt": "2026-05-05T23:45:07.473Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39730,7 +39730,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.872Z",
+          "evaluatedAt": "2026-05-05T23:45:07.473Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39794,7 +39794,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.873Z",
+        "evaluatedAt": "2026-05-05T23:45:07.474Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39849,7 +39849,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.873Z",
+          "evaluatedAt": "2026-05-05T23:45:07.474Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39867,7 +39867,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.873Z",
+          "evaluatedAt": "2026-05-05T23:45:07.474Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39931,7 +39931,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.873Z",
+        "evaluatedAt": "2026-05-05T23:45:07.475Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39986,7 +39986,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.873Z",
+          "evaluatedAt": "2026-05-05T23:45:07.475Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40004,7 +40004,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.873Z",
+          "evaluatedAt": "2026-05-05T23:45:07.475Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40068,7 +40068,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.874Z",
+        "evaluatedAt": "2026-05-05T23:45:07.475Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40123,7 +40123,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.874Z",
+          "evaluatedAt": "2026-05-05T23:45:07.475Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40141,7 +40141,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.874Z",
+          "evaluatedAt": "2026-05-05T23:45:07.475Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40205,7 +40205,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.875Z",
+        "evaluatedAt": "2026-05-05T23:45:07.476Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40260,7 +40260,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.875Z",
+          "evaluatedAt": "2026-05-05T23:45:07.476Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40278,7 +40278,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.875Z",
+          "evaluatedAt": "2026-05-05T23:45:07.476Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40342,7 +40342,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.876Z",
+        "evaluatedAt": "2026-05-05T23:45:07.477Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40397,7 +40397,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.876Z",
+          "evaluatedAt": "2026-05-05T23:45:07.477Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40415,7 +40415,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.876Z",
+          "evaluatedAt": "2026-05-05T23:45:07.477Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40479,7 +40479,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.876Z",
+        "evaluatedAt": "2026-05-05T23:45:07.478Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40534,7 +40534,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.876Z",
+          "evaluatedAt": "2026-05-05T23:45:07.478Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40552,7 +40552,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.876Z",
+          "evaluatedAt": "2026-05-05T23:45:07.478Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40616,7 +40616,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.877Z",
+        "evaluatedAt": "2026-05-05T23:45:07.479Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40671,7 +40671,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.877Z",
+          "evaluatedAt": "2026-05-05T23:45:07.479Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40689,7 +40689,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.877Z",
+          "evaluatedAt": "2026-05-05T23:45:07.479Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40753,7 +40753,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.878Z",
+        "evaluatedAt": "2026-05-05T23:45:07.480Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40808,7 +40808,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.878Z",
+          "evaluatedAt": "2026-05-05T23:45:07.480Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40826,7 +40826,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.878Z",
+          "evaluatedAt": "2026-05-05T23:45:07.480Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40890,7 +40890,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.879Z",
+        "evaluatedAt": "2026-05-05T23:45:07.480Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40945,7 +40945,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.879Z",
+          "evaluatedAt": "2026-05-05T23:45:07.480Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40963,7 +40963,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.879Z",
+          "evaluatedAt": "2026-05-05T23:45:07.480Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41027,7 +41027,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.879Z",
+        "evaluatedAt": "2026-05-05T23:45:07.481Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41082,7 +41082,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.879Z",
+          "evaluatedAt": "2026-05-05T23:45:07.481Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41100,7 +41100,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.879Z",
+          "evaluatedAt": "2026-05-05T23:45:07.481Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41164,7 +41164,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.880Z",
+        "evaluatedAt": "2026-05-05T23:45:07.482Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41219,7 +41219,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.880Z",
+          "evaluatedAt": "2026-05-05T23:45:07.482Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41237,7 +41237,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.880Z",
+          "evaluatedAt": "2026-05-05T23:45:07.482Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41301,7 +41301,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.881Z",
+        "evaluatedAt": "2026-05-05T23:45:07.483Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41356,7 +41356,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.881Z",
+          "evaluatedAt": "2026-05-05T23:45:07.483Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41374,7 +41374,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.881Z",
+          "evaluatedAt": "2026-05-05T23:45:07.483Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41438,7 +41438,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.882Z",
+        "evaluatedAt": "2026-05-05T23:45:07.484Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41493,7 +41493,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.882Z",
+          "evaluatedAt": "2026-05-05T23:45:07.484Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41511,7 +41511,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.882Z",
+          "evaluatedAt": "2026-05-05T23:45:07.484Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41575,7 +41575,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.883Z",
+        "evaluatedAt": "2026-05-05T23:45:07.484Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41630,7 +41630,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.883Z",
+          "evaluatedAt": "2026-05-05T23:45:07.484Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41648,7 +41648,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.883Z",
+          "evaluatedAt": "2026-05-05T23:45:07.484Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41712,7 +41712,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.883Z",
+        "evaluatedAt": "2026-05-05T23:45:07.485Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41767,7 +41767,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.883Z",
+          "evaluatedAt": "2026-05-05T23:45:07.485Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41785,7 +41785,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.883Z",
+          "evaluatedAt": "2026-05-05T23:45:07.485Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41849,7 +41849,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.884Z",
+        "evaluatedAt": "2026-05-05T23:45:07.485Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41904,7 +41904,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.884Z",
+          "evaluatedAt": "2026-05-05T23:45:07.485Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41922,7 +41922,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.884Z",
+          "evaluatedAt": "2026-05-05T23:45:07.485Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41986,7 +41986,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.885Z",
+        "evaluatedAt": "2026-05-05T23:45:07.486Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -42041,7 +42041,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.885Z",
+          "evaluatedAt": "2026-05-05T23:45:07.486Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -42059,7 +42059,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.885Z",
+          "evaluatedAt": "2026-05-05T23:45:07.486Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -42123,7 +42123,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.886Z",
+        "evaluatedAt": "2026-05-05T23:45:07.487Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42178,7 +42178,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.886Z",
+          "evaluatedAt": "2026-05-05T23:45:07.487Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42196,7 +42196,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.886Z",
+          "evaluatedAt": "2026-05-05T23:45:07.487Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42260,7 +42260,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.887Z",
+        "evaluatedAt": "2026-05-05T23:45:07.488Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42315,7 +42315,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.887Z",
+          "evaluatedAt": "2026-05-05T23:45:07.488Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42333,7 +42333,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.887Z",
+          "evaluatedAt": "2026-05-05T23:45:07.488Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42397,7 +42397,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.888Z",
+        "evaluatedAt": "2026-05-05T23:45:07.489Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42452,7 +42452,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.888Z",
+          "evaluatedAt": "2026-05-05T23:45:07.489Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42470,7 +42470,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.888Z",
+          "evaluatedAt": "2026-05-05T23:45:07.489Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42534,7 +42534,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.889Z",
+        "evaluatedAt": "2026-05-05T23:45:07.490Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42589,7 +42589,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.889Z",
+          "evaluatedAt": "2026-05-05T23:45:07.490Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42607,7 +42607,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.889Z",
+          "evaluatedAt": "2026-05-05T23:45:07.490Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42671,7 +42671,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.890Z",
+        "evaluatedAt": "2026-05-05T23:45:07.491Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42726,7 +42726,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.890Z",
+          "evaluatedAt": "2026-05-05T23:45:07.491Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42744,7 +42744,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.890Z",
+          "evaluatedAt": "2026-05-05T23:45:07.491Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42808,7 +42808,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.892Z",
+        "evaluatedAt": "2026-05-05T23:45:07.492Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42863,7 +42863,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.892Z",
+          "evaluatedAt": "2026-05-05T23:45:07.492Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42881,7 +42881,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.892Z",
+          "evaluatedAt": "2026-05-05T23:45:07.492Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42945,7 +42945,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.893Z",
+        "evaluatedAt": "2026-05-05T23:45:07.493Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43000,7 +43000,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.893Z",
+          "evaluatedAt": "2026-05-05T23:45:07.493Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43018,7 +43018,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.893Z",
+          "evaluatedAt": "2026-05-05T23:45:07.493Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43082,7 +43082,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.895Z",
+        "evaluatedAt": "2026-05-05T23:45:07.495Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43137,7 +43137,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.895Z",
+          "evaluatedAt": "2026-05-05T23:45:07.495Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43155,7 +43155,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.895Z",
+          "evaluatedAt": "2026-05-05T23:45:07.495Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43219,7 +43219,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.897Z",
+        "evaluatedAt": "2026-05-05T23:45:07.497Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43274,7 +43274,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.897Z",
+          "evaluatedAt": "2026-05-05T23:45:07.497Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43292,7 +43292,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.897Z",
+          "evaluatedAt": "2026-05-05T23:45:07.497Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43356,7 +43356,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.899Z",
+        "evaluatedAt": "2026-05-05T23:45:07.499Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43411,7 +43411,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.899Z",
+          "evaluatedAt": "2026-05-05T23:45:07.499Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43429,7 +43429,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.899Z",
+          "evaluatedAt": "2026-05-05T23:45:07.499Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43493,7 +43493,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.901Z",
+        "evaluatedAt": "2026-05-05T23:45:07.501Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43548,7 +43548,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.901Z",
+          "evaluatedAt": "2026-05-05T23:45:07.501Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43566,7 +43566,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.901Z",
+          "evaluatedAt": "2026-05-05T23:45:07.501Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43630,7 +43630,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.903Z",
+        "evaluatedAt": "2026-05-05T23:45:07.504Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43685,7 +43685,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.903Z",
+          "evaluatedAt": "2026-05-05T23:45:07.504Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43703,7 +43703,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.903Z",
+          "evaluatedAt": "2026-05-05T23:45:07.504Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43767,7 +43767,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.905Z",
+        "evaluatedAt": "2026-05-05T23:45:07.506Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43822,7 +43822,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.905Z",
+          "evaluatedAt": "2026-05-05T23:45:07.506Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43840,7 +43840,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.905Z",
+          "evaluatedAt": "2026-05-05T23:45:07.506Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43904,7 +43904,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.907Z",
+        "evaluatedAt": "2026-05-05T23:45:07.507Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43959,7 +43959,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.907Z",
+          "evaluatedAt": "2026-05-05T23:45:07.507Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43977,7 +43977,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.907Z",
+          "evaluatedAt": "2026-05-05T23:45:07.507Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44041,7 +44041,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.908Z",
+        "evaluatedAt": "2026-05-05T23:45:07.508Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44096,7 +44096,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.908Z",
+          "evaluatedAt": "2026-05-05T23:45:07.508Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44114,7 +44114,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.908Z",
+          "evaluatedAt": "2026-05-05T23:45:07.508Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44178,7 +44178,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.909Z",
+        "evaluatedAt": "2026-05-05T23:45:07.510Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44233,7 +44233,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.909Z",
+          "evaluatedAt": "2026-05-05T23:45:07.510Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44251,7 +44251,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.909Z",
+          "evaluatedAt": "2026-05-05T23:45:07.510Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44315,7 +44315,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.911Z",
+        "evaluatedAt": "2026-05-05T23:45:07.511Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44370,7 +44370,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.911Z",
+          "evaluatedAt": "2026-05-05T23:45:07.511Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44388,7 +44388,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.911Z",
+          "evaluatedAt": "2026-05-05T23:45:07.511Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44452,7 +44452,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.912Z",
+        "evaluatedAt": "2026-05-05T23:45:07.512Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44507,7 +44507,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.912Z",
+          "evaluatedAt": "2026-05-05T23:45:07.512Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44525,7 +44525,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.912Z",
+          "evaluatedAt": "2026-05-05T23:45:07.512Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44589,7 +44589,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.913Z",
+        "evaluatedAt": "2026-05-05T23:45:07.513Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44644,7 +44644,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.913Z",
+          "evaluatedAt": "2026-05-05T23:45:07.513Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44662,7 +44662,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.913Z",
+          "evaluatedAt": "2026-05-05T23:45:07.513Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44726,7 +44726,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.914Z",
+        "evaluatedAt": "2026-05-05T23:45:07.514Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44781,7 +44781,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.914Z",
+          "evaluatedAt": "2026-05-05T23:45:07.514Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44799,7 +44799,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.914Z",
+          "evaluatedAt": "2026-05-05T23:45:07.514Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44863,7 +44863,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.915Z",
+        "evaluatedAt": "2026-05-05T23:45:07.514Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44918,7 +44918,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.915Z",
+          "evaluatedAt": "2026-05-05T23:45:07.514Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44936,7 +44936,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.915Z",
+          "evaluatedAt": "2026-05-05T23:45:07.514Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45000,7 +45000,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.916Z",
+        "evaluatedAt": "2026-05-05T23:45:07.515Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45055,7 +45055,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.916Z",
+          "evaluatedAt": "2026-05-05T23:45:07.515Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45073,7 +45073,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.916Z",
+          "evaluatedAt": "2026-05-05T23:45:07.515Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45137,7 +45137,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.917Z",
+        "evaluatedAt": "2026-05-05T23:45:07.516Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45192,7 +45192,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.917Z",
+          "evaluatedAt": "2026-05-05T23:45:07.516Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45210,7 +45210,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.917Z",
+          "evaluatedAt": "2026-05-05T23:45:07.516Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45274,7 +45274,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.918Z",
+        "evaluatedAt": "2026-05-05T23:45:07.517Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45329,7 +45329,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.918Z",
+          "evaluatedAt": "2026-05-05T23:45:07.517Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45347,7 +45347,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.918Z",
+          "evaluatedAt": "2026-05-05T23:45:07.517Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45411,7 +45411,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.919Z",
+        "evaluatedAt": "2026-05-05T23:45:07.518Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45466,7 +45466,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.919Z",
+          "evaluatedAt": "2026-05-05T23:45:07.518Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45484,7 +45484,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.919Z",
+          "evaluatedAt": "2026-05-05T23:45:07.518Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45548,7 +45548,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.920Z",
+        "evaluatedAt": "2026-05-05T23:45:07.519Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -45603,7 +45603,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.920Z",
+          "evaluatedAt": "2026-05-05T23:45:07.519Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -45621,7 +45621,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.920Z",
+          "evaluatedAt": "2026-05-05T23:45:07.519Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -45685,7 +45685,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.924Z",
+        "evaluatedAt": "2026-05-05T23:45:07.522Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -45740,7 +45740,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.924Z",
+          "evaluatedAt": "2026-05-05T23:45:07.522Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -45758,7 +45758,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.924Z",
+          "evaluatedAt": "2026-05-05T23:45:07.522Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -45822,7 +45822,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.926Z",
+        "evaluatedAt": "2026-05-05T23:45:07.525Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45877,7 +45877,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.926Z",
+          "evaluatedAt": "2026-05-05T23:45:07.525Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45895,7 +45895,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.926Z",
+          "evaluatedAt": "2026-05-05T23:45:07.525Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45959,7 +45959,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.928Z",
+        "evaluatedAt": "2026-05-05T23:45:07.526Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46014,7 +46014,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.928Z",
+          "evaluatedAt": "2026-05-05T23:45:07.526Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46032,7 +46032,7 @@
               "max": 1
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.928Z",
+          "evaluatedAt": "2026-05-05T23:45:07.526Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46096,7 +46096,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.929Z",
+        "evaluatedAt": "2026-05-05T23:45:07.527Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46151,7 +46151,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.929Z",
+          "evaluatedAt": "2026-05-05T23:45:07.527Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46169,7 +46169,7 @@
               "max": 1
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.929Z",
+          "evaluatedAt": "2026-05-05T23:45:07.527Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46233,7 +46233,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.931Z",
+        "evaluatedAt": "2026-05-05T23:45:07.529Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -46288,7 +46288,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.931Z",
+          "evaluatedAt": "2026-05-05T23:45:07.529Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -46306,7 +46306,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.931Z",
+          "evaluatedAt": "2026-05-05T23:45:07.529Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -46370,7 +46370,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.933Z",
+        "evaluatedAt": "2026-05-05T23:45:07.531Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -46425,7 +46425,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.934Z",
+          "evaluatedAt": "2026-05-05T23:45:07.531Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -46443,7 +46443,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.934Z",
+          "evaluatedAt": "2026-05-05T23:45:07.531Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -46507,7 +46507,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.936Z",
+        "evaluatedAt": "2026-05-05T23:45:07.534Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46562,7 +46562,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.936Z",
+          "evaluatedAt": "2026-05-05T23:45:07.534Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46580,7 +46580,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.936Z",
+          "evaluatedAt": "2026-05-05T23:45:07.534Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46644,7 +46644,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.939Z",
+        "evaluatedAt": "2026-05-05T23:45:07.536Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46699,7 +46699,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.939Z",
+          "evaluatedAt": "2026-05-05T23:45:07.536Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46717,7 +46717,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.939Z",
+          "evaluatedAt": "2026-05-05T23:45:07.536Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46781,7 +46781,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.942Z",
+        "evaluatedAt": "2026-05-05T23:45:07.539Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46836,7 +46836,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.942Z",
+          "evaluatedAt": "2026-05-05T23:45:07.539Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46854,7 +46854,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.942Z",
+          "evaluatedAt": "2026-05-05T23:45:07.539Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46918,7 +46918,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.945Z",
+        "evaluatedAt": "2026-05-05T23:45:07.542Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46973,7 +46973,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.945Z",
+          "evaluatedAt": "2026-05-05T23:45:07.542Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46991,7 +46991,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.945Z",
+          "evaluatedAt": "2026-05-05T23:45:07.542Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47055,7 +47055,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.948Z",
+        "evaluatedAt": "2026-05-05T23:45:07.544Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47110,7 +47110,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.948Z",
+          "evaluatedAt": "2026-05-05T23:45:07.544Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47128,7 +47128,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.948Z",
+          "evaluatedAt": "2026-05-05T23:45:07.544Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47192,7 +47192,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.950Z",
+        "evaluatedAt": "2026-05-05T23:45:07.547Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47247,7 +47247,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.950Z",
+          "evaluatedAt": "2026-05-05T23:45:07.547Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47265,7 +47265,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.950Z",
+          "evaluatedAt": "2026-05-05T23:45:07.547Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47329,7 +47329,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.953Z",
+        "evaluatedAt": "2026-05-05T23:45:07.549Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47384,7 +47384,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.953Z",
+          "evaluatedAt": "2026-05-05T23:45:07.549Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47402,7 +47402,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.953Z",
+          "evaluatedAt": "2026-05-05T23:45:07.549Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47466,7 +47466,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.956Z",
+        "evaluatedAt": "2026-05-05T23:45:07.552Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47521,7 +47521,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.956Z",
+          "evaluatedAt": "2026-05-05T23:45:07.552Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47539,7 +47539,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.956Z",
+          "evaluatedAt": "2026-05-05T23:45:07.552Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47603,7 +47603,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.959Z",
+        "evaluatedAt": "2026-05-05T23:45:07.555Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47658,7 +47658,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.959Z",
+          "evaluatedAt": "2026-05-05T23:45:07.555Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47676,7 +47676,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.959Z",
+          "evaluatedAt": "2026-05-05T23:45:07.555Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47740,7 +47740,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.965Z",
+        "evaluatedAt": "2026-05-05T23:45:07.558Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47795,7 +47795,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.966Z",
+          "evaluatedAt": "2026-05-05T23:45:07.558Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47813,7 +47813,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.966Z",
+          "evaluatedAt": "2026-05-05T23:45:07.558Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47877,7 +47877,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.971Z",
+        "evaluatedAt": "2026-05-05T23:45:07.560Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47932,7 +47932,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.971Z",
+          "evaluatedAt": "2026-05-05T23:45:07.560Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47950,7 +47950,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.971Z",
+          "evaluatedAt": "2026-05-05T23:45:07.560Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48014,7 +48014,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.976Z",
+        "evaluatedAt": "2026-05-05T23:45:07.562Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48069,7 +48069,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.977Z",
+          "evaluatedAt": "2026-05-05T23:45:07.562Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48087,7 +48087,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.977Z",
+          "evaluatedAt": "2026-05-05T23:45:07.562Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48151,7 +48151,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.983Z",
+        "evaluatedAt": "2026-05-05T23:45:07.564Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -48206,7 +48206,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.983Z",
+          "evaluatedAt": "2026-05-05T23:45:07.564Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -48224,7 +48224,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.983Z",
+          "evaluatedAt": "2026-05-05T23:45:07.564Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -48288,7 +48288,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.987Z",
+        "evaluatedAt": "2026-05-05T23:45:07.568Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -48343,7 +48343,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.987Z",
+          "evaluatedAt": "2026-05-05T23:45:07.568Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -48361,7 +48361,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.987Z",
+          "evaluatedAt": "2026-05-05T23:45:07.568Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -48425,7 +48425,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.990Z",
+        "evaluatedAt": "2026-05-05T23:45:07.570Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48480,7 +48480,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.990Z",
+          "evaluatedAt": "2026-05-05T23:45:07.570Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48498,7 +48498,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.990Z",
+          "evaluatedAt": "2026-05-05T23:45:07.570Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48562,7 +48562,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.991Z",
+        "evaluatedAt": "2026-05-05T23:45:07.571Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48617,7 +48617,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.991Z",
+          "evaluatedAt": "2026-05-05T23:45:07.571Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48635,7 +48635,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.991Z",
+          "evaluatedAt": "2026-05-05T23:45:07.571Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48699,7 +48699,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.992Z",
+        "evaluatedAt": "2026-05-05T23:45:07.571Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48754,7 +48754,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.992Z",
+          "evaluatedAt": "2026-05-05T23:45:07.571Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48772,7 +48772,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.992Z",
+          "evaluatedAt": "2026-05-05T23:45:07.572Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48836,7 +48836,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.994Z",
+        "evaluatedAt": "2026-05-05T23:45:07.573Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48891,7 +48891,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.994Z",
+          "evaluatedAt": "2026-05-05T23:45:07.573Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48909,7 +48909,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.994Z",
+          "evaluatedAt": "2026-05-05T23:45:07.573Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48973,7 +48973,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.995Z",
+        "evaluatedAt": "2026-05-05T23:45:07.574Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49028,7 +49028,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.995Z",
+          "evaluatedAt": "2026-05-05T23:45:07.574Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49046,7 +49046,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.995Z",
+          "evaluatedAt": "2026-05-05T23:45:07.574Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49110,7 +49110,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.996Z",
+        "evaluatedAt": "2026-05-05T23:45:07.575Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49165,7 +49165,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.996Z",
+          "evaluatedAt": "2026-05-05T23:45:07.575Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49183,7 +49183,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.996Z",
+          "evaluatedAt": "2026-05-05T23:45:07.575Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49247,7 +49247,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.997Z",
+        "evaluatedAt": "2026-05-05T23:45:07.575Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49302,7 +49302,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.997Z",
+          "evaluatedAt": "2026-05-05T23:45:07.575Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49320,7 +49320,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.997Z",
+          "evaluatedAt": "2026-05-05T23:45:07.575Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49384,7 +49384,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:53.998Z",
+        "evaluatedAt": "2026-05-05T23:45:07.577Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -49439,7 +49439,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.998Z",
+          "evaluatedAt": "2026-05-05T23:45:07.577Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -49457,7 +49457,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:53.998Z",
+          "evaluatedAt": "2026-05-05T23:45:07.577Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -49521,7 +49521,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.001Z",
+        "evaluatedAt": "2026-05-05T23:45:07.579Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -49576,7 +49576,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.001Z",
+          "evaluatedAt": "2026-05-05T23:45:07.579Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -49594,7 +49594,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.001Z",
+          "evaluatedAt": "2026-05-05T23:45:07.579Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -49658,7 +49658,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.003Z",
+        "evaluatedAt": "2026-05-05T23:45:07.582Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49713,7 +49713,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.003Z",
+          "evaluatedAt": "2026-05-05T23:45:07.582Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49731,7 +49731,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.003Z",
+          "evaluatedAt": "2026-05-05T23:45:07.582Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49795,7 +49795,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.005Z",
+        "evaluatedAt": "2026-05-05T23:45:07.583Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49850,7 +49850,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.005Z",
+          "evaluatedAt": "2026-05-05T23:45:07.583Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49868,7 +49868,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.005Z",
+          "evaluatedAt": "2026-05-05T23:45:07.583Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49932,7 +49932,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.007Z",
+        "evaluatedAt": "2026-05-05T23:45:07.585Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49987,7 +49987,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.007Z",
+          "evaluatedAt": "2026-05-05T23:45:07.585Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50005,7 +50005,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.007Z",
+          "evaluatedAt": "2026-05-05T23:45:07.585Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50069,7 +50069,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.009Z",
+        "evaluatedAt": "2026-05-05T23:45:07.588Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50124,7 +50124,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.009Z",
+          "evaluatedAt": "2026-05-05T23:45:07.588Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50142,7 +50142,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.009Z",
+          "evaluatedAt": "2026-05-05T23:45:07.588Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50206,7 +50206,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.012Z",
+        "evaluatedAt": "2026-05-05T23:45:07.590Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50261,7 +50261,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.012Z",
+          "evaluatedAt": "2026-05-05T23:45:07.590Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50279,7 +50279,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.012Z",
+          "evaluatedAt": "2026-05-05T23:45:07.590Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50343,7 +50343,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.014Z",
+        "evaluatedAt": "2026-05-05T23:45:07.592Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50398,7 +50398,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.014Z",
+          "evaluatedAt": "2026-05-05T23:45:07.592Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50416,7 +50416,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.014Z",
+          "evaluatedAt": "2026-05-05T23:45:07.592Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50480,7 +50480,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.016Z",
+        "evaluatedAt": "2026-05-05T23:45:07.594Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50535,7 +50535,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.016Z",
+          "evaluatedAt": "2026-05-05T23:45:07.594Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50553,7 +50553,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.016Z",
+          "evaluatedAt": "2026-05-05T23:45:07.594Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50617,7 +50617,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.019Z",
+        "evaluatedAt": "2026-05-05T23:45:07.596Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50672,7 +50672,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.019Z",
+          "evaluatedAt": "2026-05-05T23:45:07.596Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50690,7 +50690,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.019Z",
+          "evaluatedAt": "2026-05-05T23:45:07.596Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50754,7 +50754,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.021Z",
+        "evaluatedAt": "2026-05-05T23:45:07.598Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50809,7 +50809,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.021Z",
+          "evaluatedAt": "2026-05-05T23:45:07.598Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50827,7 +50827,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.021Z",
+          "evaluatedAt": "2026-05-05T23:45:07.598Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50891,7 +50891,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.022Z",
+        "evaluatedAt": "2026-05-05T23:45:07.599Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50946,7 +50946,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.022Z",
+          "evaluatedAt": "2026-05-05T23:45:07.599Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50964,7 +50964,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.022Z",
+          "evaluatedAt": "2026-05-05T23:45:07.599Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51028,7 +51028,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.024Z",
+        "evaluatedAt": "2026-05-05T23:45:07.601Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51083,7 +51083,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.024Z",
+          "evaluatedAt": "2026-05-05T23:45:07.601Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51101,7 +51101,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.024Z",
+          "evaluatedAt": "2026-05-05T23:45:07.601Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51165,7 +51165,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.025Z",
+        "evaluatedAt": "2026-05-05T23:45:07.602Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51220,7 +51220,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.025Z",
+          "evaluatedAt": "2026-05-05T23:45:07.602Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51238,7 +51238,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.025Z",
+          "evaluatedAt": "2026-05-05T23:45:07.602Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51302,7 +51302,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.026Z",
+        "evaluatedAt": "2026-05-05T23:45:07.603Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51357,7 +51357,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.026Z",
+          "evaluatedAt": "2026-05-05T23:45:07.603Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51375,7 +51375,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.026Z",
+          "evaluatedAt": "2026-05-05T23:45:07.603Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51439,7 +51439,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.027Z",
+        "evaluatedAt": "2026-05-05T23:45:07.605Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -51494,7 +51494,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.027Z",
+          "evaluatedAt": "2026-05-05T23:45:07.605Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -51512,7 +51512,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.027Z",
+          "evaluatedAt": "2026-05-05T23:45:07.605Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -51576,7 +51576,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.028Z",
+        "evaluatedAt": "2026-05-05T23:45:07.606Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51631,7 +51631,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.028Z",
+          "evaluatedAt": "2026-05-05T23:45:07.606Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51649,7 +51649,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.028Z",
+          "evaluatedAt": "2026-05-05T23:45:07.606Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51713,7 +51713,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.030Z",
+        "evaluatedAt": "2026-05-05T23:45:07.608Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51768,7 +51768,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.031Z",
+          "evaluatedAt": "2026-05-05T23:45:07.608Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51786,7 +51786,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.031Z",
+          "evaluatedAt": "2026-05-05T23:45:07.608Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51850,7 +51850,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.033Z",
+        "evaluatedAt": "2026-05-05T23:45:07.610Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51905,7 +51905,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.033Z",
+          "evaluatedAt": "2026-05-05T23:45:07.610Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51923,7 +51923,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.033Z",
+          "evaluatedAt": "2026-05-05T23:45:07.610Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51987,7 +51987,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.035Z",
+        "evaluatedAt": "2026-05-05T23:45:07.612Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52042,7 +52042,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.035Z",
+          "evaluatedAt": "2026-05-05T23:45:07.612Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52060,7 +52060,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.035Z",
+          "evaluatedAt": "2026-05-05T23:45:07.612Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52124,7 +52124,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.037Z",
+        "evaluatedAt": "2026-05-05T23:45:07.614Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52179,7 +52179,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.037Z",
+          "evaluatedAt": "2026-05-05T23:45:07.614Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52197,7 +52197,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.037Z",
+          "evaluatedAt": "2026-05-05T23:45:07.614Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52261,7 +52261,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.039Z",
+        "evaluatedAt": "2026-05-05T23:45:07.616Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52316,7 +52316,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.039Z",
+          "evaluatedAt": "2026-05-05T23:45:07.616Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52334,7 +52334,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.040Z",
+          "evaluatedAt": "2026-05-05T23:45:07.616Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52398,7 +52398,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.041Z",
+        "evaluatedAt": "2026-05-05T23:45:07.618Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52453,7 +52453,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.041Z",
+          "evaluatedAt": "2026-05-05T23:45:07.618Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52471,7 +52471,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.041Z",
+          "evaluatedAt": "2026-05-05T23:45:07.618Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52535,7 +52535,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.043Z",
+        "evaluatedAt": "2026-05-05T23:45:07.620Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52590,7 +52590,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.043Z",
+          "evaluatedAt": "2026-05-05T23:45:07.620Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52608,7 +52608,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.043Z",
+          "evaluatedAt": "2026-05-05T23:45:07.620Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52672,7 +52672,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.045Z",
+        "evaluatedAt": "2026-05-05T23:45:07.621Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52727,7 +52727,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.045Z",
+          "evaluatedAt": "2026-05-05T23:45:07.621Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52745,7 +52745,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.045Z",
+          "evaluatedAt": "2026-05-05T23:45:07.621Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52809,7 +52809,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.045Z",
+        "evaluatedAt": "2026-05-05T23:45:07.622Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52864,7 +52864,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.046Z",
+          "evaluatedAt": "2026-05-05T23:45:07.622Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52882,7 +52882,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.046Z",
+          "evaluatedAt": "2026-05-05T23:45:07.622Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52946,7 +52946,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.047Z",
+        "evaluatedAt": "2026-05-05T23:45:07.623Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53001,7 +53001,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.047Z",
+          "evaluatedAt": "2026-05-05T23:45:07.623Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53019,7 +53019,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.047Z",
+          "evaluatedAt": "2026-05-05T23:45:07.623Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53083,7 +53083,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.048Z",
+        "evaluatedAt": "2026-05-05T23:45:07.624Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53138,7 +53138,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.048Z",
+          "evaluatedAt": "2026-05-05T23:45:07.624Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53156,7 +53156,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.048Z",
+          "evaluatedAt": "2026-05-05T23:45:07.624Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53220,7 +53220,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.049Z",
+        "evaluatedAt": "2026-05-05T23:45:07.625Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53275,7 +53275,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.049Z",
+          "evaluatedAt": "2026-05-05T23:45:07.625Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53293,7 +53293,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.049Z",
+          "evaluatedAt": "2026-05-05T23:45:07.625Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53357,7 +53357,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.050Z",
+        "evaluatedAt": "2026-05-05T23:45:07.626Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53412,7 +53412,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.050Z",
+          "evaluatedAt": "2026-05-05T23:45:07.626Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53430,7 +53430,7 @@
               "max": 11
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.050Z",
+          "evaluatedAt": "2026-05-05T23:45:07.626Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53494,7 +53494,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.051Z",
+        "evaluatedAt": "2026-05-05T23:45:07.627Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53549,7 +53549,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.051Z",
+          "evaluatedAt": "2026-05-05T23:45:07.627Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53567,7 +53567,7 @@
               "max": 11
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.051Z",
+          "evaluatedAt": "2026-05-05T23:45:07.627Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53631,7 +53631,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.053Z",
+        "evaluatedAt": "2026-05-05T23:45:07.629Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53686,7 +53686,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.053Z",
+          "evaluatedAt": "2026-05-05T23:45:07.629Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53704,7 +53704,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.053Z",
+          "evaluatedAt": "2026-05-05T23:45:07.629Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53768,7 +53768,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.054Z",
+        "evaluatedAt": "2026-05-05T23:45:07.630Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53823,7 +53823,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.054Z",
+          "evaluatedAt": "2026-05-05T23:45:07.630Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53841,7 +53841,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.054Z",
+          "evaluatedAt": "2026-05-05T23:45:07.630Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53905,7 +53905,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.056Z",
+        "evaluatedAt": "2026-05-05T23:45:07.632Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53960,7 +53960,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.056Z",
+          "evaluatedAt": "2026-05-05T23:45:07.632Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53978,7 +53978,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.056Z",
+          "evaluatedAt": "2026-05-05T23:45:07.632Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54042,7 +54042,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.058Z",
+        "evaluatedAt": "2026-05-05T23:45:07.634Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54097,7 +54097,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.058Z",
+          "evaluatedAt": "2026-05-05T23:45:07.634Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54115,7 +54115,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.058Z",
+          "evaluatedAt": "2026-05-05T23:45:07.634Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54179,7 +54179,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.060Z",
+        "evaluatedAt": "2026-05-05T23:45:07.636Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54234,7 +54234,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.060Z",
+          "evaluatedAt": "2026-05-05T23:45:07.636Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54252,7 +54252,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.060Z",
+          "evaluatedAt": "2026-05-05T23:45:07.636Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54316,7 +54316,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.061Z",
+        "evaluatedAt": "2026-05-05T23:45:07.637Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54371,7 +54371,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.061Z",
+          "evaluatedAt": "2026-05-05T23:45:07.637Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54389,7 +54389,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.061Z",
+          "evaluatedAt": "2026-05-05T23:45:07.637Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54453,7 +54453,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.062Z",
+        "evaluatedAt": "2026-05-05T23:45:07.638Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54508,7 +54508,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.062Z",
+          "evaluatedAt": "2026-05-05T23:45:07.638Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54526,7 +54526,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.062Z",
+          "evaluatedAt": "2026-05-05T23:45:07.638Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54590,7 +54590,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.064Z",
+        "evaluatedAt": "2026-05-05T23:45:07.640Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54645,7 +54645,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.064Z",
+          "evaluatedAt": "2026-05-05T23:45:07.640Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54663,7 +54663,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.064Z",
+          "evaluatedAt": "2026-05-05T23:45:07.640Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54727,7 +54727,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.065Z",
+        "evaluatedAt": "2026-05-05T23:45:07.641Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54782,7 +54782,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.066Z",
+          "evaluatedAt": "2026-05-05T23:45:07.641Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54800,7 +54800,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.066Z",
+          "evaluatedAt": "2026-05-05T23:45:07.641Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54864,7 +54864,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.067Z",
+        "evaluatedAt": "2026-05-05T23:45:07.642Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54919,7 +54919,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.067Z",
+          "evaluatedAt": "2026-05-05T23:45:07.642Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54937,7 +54937,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.067Z",
+          "evaluatedAt": "2026-05-05T23:45:07.642Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55001,7 +55001,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.068Z",
+        "evaluatedAt": "2026-05-05T23:45:07.643Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55056,7 +55056,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.068Z",
+          "evaluatedAt": "2026-05-05T23:45:07.643Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55074,7 +55074,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.068Z",
+          "evaluatedAt": "2026-05-05T23:45:07.643Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55138,7 +55138,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.070Z",
+        "evaluatedAt": "2026-05-05T23:45:07.644Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55193,7 +55193,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.070Z",
+          "evaluatedAt": "2026-05-05T23:45:07.644Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55211,7 +55211,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.070Z",
+          "evaluatedAt": "2026-05-05T23:45:07.644Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55275,7 +55275,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.071Z",
+        "evaluatedAt": "2026-05-05T23:45:07.645Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55330,7 +55330,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.071Z",
+          "evaluatedAt": "2026-05-05T23:45:07.645Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55348,7 +55348,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.071Z",
+          "evaluatedAt": "2026-05-05T23:45:07.645Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55412,7 +55412,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.072Z",
+        "evaluatedAt": "2026-05-05T23:45:07.645Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55467,7 +55467,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.072Z",
+          "evaluatedAt": "2026-05-05T23:45:07.645Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55485,7 +55485,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.072Z",
+          "evaluatedAt": "2026-05-05T23:45:07.645Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55549,7 +55549,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.073Z",
+        "evaluatedAt": "2026-05-05T23:45:07.646Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55604,7 +55604,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.073Z",
+          "evaluatedAt": "2026-05-05T23:45:07.647Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55622,7 +55622,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.073Z",
+          "evaluatedAt": "2026-05-05T23:45:07.647Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55686,7 +55686,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.074Z",
+        "evaluatedAt": "2026-05-05T23:45:07.648Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55741,7 +55741,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.074Z",
+          "evaluatedAt": "2026-05-05T23:45:07.648Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55759,7 +55759,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.074Z",
+          "evaluatedAt": "2026-05-05T23:45:07.648Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55823,7 +55823,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.075Z",
+        "evaluatedAt": "2026-05-05T23:45:07.649Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55878,7 +55878,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.076Z",
+          "evaluatedAt": "2026-05-05T23:45:07.649Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55896,7 +55896,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.076Z",
+          "evaluatedAt": "2026-05-05T23:45:07.649Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55960,7 +55960,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.077Z",
+        "evaluatedAt": "2026-05-05T23:45:07.650Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56015,7 +56015,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.077Z",
+          "evaluatedAt": "2026-05-05T23:45:07.650Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56033,7 +56033,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.077Z",
+          "evaluatedAt": "2026-05-05T23:45:07.650Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56097,7 +56097,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.078Z",
+        "evaluatedAt": "2026-05-05T23:45:07.651Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56152,7 +56152,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.078Z",
+          "evaluatedAt": "2026-05-05T23:45:07.651Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56170,7 +56170,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.078Z",
+          "evaluatedAt": "2026-05-05T23:45:07.651Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56234,7 +56234,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.078Z",
+        "evaluatedAt": "2026-05-05T23:45:07.652Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56289,7 +56289,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.078Z",
+          "evaluatedAt": "2026-05-05T23:45:07.652Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56307,7 +56307,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.078Z",
+          "evaluatedAt": "2026-05-05T23:45:07.652Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56371,7 +56371,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.079Z",
+        "evaluatedAt": "2026-05-05T23:45:07.653Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56426,7 +56426,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.079Z",
+          "evaluatedAt": "2026-05-05T23:45:07.653Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56444,7 +56444,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.079Z",
+          "evaluatedAt": "2026-05-05T23:45:07.653Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56508,7 +56508,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.080Z",
+        "evaluatedAt": "2026-05-05T23:45:07.653Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56563,7 +56563,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.080Z",
+          "evaluatedAt": "2026-05-05T23:45:07.653Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56581,7 +56581,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.080Z",
+          "evaluatedAt": "2026-05-05T23:45:07.653Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56645,7 +56645,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.081Z",
+        "evaluatedAt": "2026-05-05T23:45:07.654Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56700,7 +56700,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.081Z",
+          "evaluatedAt": "2026-05-05T23:45:07.654Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56718,7 +56718,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.081Z",
+          "evaluatedAt": "2026-05-05T23:45:07.654Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56782,7 +56782,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.082Z",
+        "evaluatedAt": "2026-05-05T23:45:07.655Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56837,7 +56837,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.082Z",
+          "evaluatedAt": "2026-05-05T23:45:07.655Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56855,7 +56855,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.082Z",
+          "evaluatedAt": "2026-05-05T23:45:07.655Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56919,7 +56919,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.083Z",
+        "evaluatedAt": "2026-05-05T23:45:07.656Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56974,7 +56974,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.083Z",
+          "evaluatedAt": "2026-05-05T23:45:07.656Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56992,7 +56992,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.083Z",
+          "evaluatedAt": "2026-05-05T23:45:07.656Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57056,7 +57056,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.084Z",
+        "evaluatedAt": "2026-05-05T23:45:07.657Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57111,7 +57111,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.084Z",
+          "evaluatedAt": "2026-05-05T23:45:07.657Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57129,7 +57129,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.084Z",
+          "evaluatedAt": "2026-05-05T23:45:07.657Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57193,7 +57193,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.086Z",
+        "evaluatedAt": "2026-05-05T23:45:07.659Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57248,7 +57248,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.086Z",
+          "evaluatedAt": "2026-05-05T23:45:07.659Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57266,7 +57266,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.086Z",
+          "evaluatedAt": "2026-05-05T23:45:07.659Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57330,7 +57330,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.087Z",
+        "evaluatedAt": "2026-05-05T23:45:07.660Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57385,7 +57385,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.087Z",
+          "evaluatedAt": "2026-05-05T23:45:07.660Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57403,7 +57403,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.087Z",
+          "evaluatedAt": "2026-05-05T23:45:07.660Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57467,7 +57467,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.089Z",
+        "evaluatedAt": "2026-05-05T23:45:07.661Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57522,7 +57522,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.089Z",
+          "evaluatedAt": "2026-05-05T23:45:07.661Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57540,7 +57540,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.089Z",
+          "evaluatedAt": "2026-05-05T23:45:07.661Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57604,7 +57604,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.090Z",
+        "evaluatedAt": "2026-05-05T23:45:07.662Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57659,7 +57659,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.090Z",
+          "evaluatedAt": "2026-05-05T23:45:07.662Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57677,7 +57677,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.090Z",
+          "evaluatedAt": "2026-05-05T23:45:07.662Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57741,7 +57741,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.092Z",
+        "evaluatedAt": "2026-05-05T23:45:07.664Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57796,7 +57796,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.092Z",
+          "evaluatedAt": "2026-05-05T23:45:07.664Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57814,7 +57814,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.092Z",
+          "evaluatedAt": "2026-05-05T23:45:07.664Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57878,7 +57878,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.094Z",
+        "evaluatedAt": "2026-05-05T23:45:07.665Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57933,7 +57933,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.094Z",
+          "evaluatedAt": "2026-05-05T23:45:07.665Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57951,7 +57951,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.094Z",
+          "evaluatedAt": "2026-05-05T23:45:07.665Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58015,7 +58015,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.095Z",
+        "evaluatedAt": "2026-05-05T23:45:07.667Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -58070,7 +58070,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.095Z",
+          "evaluatedAt": "2026-05-05T23:45:07.667Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -58088,7 +58088,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.095Z",
+          "evaluatedAt": "2026-05-05T23:45:07.667Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -58152,7 +58152,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.097Z",
+        "evaluatedAt": "2026-05-05T23:45:07.669Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58207,7 +58207,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.097Z",
+          "evaluatedAt": "2026-05-05T23:45:07.669Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58225,7 +58225,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.097Z",
+          "evaluatedAt": "2026-05-05T23:45:07.669Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58289,7 +58289,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.099Z",
+        "evaluatedAt": "2026-05-05T23:45:07.670Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58344,7 +58344,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.099Z",
+          "evaluatedAt": "2026-05-05T23:45:07.670Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58362,7 +58362,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.099Z",
+          "evaluatedAt": "2026-05-05T23:45:07.670Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58426,7 +58426,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.100Z",
+        "evaluatedAt": "2026-05-05T23:45:07.672Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58481,7 +58481,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.100Z",
+          "evaluatedAt": "2026-05-05T23:45:07.672Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58499,7 +58499,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.100Z",
+          "evaluatedAt": "2026-05-05T23:45:07.672Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58563,7 +58563,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.103Z",
+        "evaluatedAt": "2026-05-05T23:45:07.674Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58618,7 +58618,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.103Z",
+          "evaluatedAt": "2026-05-05T23:45:07.674Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58636,7 +58636,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.103Z",
+          "evaluatedAt": "2026-05-05T23:45:07.674Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58700,7 +58700,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.104Z",
+        "evaluatedAt": "2026-05-05T23:45:07.676Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58755,7 +58755,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.104Z",
+          "evaluatedAt": "2026-05-05T23:45:07.676Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58773,7 +58773,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.104Z",
+          "evaluatedAt": "2026-05-05T23:45:07.676Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58837,7 +58837,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.106Z",
+        "evaluatedAt": "2026-05-05T23:45:07.677Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58892,7 +58892,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.106Z",
+          "evaluatedAt": "2026-05-05T23:45:07.678Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58910,7 +58910,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.106Z",
+          "evaluatedAt": "2026-05-05T23:45:07.678Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58974,7 +58974,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.108Z",
+        "evaluatedAt": "2026-05-05T23:45:07.679Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59029,7 +59029,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.108Z",
+          "evaluatedAt": "2026-05-05T23:45:07.679Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59047,7 +59047,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.108Z",
+          "evaluatedAt": "2026-05-05T23:45:07.679Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59111,7 +59111,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.109Z",
+        "evaluatedAt": "2026-05-05T23:45:07.680Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59166,7 +59166,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.109Z",
+          "evaluatedAt": "2026-05-05T23:45:07.680Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59184,7 +59184,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.109Z",
+          "evaluatedAt": "2026-05-05T23:45:07.680Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59248,7 +59248,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.110Z",
+        "evaluatedAt": "2026-05-05T23:45:07.681Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59303,7 +59303,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.110Z",
+          "evaluatedAt": "2026-05-05T23:45:07.681Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59321,7 +59321,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.110Z",
+          "evaluatedAt": "2026-05-05T23:45:07.681Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59385,7 +59385,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.111Z",
+        "evaluatedAt": "2026-05-05T23:45:07.682Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59440,7 +59440,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.111Z",
+          "evaluatedAt": "2026-05-05T23:45:07.682Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59458,7 +59458,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.111Z",
+          "evaluatedAt": "2026-05-05T23:45:07.682Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59522,7 +59522,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.113Z",
+        "evaluatedAt": "2026-05-05T23:45:07.684Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59577,7 +59577,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.113Z",
+          "evaluatedAt": "2026-05-05T23:45:07.684Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59595,7 +59595,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.113Z",
+          "evaluatedAt": "2026-05-05T23:45:07.684Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59659,7 +59659,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.114Z",
+        "evaluatedAt": "2026-05-05T23:45:07.685Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59714,7 +59714,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.114Z",
+          "evaluatedAt": "2026-05-05T23:45:07.685Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59732,7 +59732,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.114Z",
+          "evaluatedAt": "2026-05-05T23:45:07.685Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59796,7 +59796,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.115Z",
+        "evaluatedAt": "2026-05-05T23:45:07.686Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59851,7 +59851,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.115Z",
+          "evaluatedAt": "2026-05-05T23:45:07.686Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59869,7 +59869,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.115Z",
+          "evaluatedAt": "2026-05-05T23:45:07.686Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59933,7 +59933,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.116Z",
+        "evaluatedAt": "2026-05-05T23:45:07.687Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59988,7 +59988,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.116Z",
+          "evaluatedAt": "2026-05-05T23:45:07.687Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60006,7 +60006,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.116Z",
+          "evaluatedAt": "2026-05-05T23:45:07.687Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60070,7 +60070,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.117Z",
+        "evaluatedAt": "2026-05-05T23:45:07.687Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60125,7 +60125,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.117Z",
+          "evaluatedAt": "2026-05-05T23:45:07.688Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60143,7 +60143,7 @@
               "max": 1
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.117Z",
+          "evaluatedAt": "2026-05-05T23:45:07.688Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60207,7 +60207,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.117Z",
+        "evaluatedAt": "2026-05-05T23:45:07.688Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60262,7 +60262,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.117Z",
+          "evaluatedAt": "2026-05-05T23:45:07.688Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60280,7 +60280,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.117Z",
+          "evaluatedAt": "2026-05-05T23:45:07.688Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60344,7 +60344,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.118Z",
+        "evaluatedAt": "2026-05-05T23:45:07.689Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60399,7 +60399,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.118Z",
+          "evaluatedAt": "2026-05-05T23:45:07.689Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60417,7 +60417,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.118Z",
+          "evaluatedAt": "2026-05-05T23:45:07.689Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60481,7 +60481,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.119Z",
+        "evaluatedAt": "2026-05-05T23:45:07.690Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60536,7 +60536,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.119Z",
+          "evaluatedAt": "2026-05-05T23:45:07.690Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60554,7 +60554,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.119Z",
+          "evaluatedAt": "2026-05-05T23:45:07.690Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60618,7 +60618,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.120Z",
+        "evaluatedAt": "2026-05-05T23:45:07.690Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60673,7 +60673,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.120Z",
+          "evaluatedAt": "2026-05-05T23:45:07.690Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60691,7 +60691,7 @@
               "max": 1
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.120Z",
+          "evaluatedAt": "2026-05-05T23:45:07.690Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60755,7 +60755,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.120Z",
+        "evaluatedAt": "2026-05-05T23:45:07.691Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60810,7 +60810,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.120Z",
+          "evaluatedAt": "2026-05-05T23:45:07.691Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60828,7 +60828,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.120Z",
+          "evaluatedAt": "2026-05-05T23:45:07.691Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60892,7 +60892,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.121Z",
+        "evaluatedAt": "2026-05-05T23:45:07.692Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60947,7 +60947,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.121Z",
+          "evaluatedAt": "2026-05-05T23:45:07.692Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60965,7 +60965,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.121Z",
+          "evaluatedAt": "2026-05-05T23:45:07.692Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61029,7 +61029,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.123Z",
+        "evaluatedAt": "2026-05-05T23:45:07.694Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61084,7 +61084,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.123Z",
+          "evaluatedAt": "2026-05-05T23:45:07.694Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61102,7 +61102,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.123Z",
+          "evaluatedAt": "2026-05-05T23:45:07.694Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61166,7 +61166,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.124Z",
+        "evaluatedAt": "2026-05-05T23:45:07.695Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61221,7 +61221,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.125Z",
+          "evaluatedAt": "2026-05-05T23:45:07.695Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61239,7 +61239,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.125Z",
+          "evaluatedAt": "2026-05-05T23:45:07.695Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61303,7 +61303,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.127Z",
+        "evaluatedAt": "2026-05-05T23:45:07.697Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61358,7 +61358,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.127Z",
+          "evaluatedAt": "2026-05-05T23:45:07.697Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61376,7 +61376,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.127Z",
+          "evaluatedAt": "2026-05-05T23:45:07.697Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61440,7 +61440,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.129Z",
+        "evaluatedAt": "2026-05-05T23:45:07.699Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61495,7 +61495,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.129Z",
+          "evaluatedAt": "2026-05-05T23:45:07.699Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61513,7 +61513,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.129Z",
+          "evaluatedAt": "2026-05-05T23:45:07.699Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61577,7 +61577,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.130Z",
+        "evaluatedAt": "2026-05-05T23:45:07.701Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61632,7 +61632,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.131Z",
+          "evaluatedAt": "2026-05-05T23:45:07.701Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61650,7 +61650,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.131Z",
+          "evaluatedAt": "2026-05-05T23:45:07.701Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61714,7 +61714,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.131Z",
+        "evaluatedAt": "2026-05-05T23:45:07.701Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61769,7 +61769,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.131Z",
+          "evaluatedAt": "2026-05-05T23:45:07.702Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61787,7 +61787,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.131Z",
+          "evaluatedAt": "2026-05-05T23:45:07.702Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61851,7 +61851,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.132Z",
+        "evaluatedAt": "2026-05-05T23:45:07.703Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61906,7 +61906,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.132Z",
+          "evaluatedAt": "2026-05-05T23:45:07.703Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61924,7 +61924,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.132Z",
+          "evaluatedAt": "2026-05-05T23:45:07.703Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61988,7 +61988,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.133Z",
+        "evaluatedAt": "2026-05-05T23:45:07.704Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62043,7 +62043,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.134Z",
+          "evaluatedAt": "2026-05-05T23:45:07.704Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62061,7 +62061,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.134Z",
+          "evaluatedAt": "2026-05-05T23:45:07.704Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62125,7 +62125,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.135Z",
+        "evaluatedAt": "2026-05-05T23:45:07.705Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62180,7 +62180,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.135Z",
+          "evaluatedAt": "2026-05-05T23:45:07.705Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62198,7 +62198,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.135Z",
+          "evaluatedAt": "2026-05-05T23:45:07.705Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62262,7 +62262,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:54.136Z",
+        "evaluatedAt": "2026-05-05T23:45:07.706Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62317,7 +62317,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.136Z",
+          "evaluatedAt": "2026-05-05T23:45:07.706Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62335,7 +62335,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:54.136Z",
+          "evaluatedAt": "2026-05-05T23:45:07.706Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/alirezarezvani_claude-skills.json
+++ b/data/skill-index/alirezarezvani_claude-skills.json
@@ -2,8 +2,8 @@
   "repoUrl": "https://github.com/alirezarezvani/claude-skills.git",
   "owner": "alirezarezvani",
   "repo": "claude-skills",
-  "updatedAt": "2026-04-30T23:05:32.714Z",
-  "skillCount": 514,
+  "updatedAt": "2026-05-05T23:45:45.731Z",
+  "skillCount": 568,
   "skills": [
     {
       "name": "a11y-audit",
@@ -13,8 +13,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/a11y-audit",
-      "relPath": ".codex/skills/a11y-audit",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/a11y-audit/skills/a11y-audit",
+      "relPath": ".codex/skills/a11y-audit/skills/a11y-audit",
       "verified": true,
       "tokenCount": 2605,
       "evalSummary": {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.852Z",
+        "evaluatedAt": "2026-05-05T23:45:44.777Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.852Z",
+          "evaluatedAt": "2026-05-05T23:45:44.777Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,144 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.852Z",
-          "evaluatedVersion": "0.0.0"
-        }
-      }
-    },
-    {
-      "name": "a11y-audit",
-      "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines.",
-      "version": "0.0.0",
-      "license": "",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/a11y-audit",
-      "relPath": ".gemini/skills/a11y-audit",
-      "verified": true,
-      "tokenCount": 2605,
-      "evalSummary": {
-        "overallScore": 77,
-        "grade": "C",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 5,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 10,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:31.853Z",
-        "evaluatedVersion": "0.0.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 77,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 5,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 10,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.853Z",
-          "evaluatedVersion": "0.0.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 69,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 9,
-              "max": 13
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.853Z",
+          "evaluatedAt": "2026-05-05T23:45:44.777Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.854Z",
+        "evaluatedAt": "2026-05-05T23:45:44.779Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.854Z",
+          "evaluatedAt": "2026-05-05T23:45:44.779Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +274,144 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.854Z",
+          "evaluatedAt": "2026-05-05T23:45:44.779Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "a11y-audit",
+      "description": "Accessibility audit skill for scanning, fixing, and verifying WCAG 2.2 Level A and AA compliance across React, Next.js, Vue, Angular, Svelte, and plain HTML codebases. Use when auditing accessibility, fixing a11y violations, checking color contrast, generating compliance reports, or integrating accessibility checks into CI/CD pipelines.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/a11y-audit/skills/a11y-audit",
+      "relPath": "engineering-team/a11y-audit/skills/a11y-audit",
+      "verified": true,
+      "tokenCount": 2605,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.780Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.780Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.780Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.856Z",
+        "evaluatedAt": "2026-05-05T23:45:44.781Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.856Z",
+          "evaluatedAt": "2026-05-05T23:45:44.781Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.856Z",
+          "evaluatedAt": "2026-05-05T23:45:44.781Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -561,8 +561,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ab-test-setup",
-      "relPath": ".gemini/skills/ab-test-setup",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/ab-test-setup",
+      "relPath": "marketing-skill/skills/ab-test-setup",
       "verified": true,
       "tokenCount": 2624,
       "evalSummary": {
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.857Z",
+        "evaluatedAt": "2026-05-05T23:45:44.783Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.858Z",
+          "evaluatedAt": "2026-05-05T23:45:44.783Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.858Z",
+          "evaluatedAt": "2026-05-05T23:45:44.783Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.859Z",
+        "evaluatedAt": "2026-05-05T23:45:44.785Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.859Z",
+          "evaluatedAt": "2026-05-05T23:45:44.785Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.859Z",
+          "evaluatedAt": "2026-05-05T23:45:44.785Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -835,8 +835,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ad-creative",
-      "relPath": ".gemini/skills/ad-creative",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/ad-creative",
+      "relPath": "marketing-skill/skills/ad-creative",
       "verified": true,
       "tokenCount": 3422,
       "evalSummary": {
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.861Z",
+        "evaluatedAt": "2026-05-05T23:45:44.787Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.861Z",
+          "evaluatedAt": "2026-05-05T23:45:44.787Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.861Z",
+          "evaluatedAt": "2026-05-05T23:45:44.787Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.863Z",
+        "evaluatedAt": "2026-05-05T23:45:44.789Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.863Z",
+          "evaluatedAt": "2026-05-05T23:45:44.790Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.863Z",
+          "evaluatedAt": "2026-05-05T23:45:44.790Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1109,8 +1109,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/adversarial-reviewer",
-      "relPath": ".gemini/skills/adversarial-reviewer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/adversarial-reviewer",
+      "relPath": "engineering-team/skills/adversarial-reviewer",
       "verified": true,
       "tokenCount": 3464,
       "evalSummary": {
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.865Z",
+        "evaluatedAt": "2026-05-05T23:45:44.792Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.865Z",
+          "evaluatedAt": "2026-05-05T23:45:44.792Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.865Z",
+          "evaluatedAt": "2026-05-05T23:45:44.792Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.867Z",
+        "evaluatedAt": "2026-05-05T23:45:44.793Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.867Z",
+          "evaluatedAt": "2026-05-05T23:45:44.793Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 1
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.867Z",
+          "evaluatedAt": "2026-05-05T23:45:44.793Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.867Z",
+        "evaluatedAt": "2026-05-05T23:45:44.794Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.867Z",
+          "evaluatedAt": "2026-05-05T23:45:44.794Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.867Z",
+          "evaluatedAt": "2026-05-05T23:45:44.794Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.869Z",
+        "evaluatedAt": "2026-05-05T23:45:44.795Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.869Z",
+          "evaluatedAt": "2026-05-05T23:45:44.795Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.869Z",
+          "evaluatedAt": "2026-05-05T23:45:44.795Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1657,8 +1657,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/agent-designer",
-      "relPath": ".gemini/skills/agent-designer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/agent-designer",
+      "relPath": "engineering/skills/agent-designer",
       "verified": true,
       "tokenCount": 2707,
       "evalSummary": {
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.870Z",
+        "evaluatedAt": "2026-05-05T23:45:44.797Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.870Z",
+          "evaluatedAt": "2026-05-05T23:45:44.797Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.870Z",
+          "evaluatedAt": "2026-05-05T23:45:44.797Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.872Z",
+        "evaluatedAt": "2026-05-05T23:45:44.799Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.872Z",
+          "evaluatedAt": "2026-05-05T23:45:44.799Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.872Z",
+          "evaluatedAt": "2026-05-05T23:45:44.799Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1931,8 +1931,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/agent-protocol",
-      "relPath": ".gemini/skills/agent-protocol",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/agent-protocol",
+      "relPath": "c-level-advisor/skills/agent-protocol",
       "verified": true,
       "tokenCount": 3901,
       "evalSummary": {
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.875Z",
+        "evaluatedAt": "2026-05-05T23:45:44.802Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.875Z",
+          "evaluatedAt": "2026-05-05T23:45:44.802Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.875Z",
+          "evaluatedAt": "2026-05-05T23:45:44.802Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.876Z",
+        "evaluatedAt": "2026-05-05T23:45:44.804Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.876Z",
+          "evaluatedAt": "2026-05-05T23:45:44.804Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.876Z",
+          "evaluatedAt": "2026-05-05T23:45:44.804Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2205,8 +2205,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/agent-workflow-designer",
-      "relPath": ".gemini/skills/agent-workflow-designer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/agent-workflow-designer",
+      "relPath": "engineering/skills/agent-workflow-designer",
       "verified": true,
       "tokenCount": 555,
       "evalSummary": {
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.877Z",
+        "evaluatedAt": "2026-05-05T23:45:44.805Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.877Z",
+          "evaluatedAt": "2026-05-05T23:45:44.805Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.877Z",
+          "evaluatedAt": "2026-05-05T23:45:44.805Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2342,8 +2342,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub",
-      "relPath": ".codex/skills/agenthub",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/agenthub",
+      "relPath": ".codex/skills/agenthub/skills/agenthub",
       "verified": true,
       "tokenCount": 2162,
       "evalSummary": {
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.878Z",
+        "evaluatedAt": "2026-05-05T23:45:44.806Z",
         "evaluatedVersion": "2.1.2"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.878Z",
+          "evaluatedAt": "2026-05-05T23:45:44.806Z",
           "evaluatedVersion": "2.1.2"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.878Z",
+          "evaluatedAt": "2026-05-05T23:45:44.806Z",
           "evaluatedVersion": "2.1.2"
         }
       }
@@ -2479,8 +2479,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/agenthub",
-      "relPath": ".gemini/skills/agenthub",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/agenthub/skills/agenthub",
+      "relPath": "engineering/agenthub/skills/agenthub",
       "verified": true,
       "tokenCount": 2162,
       "evalSummary": {
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.880Z",
+        "evaluatedAt": "2026-05-05T23:45:44.807Z",
         "evaluatedVersion": "2.1.2"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.880Z",
+          "evaluatedAt": "2026-05-05T23:45:44.807Z",
           "evaluatedVersion": "2.1.2"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.880Z",
+          "evaluatedAt": "2026-05-05T23:45:44.807Z",
           "evaluatedVersion": "2.1.2"
         }
       }
@@ -2616,8 +2616,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agile-product-owner",
-      "relPath": ".codex/skills/agile-product-owner",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agile-product-owner/skills/agile-product-owner",
+      "relPath": ".codex/skills/agile-product-owner/skills/agile-product-owner",
       "verified": true,
       "tokenCount": 3555,
       "evalSummary": {
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.881Z",
+        "evaluatedAt": "2026-05-05T23:45:44.809Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.881Z",
+          "evaluatedAt": "2026-05-05T23:45:44.809Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.881Z",
+          "evaluatedAt": "2026-05-05T23:45:44.809Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2753,8 +2753,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/agile-product-owner",
-      "relPath": ".gemini/skills/agile-product-owner",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/agile-product-owner/skills/agile-product-owner",
+      "relPath": "product-team/agile-product-owner/skills/agile-product-owner",
       "verified": true,
       "tokenCount": 3555,
       "evalSummary": {
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.883Z",
+        "evaluatedAt": "2026-05-05T23:45:44.812Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.883Z",
+          "evaluatedAt": "2026-05-05T23:45:44.812Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.883Z",
+          "evaluatedAt": "2026-05-05T23:45:44.812Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.886Z",
+        "evaluatedAt": "2026-05-05T23:45:44.814Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.886Z",
+          "evaluatedAt": "2026-05-05T23:45:44.814Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.886Z",
+          "evaluatedAt": "2026-05-05T23:45:44.814Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3027,8 +3027,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ai-security",
-      "relPath": ".gemini/skills/ai-security",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/ai-security",
+      "relPath": "engineering-team/skills/ai-security",
       "verified": true,
       "tokenCount": 4674,
       "evalSummary": {
@@ -3078,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.888Z",
+        "evaluatedAt": "2026-05-05T23:45:44.818Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3133,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.888Z",
+          "evaluatedAt": "2026-05-05T23:45:44.818Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3151,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.888Z",
+          "evaluatedAt": "2026-05-05T23:45:44.818Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3215,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.891Z",
+        "evaluatedAt": "2026-05-05T23:45:44.822Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3270,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.891Z",
+          "evaluatedAt": "2026-05-05T23:45:44.822Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3288,7 +3288,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.891Z",
+          "evaluatedAt": "2026-05-05T23:45:44.822Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3301,8 +3301,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ai-seo",
-      "relPath": ".gemini/skills/ai-seo",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/ai-seo",
+      "relPath": "marketing-skill/skills/ai-seo",
       "verified": true,
       "tokenCount": 4792,
       "evalSummary": {
@@ -3352,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.894Z",
+        "evaluatedAt": "2026-05-05T23:45:44.825Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3407,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.894Z",
+          "evaluatedAt": "2026-05-05T23:45:44.825Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3425,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.894Z",
+          "evaluatedAt": "2026-05-05T23:45:44.825Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3489,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.897Z",
+        "evaluatedAt": "2026-05-05T23:45:44.828Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3544,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.897Z",
+          "evaluatedAt": "2026-05-05T23:45:44.828Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3562,7 +3562,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.897Z",
+          "evaluatedAt": "2026-05-05T23:45:44.828Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3575,8 +3575,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/analytics-tracking",
-      "relPath": ".gemini/skills/analytics-tracking",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/analytics-tracking",
+      "relPath": "marketing-skill/skills/analytics-tracking",
       "verified": true,
       "tokenCount": 4077,
       "evalSummary": {
@@ -3626,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.899Z",
+        "evaluatedAt": "2026-05-05T23:45:44.830Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -3681,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.899Z",
+          "evaluatedAt": "2026-05-05T23:45:44.830Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3699,7 +3699,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.899Z",
+          "evaluatedAt": "2026-05-05T23:45:44.830Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -3763,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.902Z",
+        "evaluatedAt": "2026-05-05T23:45:44.833Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3818,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.902Z",
+          "evaluatedAt": "2026-05-05T23:45:44.833Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3836,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.902Z",
+          "evaluatedAt": "2026-05-05T23:45:44.833Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3849,8 +3849,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/api-design-reviewer",
-      "relPath": ".gemini/skills/api-design-reviewer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/api-design-reviewer",
+      "relPath": "engineering/skills/api-design-reviewer",
       "verified": true,
       "tokenCount": 2861,
       "evalSummary": {
@@ -3900,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.904Z",
+        "evaluatedAt": "2026-05-05T23:45:44.835Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3955,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.904Z",
+          "evaluatedAt": "2026-05-05T23:45:44.835Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3973,7 +3973,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.904Z",
+          "evaluatedAt": "2026-05-05T23:45:44.835Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4037,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.906Z",
+        "evaluatedAt": "2026-05-05T23:45:44.837Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4092,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.906Z",
+          "evaluatedAt": "2026-05-05T23:45:44.837Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4110,7 +4110,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.906Z",
+          "evaluatedAt": "2026-05-05T23:45:44.837Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4123,8 +4123,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/api-test-suite-builder",
-      "relPath": ".gemini/skills/api-test-suite-builder",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/api-test-suite-builder",
+      "relPath": "engineering/skills/api-test-suite-builder",
       "verified": true,
       "tokenCount": 1759,
       "evalSummary": {
@@ -4174,7 +4174,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.907Z",
+        "evaluatedAt": "2026-05-05T23:45:44.838Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4229,7 +4229,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.907Z",
+          "evaluatedAt": "2026-05-05T23:45:44.838Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4247,7 +4247,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.907Z",
+          "evaluatedAt": "2026-05-05T23:45:44.839Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4311,7 +4311,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.909Z",
+        "evaluatedAt": "2026-05-05T23:45:44.840Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4366,7 +4366,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.909Z",
+          "evaluatedAt": "2026-05-05T23:45:44.840Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4384,7 +4384,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.909Z",
+          "evaluatedAt": "2026-05-05T23:45:44.840Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4397,8 +4397,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/app-store-optimization",
-      "relPath": ".gemini/skills/app-store-optimization",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/app-store-optimization",
+      "relPath": "marketing-skill/skills/app-store-optimization",
       "verified": true,
       "tokenCount": 4649,
       "evalSummary": {
@@ -4448,7 +4448,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.911Z",
+        "evaluatedAt": "2026-05-05T23:45:44.843Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4503,7 +4503,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.912Z",
+          "evaluatedAt": "2026-05-05T23:45:44.843Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4521,7 +4521,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.912Z",
+          "evaluatedAt": "2026-05-05T23:45:44.843Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4534,8 +4534,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/apple-hig-expert",
-      "relPath": ".codex/skills/apple-hig-expert",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/apple-hig-expert/skills/apple-hig-expert",
+      "relPath": ".codex/skills/apple-hig-expert/skills/apple-hig-expert",
       "verified": true,
       "tokenCount": 964,
       "evalSummary": {
@@ -4585,7 +4585,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.914Z",
+        "evaluatedAt": "2026-05-05T23:45:44.845Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -4640,7 +4640,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.914Z",
+          "evaluatedAt": "2026-05-05T23:45:44.845Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -4658,7 +4658,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.914Z",
+          "evaluatedAt": "2026-05-05T23:45:44.845Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -4671,8 +4671,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/apple-hig-expert",
-      "relPath": ".gemini/skills/apple-hig-expert",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/apple-hig-expert/skills/apple-hig-expert",
+      "relPath": "product-team/apple-hig-expert/skills/apple-hig-expert",
       "verified": true,
       "tokenCount": 964,
       "evalSummary": {
@@ -4722,7 +4722,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.915Z",
+        "evaluatedAt": "2026-05-05T23:45:44.846Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -4777,7 +4777,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.915Z",
+          "evaluatedAt": "2026-05-05T23:45:44.846Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -4795,7 +4795,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.915Z",
+          "evaluatedAt": "2026-05-05T23:45:44.846Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -4859,7 +4859,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.916Z",
+        "evaluatedAt": "2026-05-05T23:45:44.848Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4914,7 +4914,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.916Z",
+          "evaluatedAt": "2026-05-05T23:45:44.848Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4932,7 +4932,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.916Z",
+          "evaluatedAt": "2026-05-05T23:45:44.848Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4945,8 +4945,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/atlassian-admin",
-      "relPath": ".gemini/skills/atlassian-admin",
+      "installUrl": "github:alirezarezvani/claude-skills:project-management/skills/atlassian-admin",
+      "relPath": "project-management/skills/atlassian-admin",
       "verified": true,
       "tokenCount": 3111,
       "evalSummary": {
@@ -4996,7 +4996,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.918Z",
+        "evaluatedAt": "2026-05-05T23:45:44.850Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5051,7 +5051,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.918Z",
+          "evaluatedAt": "2026-05-05T23:45:44.850Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5069,7 +5069,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.918Z",
+          "evaluatedAt": "2026-05-05T23:45:44.850Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5133,7 +5133,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.920Z",
+        "evaluatedAt": "2026-05-05T23:45:44.852Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5188,7 +5188,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.920Z",
+          "evaluatedAt": "2026-05-05T23:45:44.852Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5206,7 +5206,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.920Z",
+          "evaluatedAt": "2026-05-05T23:45:44.852Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5219,8 +5219,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/atlassian-templates",
-      "relPath": ".gemini/skills/atlassian-templates",
+      "installUrl": "github:alirezarezvani/claude-skills:project-management/skills/atlassian-templates",
+      "relPath": "project-management/skills/atlassian-templates",
       "verified": true,
       "tokenCount": 2511,
       "evalSummary": {
@@ -5270,7 +5270,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.921Z",
+        "evaluatedAt": "2026-05-05T23:45:44.853Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5325,7 +5325,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.922Z",
+          "evaluatedAt": "2026-05-05T23:45:44.853Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5343,7 +5343,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.921Z",
+          "evaluatedAt": "2026-05-05T23:45:44.853Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5356,8 +5356,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent",
-      "relPath": ".codex/skills/autoresearch-agent",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/autoresearch-agent",
+      "relPath": ".codex/skills/autoresearch-agent/skills/autoresearch-agent",
       "verified": true,
       "tokenCount": 3493,
       "evalSummary": {
@@ -5407,7 +5407,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.924Z",
+        "evaluatedAt": "2026-05-05T23:45:44.855Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -5462,7 +5462,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.924Z",
+          "evaluatedAt": "2026-05-05T23:45:44.855Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -5480,7 +5480,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.924Z",
+          "evaluatedAt": "2026-05-05T23:45:44.855Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -5493,8 +5493,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/autoresearch-agent",
-      "relPath": ".gemini/skills/autoresearch-agent",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/autoresearch-agent/skills/autoresearch-agent",
+      "relPath": "engineering/autoresearch-agent/skills/autoresearch-agent",
       "verified": true,
       "tokenCount": 3493,
       "evalSummary": {
@@ -5544,7 +5544,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.926Z",
+        "evaluatedAt": "2026-05-05T23:45:44.858Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -5599,7 +5599,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.926Z",
+          "evaluatedAt": "2026-05-05T23:45:44.858Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -5617,7 +5617,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.926Z",
+          "evaluatedAt": "2026-05-05T23:45:44.858Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -5681,7 +5681,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.930Z",
+        "evaluatedAt": "2026-05-05T23:45:44.860Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5736,7 +5736,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.930Z",
+          "evaluatedAt": "2026-05-05T23:45:44.860Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5754,7 +5754,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.930Z",
+          "evaluatedAt": "2026-05-05T23:45:44.860Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5767,8 +5767,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/aws-solution-architect",
-      "relPath": ".gemini/skills/aws-solution-architect",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/aws-solution-architect",
+      "relPath": "engineering-team/skills/aws-solution-architect",
       "verified": true,
       "tokenCount": 2498,
       "evalSummary": {
@@ -5818,7 +5818,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.932Z",
+        "evaluatedAt": "2026-05-05T23:45:44.861Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5873,7 +5873,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.932Z",
+          "evaluatedAt": "2026-05-05T23:45:44.861Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5891,7 +5891,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.932Z",
+          "evaluatedAt": "2026-05-05T23:45:44.861Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5955,7 +5955,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.934Z",
+        "evaluatedAt": "2026-05-05T23:45:44.863Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6010,7 +6010,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.934Z",
+          "evaluatedAt": "2026-05-05T23:45:44.863Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6028,7 +6028,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.934Z",
+          "evaluatedAt": "2026-05-05T23:45:44.863Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6041,8 +6041,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/azure-cloud-architect",
-      "relPath": ".gemini/skills/azure-cloud-architect",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/azure-cloud-architect",
+      "relPath": "engineering-team/skills/azure-cloud-architect",
       "verified": true,
       "tokenCount": 3602,
       "evalSummary": {
@@ -6092,7 +6092,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.936Z",
+        "evaluatedAt": "2026-05-05T23:45:44.866Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6147,7 +6147,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.936Z",
+          "evaluatedAt": "2026-05-05T23:45:44.866Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6165,7 +6165,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.936Z",
+          "evaluatedAt": "2026-05-05T23:45:44.866Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6178,8 +6178,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/behuman",
-      "relPath": ".codex/skills/behuman",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/behuman/skills/behuman",
+      "relPath": ".codex/skills/behuman/skills/behuman",
       "verified": true,
       "tokenCount": 2434,
       "evalSummary": {
@@ -6229,7 +6229,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.939Z",
+        "evaluatedAt": "2026-05-05T23:45:44.868Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6284,7 +6284,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.939Z",
+          "evaluatedAt": "2026-05-05T23:45:44.868Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6302,7 +6302,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.939Z",
+          "evaluatedAt": "2026-05-05T23:45:44.868Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6315,8 +6315,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/behuman",
-      "relPath": ".gemini/skills/behuman",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/behuman/skills/behuman",
+      "relPath": "engineering/behuman/skills/behuman",
       "verified": true,
       "tokenCount": 2434,
       "evalSummary": {
@@ -6366,7 +6366,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.940Z",
+        "evaluatedAt": "2026-05-05T23:45:44.869Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6421,7 +6421,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.940Z",
+          "evaluatedAt": "2026-05-05T23:45:44.869Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6439,7 +6439,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.940Z",
+          "evaluatedAt": "2026-05-05T23:45:44.869Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "board",
+      "description": "Read, write, and browse the AgentHub message board for agent coordination.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/board",
+      "relPath": ".codex/skills/agenthub/skills/board",
+      "verified": true,
+      "tokenCount": 637,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.871Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 59,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.871Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.871Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6503,7 +6640,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.942Z",
+        "evaluatedAt": "2026-05-05T23:45:44.872Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6558,7 +6695,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.942Z",
+          "evaluatedAt": "2026-05-05T23:45:44.872Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6576,7 +6713,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.942Z",
+          "evaluatedAt": "2026-05-05T23:45:44.872Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "board",
+      "description": "Read, write, and browse the AgentHub message board for agent coordination.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/agenthub/skills/board",
+      "relPath": "engineering/agenthub/skills/board",
+      "verified": true,
+      "tokenCount": 637,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.872Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 59,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.872Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.872Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6640,7 +6914,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.943Z",
+        "evaluatedAt": "2026-05-05T23:45:44.873Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -6695,7 +6969,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.943Z",
+          "evaluatedAt": "2026-05-05T23:45:44.873Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -6713,7 +6987,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.943Z",
+          "evaluatedAt": "2026-05-05T23:45:44.873Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -6726,8 +7000,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/board-deck-builder",
-      "relPath": ".gemini/skills/board-deck-builder",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/board-deck-builder",
+      "relPath": "c-level-advisor/skills/board-deck-builder",
       "verified": true,
       "tokenCount": 2264,
       "evalSummary": {
@@ -6777,7 +7051,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.944Z",
+        "evaluatedAt": "2026-05-05T23:45:44.875Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -6832,7 +7106,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.944Z",
+          "evaluatedAt": "2026-05-05T23:45:44.875Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -6850,7 +7124,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.945Z",
+          "evaluatedAt": "2026-05-05T23:45:44.875Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -6914,7 +7188,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.946Z",
+        "evaluatedAt": "2026-05-05T23:45:44.877Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -6969,7 +7243,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.946Z",
+          "evaluatedAt": "2026-05-05T23:45:44.877Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -6987,7 +7261,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.946Z",
+          "evaluatedAt": "2026-05-05T23:45:44.877Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -7000,8 +7274,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/board-meeting",
-      "relPath": ".gemini/skills/board-meeting",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/board-meeting",
+      "relPath": "c-level-advisor/skills/board-meeting",
       "verified": true,
       "tokenCount": 1456,
       "evalSummary": {
@@ -7051,7 +7325,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.947Z",
+        "evaluatedAt": "2026-05-05T23:45:44.878Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -7106,7 +7380,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.947Z",
+          "evaluatedAt": "2026-05-05T23:45:44.878Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -7124,8 +7398,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.947Z",
+          "evaluatedAt": "2026-05-05T23:45:44.878Z",
           "evaluatedVersion": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "board-prep",
+      "description": "/em -board-prep — Board Meeting Preparation",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/board-prep",
+      "relPath": ".codex/skills/executive-mentor/skills/board-prep",
+      "verified": true,
+      "tokenCount": 2027,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.879Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 59,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.879Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.879Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -7188,7 +7599,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.948Z",
+        "evaluatedAt": "2026-05-05T23:45:44.881Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7243,7 +7654,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.948Z",
+          "evaluatedAt": "2026-05-05T23:45:44.881Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7261,7 +7672,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.948Z",
+          "evaluatedAt": "2026-05-05T23:45:44.881Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "board-prep",
+      "description": "/em -board-prep — Board Meeting Preparation",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/executive-mentor/skills/board-prep",
+      "relPath": "c-level-advisor/executive-mentor/skills/board-prep",
+      "verified": true,
+      "tokenCount": 2027,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.882Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 59,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.882Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.882Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7325,7 +7873,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.950Z",
+        "evaluatedAt": "2026-05-05T23:45:44.884Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -7380,7 +7928,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.950Z",
+          "evaluatedAt": "2026-05-05T23:45:44.884Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -7398,7 +7946,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.950Z",
+          "evaluatedAt": "2026-05-05T23:45:44.884Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -7411,8 +7959,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/brand-guidelines",
-      "relPath": ".gemini/skills/brand-guidelines",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/brand-guidelines",
+      "relPath": "marketing-skill/skills/brand-guidelines",
       "verified": true,
       "tokenCount": 1547,
       "evalSummary": {
@@ -7462,7 +8010,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.951Z",
+        "evaluatedAt": "2026-05-05T23:45:44.885Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -7517,7 +8065,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.951Z",
+          "evaluatedAt": "2026-05-05T23:45:44.885Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -7535,7 +8083,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.951Z",
+          "evaluatedAt": "2026-05-05T23:45:44.885Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -7599,7 +8147,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.953Z",
+        "evaluatedAt": "2026-05-05T23:45:44.887Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7654,7 +8202,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.953Z",
+          "evaluatedAt": "2026-05-05T23:45:44.887Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7672,7 +8220,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.953Z",
+          "evaluatedAt": "2026-05-05T23:45:44.887Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7685,8 +8233,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/browser-automation",
-      "relPath": ".gemini/skills/browser-automation",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/browser-automation",
+      "relPath": "engineering/skills/browser-automation",
       "verified": true,
       "tokenCount": 3487,
       "evalSummary": {
@@ -7736,7 +8284,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.955Z",
+        "evaluatedAt": "2026-05-05T23:45:44.889Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7791,7 +8339,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.955Z",
+          "evaluatedAt": "2026-05-05T23:45:44.889Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7809,7 +8357,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.955Z",
+          "evaluatedAt": "2026-05-05T23:45:44.889Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "browserstack",
+      "description": "Run tests on BrowserStack. Use when user mentions \"browserstack\", \"cross-browser\", \"cloud testing\", \"browser matrix\", \"test on safari\", \"test on firefox\", or \"browser compatibility\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/browserstack",
+      "relPath": ".codex/skills/playwright-pro/skills/browserstack",
+      "verified": true,
+      "tokenCount": 1211,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.891Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 81,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.891Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.891Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7873,7 +8558,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.957Z",
+        "evaluatedAt": "2026-05-05T23:45:44.892Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7928,7 +8613,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.957Z",
+          "evaluatedAt": "2026-05-05T23:45:44.892Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7946,852 +8631,715 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.957Z",
+          "evaluatedAt": "2026-05-05T23:45:44.892Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
-      "name": "business-growth-skills",
-      "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
-      "version": "1.1.0",
-      "license": "MIT",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/business-growth-bundle",
-      "relPath": ".gemini/skills/business-growth-bundle",
-      "verified": true,
-      "tokenCount": 368,
-      "evalSummary": {
-        "overallScore": 64,
-        "grade": "D",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
-            "score": 10,
-            "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 8,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 2,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 0,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:31.958Z",
-        "evaluatedVersion": "1.1.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 64,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 8,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 2,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 0,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 9,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.958Z",
-          "evaluatedVersion": "1.1.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 54,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 7,
-              "max": 13
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.958Z",
-          "evaluatedVersion": "1.1.0"
-        }
-      }
-    },
-    {
-      "name": "business-growth-skills",
-      "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
-      "version": "1.1.0",
-      "license": "MIT",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:business-growth",
-      "relPath": "business-growth",
-      "verified": true,
-      "tokenCount": 368,
-      "evalSummary": {
-        "overallScore": 64,
-        "grade": "D",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
-            "score": 10,
-            "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 8,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 2,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 0,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:31.959Z",
-        "evaluatedVersion": "1.1.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 64,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 8,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 2,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 0,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 9,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.959Z",
-          "evaluatedVersion": "1.1.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 54,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 7,
-              "max": 13
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.959Z",
-          "evaluatedVersion": "1.1.0"
-        }
-      }
-    },
-    {
-      "name": "business-investment-advisor",
-      "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
+      "name": "browserstack",
+      "description": "Run tests on BrowserStack. Use when user mentions \"browserstack\", \"cross-browser\", \"cloud testing\", \"browser matrix\", \"test on safari\", \"test on firefox\", or \"browser compatibility\".",
       "version": "0.0.0",
       "license": "",
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-investment-advisor",
-      "relPath": ".codex/skills/business-investment-advisor",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/playwright-pro/skills/browserstack",
+      "relPath": "engineering-team/playwright-pro/skills/browserstack",
       "verified": true,
-      "tokenCount": 3031,
+      "tokenCount": 1211,
       "evalSummary": {
-        "overallScore": 63,
-        "grade": "D",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 5,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 5,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 6,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 2,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 10,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:31.960Z",
-        "evaluatedVersion": "0.0.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 63,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 5,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 5,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 6,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 2,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 10,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.960Z",
-          "evaluatedVersion": "0.0.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 69,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 9,
-              "max": 13
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.960Z",
-          "evaluatedVersion": "0.0.0"
-        }
-      }
-    },
-    {
-      "name": "business-investment-advisor",
-      "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
-      "version": "0.0.0",
-      "license": "",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/business-investment-advisor",
-      "relPath": ".gemini/skills/business-investment-advisor",
-      "verified": true,
-      "tokenCount": 3031,
-      "evalSummary": {
-        "overallScore": 63,
-        "grade": "D",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 5,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 5,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 6,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 2,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 10,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:31.962Z",
-        "evaluatedVersion": "0.0.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 63,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 5,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 5,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 6,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 2,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 10,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.962Z",
-          "evaluatedVersion": "0.0.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 69,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 9,
-              "max": 13
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.962Z",
-          "evaluatedVersion": "0.0.0"
-        }
-      }
-    },
-    {
-      "name": "c-level-advisor",
-      "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
-      "version": "2.0.0",
-      "license": "MIT",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/c-level-advisor-bundle",
-      "relPath": ".gemini/skills/c-level-advisor-bundle",
-      "verified": true,
-      "tokenCount": 1775,
-      "evalSummary": {
-        "overallScore": 79,
-        "grade": "C",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
-            "score": 10,
-            "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 10,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 3,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:31.964Z",
-        "evaluatedVersion": "2.0.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 79,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 3,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 9,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.964Z",
-          "evaluatedVersion": "2.0.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 79,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 11,
-              "max": 14
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.964Z",
-          "evaluatedVersion": "2.0.0"
-        }
-      }
-    },
-    {
-      "name": "c-level-advisor",
-      "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
-      "version": "2.0.0",
-      "license": "MIT",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/c-level-advisor-main",
-      "relPath": ".gemini/skills/c-level-advisor-main",
-      "verified": true,
-      "tokenCount": 1775,
-      "evalSummary": {
-        "overallScore": 79,
-        "grade": "C",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
-            "score": 10,
-            "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 10,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 3,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:31.965Z",
-        "evaluatedVersion": "2.0.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 79,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 3,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 9,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.965Z",
-          "evaluatedVersion": "2.0.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 79,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 11,
-              "max": 14
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:31.965Z",
-          "evaluatedVersion": "2.0.0"
-        }
-      }
-    },
-    {
-      "name": "c-level-advisor",
-      "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
-      "version": "2.0.0",
-      "license": "MIT",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor",
-      "relPath": "c-level-advisor",
-      "verified": true,
-      "tokenCount": 1775,
-      "evalSummary": {
-        "overallScore": 80,
+        "overallScore": 81,
         "grade": "B",
         "categories": [
           {
             "id": "structure",
             "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.893Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 81,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.893Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.893Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "business-growth-skills",
+      "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
+      "version": "1.1.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-growth-skills",
+      "relPath": ".codex/skills/business-growth-skills",
+      "verified": true,
+      "tokenCount": 368,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.894Z",
+        "evaluatedVersion": "1.1.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 66,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.894Z",
+          "evaluatedVersion": "1.1.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.894Z",
+          "evaluatedVersion": "1.1.0"
+        }
+      }
+    },
+    {
+      "name": "business-growth-skills",
+      "description": "4 business growth agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Customer success (health scoring, churn), sales engineer (RFP), revenue operations (pipeline, GTM), contract & proposal writer. Python tools (stdlib-only).",
+      "version": "1.1.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:business-growth/skills/business-growth-skills",
+      "relPath": "business-growth/skills/business-growth-skills",
+      "verified": true,
+      "tokenCount": 368,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.894Z",
+        "evaluatedVersion": "1.1.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 66,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.894Z",
+          "evaluatedVersion": "1.1.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.894Z",
+          "evaluatedVersion": "1.1.0"
+        }
+      }
+    },
+    {
+      "name": "business-investment-advisor",
+      "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/business-investment-advisor/skills/business-investment-advisor",
+      "relPath": ".codex/skills/business-investment-advisor/skills/business-investment-advisor",
+      "verified": true,
+      "tokenCount": 3031,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.895Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 63,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.895Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.895Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "business-investment-advisor",
+      "description": "Business investment analysis and capital allocation advisor. Use when evaluating whether to invest in equipment, real estate, a new business, hiring, technology, or any capital expenditure. Also use for ROI calculations, IRR, NPV, payback period, build vs buy decisions, lease vs buy analysis, vendor evaluation, or deciding where to allocate limited budget for maximum return.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:finance/business-investment-advisor/skills/business-investment-advisor",
+      "relPath": "finance/business-investment-advisor/skills/business-investment-advisor",
+      "verified": true,
+      "tokenCount": 3031,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.897Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 63,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.897Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.897Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "c-level-advisor",
+      "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
+      "version": "2.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/c-level-skills",
+      "relPath": ".codex/skills/c-level-skills",
+      "verified": true,
+      "tokenCount": 1775,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
             "score": 10,
             "max": 10
           },
@@ -8828,11 +9376,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 10,
+            "score": 9,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.966Z",
+        "evaluatedAt": "2026-05-05T23:45:44.899Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -8841,8 +9389,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 80,
-          "grade": "B",
+          "overallScore": 79,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
@@ -8883,29 +9431,166 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 10,
+              "score": 9,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.966Z",
+          "evaluatedAt": "2026-05-05T23:45:44.899Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
           "providerId": "skill-best-practice",
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 86,
-          "grade": "B",
+          "passed": false,
+          "overallScore": 79,
+          "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 12,
+              "score": 11,
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.966Z",
+          "evaluatedAt": "2026-05-05T23:45:44.899Z",
+          "evaluatedVersion": "2.0.0"
+        }
+      }
+    },
+    {
+      "name": "c-level-advisor",
+      "description": "10 C-level advisory agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. CEO, CTO, COO, CPO, CMO, CFO, CRO, CISO, CHRO, Executive Mentor. Multi-role board meetings, strategy routing, structured recommendations. For founders needing executive-level decision support.",
+      "version": "2.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/c-level-skills",
+      "relPath": "c-level-advisor/skills/c-level-skills",
+      "verified": true,
+      "tokenCount": 1775,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 9,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.900Z",
+        "evaluatedVersion": "2.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 9,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.900Z",
+          "evaluatedVersion": "2.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 11,
+              "max": 14
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.900Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -8969,7 +9654,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.968Z",
+        "evaluatedAt": "2026-05-05T23:45:44.901Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -9024,7 +9709,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.968Z",
+          "evaluatedAt": "2026-05-05T23:45:44.901Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -9042,7 +9727,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.968Z",
+          "evaluatedAt": "2026-05-05T23:45:44.901Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -9055,8 +9740,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/campaign-analytics",
-      "relPath": ".gemini/skills/campaign-analytics",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/campaign-analytics",
+      "relPath": "marketing-skill/skills/campaign-analytics",
       "verified": true,
       "tokenCount": 2077,
       "evalSummary": {
@@ -9106,7 +9791,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.969Z",
+        "evaluatedAt": "2026-05-05T23:45:44.903Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -9161,7 +9846,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.969Z",
+          "evaluatedAt": "2026-05-05T23:45:44.903Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -9179,7 +9864,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.969Z",
+          "evaluatedAt": "2026-05-05T23:45:44.903Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -9243,7 +9928,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.971Z",
+        "evaluatedAt": "2026-05-05T23:45:44.905Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9298,7 +9983,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.972Z",
+          "evaluatedAt": "2026-05-05T23:45:44.905Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9316,7 +10001,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.972Z",
+          "evaluatedAt": "2026-05-05T23:45:44.905Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9329,8 +10014,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/capa-officer",
-      "relPath": ".gemini/skills/capa-officer",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/capa-officer",
+      "relPath": "ra-qm-team/skills/capa-officer",
       "verified": true,
       "tokenCount": 3942,
       "evalSummary": {
@@ -9380,7 +10065,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.975Z",
+        "evaluatedAt": "2026-05-05T23:45:44.908Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9435,7 +10120,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.975Z",
+          "evaluatedAt": "2026-05-05T23:45:44.908Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9453,7 +10138,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.975Z",
+          "evaluatedAt": "2026-05-05T23:45:44.908Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9517,7 +10202,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.977Z",
+        "evaluatedAt": "2026-05-05T23:45:44.910Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -9572,7 +10257,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.977Z",
+          "evaluatedAt": "2026-05-05T23:45:44.910Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -9590,7 +10275,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.977Z",
+          "evaluatedAt": "2026-05-05T23:45:44.910Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -9603,8 +10288,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ceo-advisor",
-      "relPath": ".gemini/skills/ceo-advisor",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/ceo-advisor",
+      "relPath": "c-level-advisor/skills/ceo-advisor",
       "verified": true,
       "tokenCount": 2272,
       "evalSummary": {
@@ -9654,7 +10339,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.979Z",
+        "evaluatedAt": "2026-05-05T23:45:44.911Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -9709,7 +10394,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.979Z",
+          "evaluatedAt": "2026-05-05T23:45:44.911Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -9727,7 +10412,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.979Z",
+          "evaluatedAt": "2026-05-05T23:45:44.911Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -9791,7 +10476,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.981Z",
+        "evaluatedAt": "2026-05-05T23:45:44.913Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -9846,7 +10531,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.981Z",
+          "evaluatedAt": "2026-05-05T23:45:44.913Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -9864,7 +10549,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.981Z",
+          "evaluatedAt": "2026-05-05T23:45:44.913Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -9877,8 +10562,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cfo-advisor",
-      "relPath": ".gemini/skills/cfo-advisor",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/cfo-advisor",
+      "relPath": "c-level-advisor/skills/cfo-advisor",
       "verified": true,
       "tokenCount": 2049,
       "evalSummary": {
@@ -9928,7 +10613,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.982Z",
+        "evaluatedAt": "2026-05-05T23:45:44.914Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -9983,7 +10668,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.982Z",
+          "evaluatedAt": "2026-05-05T23:45:44.914Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -10001,8 +10686,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.982Z",
+          "evaluatedAt": "2026-05-05T23:45:44.914Z",
           "evaluatedVersion": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "challenge",
+      "description": "/em -challenge — Pre-Mortem Plan Analysis",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/challenge",
+      "relPath": ".codex/skills/executive-mentor/skills/challenge",
+      "verified": true,
+      "tokenCount": 1997,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.916Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 57,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.916Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.916Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -10065,7 +10887,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.984Z",
+        "evaluatedAt": "2026-05-05T23:45:44.917Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10120,7 +10942,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.984Z",
+          "evaluatedAt": "2026-05-05T23:45:44.917Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10138,7 +10960,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.984Z",
+          "evaluatedAt": "2026-05-05T23:45:44.917Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "challenge",
+      "description": "/em -challenge — Pre-Mortem Plan Analysis",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/executive-mentor/skills/challenge",
+      "relPath": "c-level-advisor/executive-mentor/skills/challenge",
+      "verified": true,
+      "tokenCount": 1997,
+      "evalSummary": {
+        "overallScore": 57,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.918Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 57,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.918Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.918Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10202,7 +11161,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.986Z",
+        "evaluatedAt": "2026-05-05T23:45:44.920Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -10257,7 +11216,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.986Z",
+          "evaluatedAt": "2026-05-05T23:45:44.920Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -10275,7 +11234,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.986Z",
+          "evaluatedAt": "2026-05-05T23:45:44.920Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -10288,8 +11247,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/change-management",
-      "relPath": ".gemini/skills/change-management",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/change-management",
+      "relPath": "c-level-advisor/skills/change-management",
       "verified": true,
       "tokenCount": 3381,
       "evalSummary": {
@@ -10339,7 +11298,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.988Z",
+        "evaluatedAt": "2026-05-05T23:45:44.922Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -10394,7 +11353,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.988Z",
+          "evaluatedAt": "2026-05-05T23:45:44.922Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -10412,7 +11371,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.988Z",
+          "evaluatedAt": "2026-05-05T23:45:44.922Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -10476,7 +11435,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.989Z",
+        "evaluatedAt": "2026-05-05T23:45:44.924Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10531,7 +11490,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.989Z",
+          "evaluatedAt": "2026-05-05T23:45:44.924Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10549,7 +11508,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.989Z",
+          "evaluatedAt": "2026-05-05T23:45:44.924Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10613,7 +11572,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.990Z",
+        "evaluatedAt": "2026-05-05T23:45:44.925Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10668,7 +11627,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.990Z",
+          "evaluatedAt": "2026-05-05T23:45:44.925Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10686,7 +11645,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.990Z",
+          "evaluatedAt": "2026-05-05T23:45:44.925Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10699,8 +11658,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/changelog-generator",
-      "relPath": ".gemini/skills/changelog-generator",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/changelog-generator",
+      "relPath": "engineering/skills/changelog-generator",
       "verified": true,
       "tokenCount": 1215,
       "evalSummary": {
@@ -10750,7 +11709,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.991Z",
+        "evaluatedAt": "2026-05-05T23:45:44.925Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10805,7 +11764,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.991Z",
+          "evaluatedAt": "2026-05-05T23:45:44.925Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10823,7 +11782,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.991Z",
+          "evaluatedAt": "2026-05-05T23:45:44.926Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10887,7 +11846,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.992Z",
+        "evaluatedAt": "2026-05-05T23:45:44.927Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -10942,7 +11901,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.992Z",
+          "evaluatedAt": "2026-05-05T23:45:44.927Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -10960,7 +11919,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.992Z",
+          "evaluatedAt": "2026-05-05T23:45:44.927Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -10973,8 +11932,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/chief-of-staff",
-      "relPath": ".gemini/skills/chief-of-staff",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/chief-of-staff",
+      "relPath": "c-level-advisor/skills/chief-of-staff",
       "verified": true,
       "tokenCount": 1508,
       "evalSummary": {
@@ -11024,7 +11983,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.994Z",
+        "evaluatedAt": "2026-05-05T23:45:44.928Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -11079,7 +12038,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.994Z",
+          "evaluatedAt": "2026-05-05T23:45:44.928Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -11097,7 +12056,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.994Z",
+          "evaluatedAt": "2026-05-05T23:45:44.928Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -11161,7 +12120,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.995Z",
+        "evaluatedAt": "2026-05-05T23:45:44.929Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -11216,7 +12175,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.995Z",
+          "evaluatedAt": "2026-05-05T23:45:44.929Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -11234,7 +12193,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.995Z",
+          "evaluatedAt": "2026-05-05T23:45:44.929Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -11247,8 +12206,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/chro-advisor",
-      "relPath": ".gemini/skills/chro-advisor",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/chro-advisor",
+      "relPath": "c-level-advisor/skills/chro-advisor",
       "verified": true,
       "tokenCount": 2117,
       "evalSummary": {
@@ -11298,7 +12257,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.997Z",
+        "evaluatedAt": "2026-05-05T23:45:44.931Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -11353,7 +12312,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.997Z",
+          "evaluatedAt": "2026-05-05T23:45:44.931Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -11371,7 +12330,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.997Z",
+          "evaluatedAt": "2026-05-05T23:45:44.931Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -11435,7 +12394,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:31.998Z",
+        "evaluatedAt": "2026-05-05T23:45:44.932Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -11490,7 +12449,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.998Z",
+          "evaluatedAt": "2026-05-05T23:45:44.932Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -11508,7 +12467,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:31.998Z",
+          "evaluatedAt": "2026-05-05T23:45:44.932Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -11521,8 +12480,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/churn-prevention",
-      "relPath": ".gemini/skills/churn-prevention",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/churn-prevention",
+      "relPath": "marketing-skill/skills/churn-prevention",
       "verified": true,
       "tokenCount": 3379,
       "evalSummary": {
@@ -11572,7 +12531,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.000Z",
+        "evaluatedAt": "2026-05-05T23:45:44.934Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -11627,7 +12586,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.000Z",
+          "evaluatedAt": "2026-05-05T23:45:44.934Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -11645,7 +12604,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.000Z",
+          "evaluatedAt": "2026-05-05T23:45:44.934Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -11709,7 +12668,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.002Z",
+        "evaluatedAt": "2026-05-05T23:45:44.936Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11764,7 +12723,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.002Z",
+          "evaluatedAt": "2026-05-05T23:45:44.936Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11782,7 +12741,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.002Z",
+          "evaluatedAt": "2026-05-05T23:45:44.936Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11795,8 +12754,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ci-cd-pipeline-builder",
-      "relPath": ".gemini/skills/ci-cd-pipeline-builder",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/ci-cd-pipeline-builder",
+      "relPath": "engineering/skills/ci-cd-pipeline-builder",
       "verified": true,
       "tokenCount": 1170,
       "evalSummary": {
@@ -11846,7 +12805,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.003Z",
+        "evaluatedAt": "2026-05-05T23:45:44.937Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11901,7 +12860,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.003Z",
+          "evaluatedAt": "2026-05-05T23:45:44.937Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11919,7 +12878,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.003Z",
+          "evaluatedAt": "2026-05-05T23:45:44.937Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11983,7 +12942,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.004Z",
+        "evaluatedAt": "2026-05-05T23:45:44.938Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -12038,7 +12997,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.004Z",
+          "evaluatedAt": "2026-05-05T23:45:44.938Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -12056,7 +13015,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.004Z",
+          "evaluatedAt": "2026-05-05T23:45:44.938Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -12069,8 +13028,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ciso-advisor",
-      "relPath": ".gemini/skills/ciso-advisor",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/ciso-advisor",
+      "relPath": "c-level-advisor/skills/ciso-advisor",
       "verified": true,
       "tokenCount": 2029,
       "evalSummary": {
@@ -12120,7 +13079,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.006Z",
+        "evaluatedAt": "2026-05-05T23:45:44.940Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -12175,7 +13134,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.006Z",
+          "evaluatedAt": "2026-05-05T23:45:44.940Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -12193,7 +13152,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.006Z",
+          "evaluatedAt": "2026-05-05T23:45:44.940Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -12257,7 +13216,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.008Z",
+        "evaluatedAt": "2026-05-05T23:45:44.942Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12312,7 +13271,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.008Z",
+          "evaluatedAt": "2026-05-05T23:45:44.942Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12330,7 +13289,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.008Z",
+          "evaluatedAt": "2026-05-05T23:45:44.942Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12343,8 +13302,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cloud-security",
-      "relPath": ".gemini/skills/cloud-security",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/cloud-security",
+      "relPath": "engineering-team/skills/cloud-security",
       "verified": true,
       "tokenCount": 4335,
       "evalSummary": {
@@ -12394,7 +13353,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.010Z",
+        "evaluatedAt": "2026-05-05T23:45:44.945Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12449,7 +13408,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.010Z",
+          "evaluatedAt": "2026-05-05T23:45:44.945Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12467,7 +13426,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.010Z",
+          "evaluatedAt": "2026-05-05T23:45:44.945Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12531,7 +13490,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.012Z",
+        "evaluatedAt": "2026-05-05T23:45:44.947Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -12586,7 +13545,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.012Z",
+          "evaluatedAt": "2026-05-05T23:45:44.947Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -12604,7 +13563,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.012Z",
+          "evaluatedAt": "2026-05-05T23:45:44.947Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -12617,8 +13576,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cmo-advisor",
-      "relPath": ".gemini/skills/cmo-advisor",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/cmo-advisor",
+      "relPath": "c-level-advisor/skills/cmo-advisor",
       "verified": true,
       "tokenCount": 2327,
       "evalSummary": {
@@ -12668,7 +13627,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.014Z",
+        "evaluatedAt": "2026-05-05T23:45:44.948Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -12723,7 +13682,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.014Z",
+          "evaluatedAt": "2026-05-05T23:45:44.948Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -12741,7 +13700,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.014Z",
+          "evaluatedAt": "2026-05-05T23:45:44.948Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -12805,7 +13764,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.015Z",
+        "evaluatedAt": "2026-05-05T23:45:44.949Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12860,7 +13819,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.015Z",
+          "evaluatedAt": "2026-05-05T23:45:44.950Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12878,7 +13837,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.015Z",
+          "evaluatedAt": "2026-05-05T23:45:44.950Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12891,8 +13850,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/code-reviewer",
-      "relPath": ".gemini/skills/code-reviewer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/code-reviewer",
+      "relPath": "engineering-team/skills/code-reviewer",
       "verified": true,
       "tokenCount": 1136,
       "evalSummary": {
@@ -12942,7 +13901,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.016Z",
+        "evaluatedAt": "2026-05-05T23:45:44.950Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12997,7 +13956,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.016Z",
+          "evaluatedAt": "2026-05-05T23:45:44.951Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13015,7 +13974,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.016Z",
+          "evaluatedAt": "2026-05-05T23:45:44.951Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13028,8 +13987,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-to-prd",
-      "relPath": ".codex/skills/code-to-prd",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-to-prd/skills/code-to-prd",
+      "relPath": ".codex/skills/code-to-prd/skills/code-to-prd",
       "verified": true,
       "tokenCount": 5178,
       "evalSummary": {
@@ -13079,7 +14038,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.018Z",
+        "evaluatedAt": "2026-05-05T23:45:44.953Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13134,7 +14093,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.018Z",
+          "evaluatedAt": "2026-05-05T23:45:44.953Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13152,7 +14111,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.018Z",
+          "evaluatedAt": "2026-05-05T23:45:44.953Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13216,7 +14175,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.020Z",
+        "evaluatedAt": "2026-05-05T23:45:44.955Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13271,7 +14230,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.020Z",
+          "evaluatedAt": "2026-05-05T23:45:44.955Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13289,7 +14248,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.020Z",
+          "evaluatedAt": "2026-05-05T23:45:44.955Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13302,8 +14261,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/code-to-prd",
-      "relPath": ".gemini/skills/code-to-prd",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/code-to-prd/skills/code-to-prd",
+      "relPath": "product-team/code-to-prd/skills/code-to-prd",
       "verified": true,
       "tokenCount": 5178,
       "evalSummary": {
@@ -13353,7 +14312,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.022Z",
+        "evaluatedAt": "2026-05-05T23:45:44.957Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13408,7 +14367,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.022Z",
+          "evaluatedAt": "2026-05-05T23:45:44.957Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13426,7 +14385,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.022Z",
+          "evaluatedAt": "2026-05-05T23:45:44.957Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13439,8 +14398,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-tour",
-      "relPath": ".codex/skills/code-tour",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/code-tour/skills/code-tour",
+      "relPath": ".codex/skills/code-tour/skills/code-tour",
       "verified": true,
       "tokenCount": 1950,
       "evalSummary": {
@@ -13490,7 +14449,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.024Z",
+        "evaluatedAt": "2026-05-05T23:45:44.959Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13545,7 +14504,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.025Z",
+          "evaluatedAt": "2026-05-05T23:45:44.959Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13563,7 +14522,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.025Z",
+          "evaluatedAt": "2026-05-05T23:45:44.959Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13576,8 +14535,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/code-tour",
-      "relPath": ".gemini/skills/code-tour",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/code-tour/skills/code-tour",
+      "relPath": "engineering/code-tour/skills/code-tour",
       "verified": true,
       "tokenCount": 1950,
       "evalSummary": {
@@ -13627,7 +14586,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.026Z",
+        "evaluatedAt": "2026-05-05T23:45:44.960Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13682,7 +14641,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.026Z",
+          "evaluatedAt": "2026-05-05T23:45:44.960Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13700,7 +14659,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.026Z",
+          "evaluatedAt": "2026-05-05T23:45:44.960Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13764,7 +14723,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.027Z",
+        "evaluatedAt": "2026-05-05T23:45:44.961Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13819,7 +14778,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.027Z",
+          "evaluatedAt": "2026-05-05T23:45:44.961Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13837,7 +14796,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.027Z",
+          "evaluatedAt": "2026-05-05T23:45:44.961Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13850,8 +14809,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/codebase-onboarding",
-      "relPath": ".gemini/skills/codebase-onboarding",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/codebase-onboarding",
+      "relPath": "engineering/skills/codebase-onboarding",
       "verified": true,
       "tokenCount": 551,
       "evalSummary": {
@@ -13901,7 +14860,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.027Z",
+        "evaluatedAt": "2026-05-05T23:45:44.962Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13956,7 +14915,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.027Z",
+          "evaluatedAt": "2026-05-05T23:45:44.962Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13974,7 +14933,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.027Z",
+          "evaluatedAt": "2026-05-05T23:45:44.962Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14038,7 +14997,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.029Z",
+        "evaluatedAt": "2026-05-05T23:45:44.964Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -14093,7 +15052,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.029Z",
+          "evaluatedAt": "2026-05-05T23:45:44.964Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -14111,7 +15070,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.029Z",
+          "evaluatedAt": "2026-05-05T23:45:44.964Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -14124,8 +15083,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cold-email",
-      "relPath": ".gemini/skills/cold-email",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/cold-email",
+      "relPath": "marketing-skill/skills/cold-email",
       "verified": true,
       "tokenCount": 4563,
       "evalSummary": {
@@ -14175,7 +15134,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.031Z",
+        "evaluatedAt": "2026-05-05T23:45:44.966Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -14230,7 +15189,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.032Z",
+          "evaluatedAt": "2026-05-05T23:45:44.966Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -14248,7 +15207,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.032Z",
+          "evaluatedAt": "2026-05-05T23:45:44.966Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -14312,7 +15271,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.034Z",
+        "evaluatedAt": "2026-05-05T23:45:44.968Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14367,7 +15326,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.034Z",
+          "evaluatedAt": "2026-05-05T23:45:44.969Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14385,7 +15344,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.034Z",
+          "evaluatedAt": "2026-05-05T23:45:44.969Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "command-guide",
+      "description": "Claude Code Command Selection Guide - Automatically recommend and select the right commands, agents, and skills in Claude Code. Use when: (1) user is unsure which command or tool to use, (2) needs to decide which agent/skill best fits the current task, (3) querying usage scenarios for /plan, /tdd, /compact, /loop and other commands, (4) understanding when to invoke planner, code-reviewer, build-error-resolver and other agents, (5) needs command cheat sheet or decision flowchart. Triggers: \"which command to use\", \"which agent\", \"command selection\", \"how to use /plan\", \"when to use /compact\", \"agent selection guide\", \"command cheat sheet\", \"skill recommendation\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/command-guide",
+      "relPath": "engineering/skills/command-guide",
+      "verified": true,
+      "tokenCount": 3119,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:44.970Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.970Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:44.970Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14449,7 +15545,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.035Z",
+        "evaluatedAt": "2026-05-05T23:45:44.972Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -14504,7 +15600,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.035Z",
+          "evaluatedAt": "2026-05-05T23:45:44.972Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -14522,7 +15618,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.035Z",
+          "evaluatedAt": "2026-05-05T23:45:44.972Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -14535,8 +15631,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/company-os",
-      "relPath": ".gemini/skills/company-os",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/company-os",
+      "relPath": "c-level-advisor/skills/company-os",
       "verified": true,
       "tokenCount": 3304,
       "evalSummary": {
@@ -14586,7 +15682,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.037Z",
+        "evaluatedAt": "2026-05-05T23:45:44.975Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -14641,7 +15737,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.038Z",
+          "evaluatedAt": "2026-05-05T23:45:44.975Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -14659,7 +15755,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.038Z",
+          "evaluatedAt": "2026-05-05T23:45:44.975Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -14723,7 +15819,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.039Z",
+        "evaluatedAt": "2026-05-05T23:45:44.976Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -14778,7 +15874,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.039Z",
+          "evaluatedAt": "2026-05-05T23:45:44.976Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -14796,7 +15892,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.039Z",
+          "evaluatedAt": "2026-05-05T23:45:44.976Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -14809,8 +15905,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitive-intel",
-      "relPath": ".gemini/skills/competitive-intel",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/competitive-intel",
+      "relPath": "c-level-advisor/skills/competitive-intel",
       "verified": true,
       "tokenCount": 2338,
       "evalSummary": {
@@ -14860,7 +15956,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.041Z",
+        "evaluatedAt": "2026-05-05T23:45:44.978Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -14915,7 +16011,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.041Z",
+          "evaluatedAt": "2026-05-05T23:45:44.978Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -14933,7 +16029,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.041Z",
+          "evaluatedAt": "2026-05-05T23:45:44.978Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -14997,7 +16093,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.042Z",
+        "evaluatedAt": "2026-05-05T23:45:44.979Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15052,7 +16148,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.042Z",
+          "evaluatedAt": "2026-05-05T23:45:44.979Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15070,7 +16166,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.042Z",
+          "evaluatedAt": "2026-05-05T23:45:44.979Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15134,7 +16230,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.043Z",
+        "evaluatedAt": "2026-05-05T23:45:44.980Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15189,7 +16285,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.043Z",
+          "evaluatedAt": "2026-05-05T23:45:44.980Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15207,7 +16303,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.043Z",
+          "evaluatedAt": "2026-05-05T23:45:44.980Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15220,8 +16316,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitive-teardown",
-      "relPath": ".gemini/skills/competitive-teardown",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/competitive-teardown",
+      "relPath": "product-team/skills/competitive-teardown",
       "verified": true,
       "tokenCount": 2311,
       "evalSummary": {
@@ -15271,7 +16367,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.045Z",
+        "evaluatedAt": "2026-05-05T23:45:44.982Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15326,7 +16422,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.045Z",
+          "evaluatedAt": "2026-05-05T23:45:44.982Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15344,7 +16440,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.045Z",
+          "evaluatedAt": "2026-05-05T23:45:44.982Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15408,7 +16504,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.046Z",
+        "evaluatedAt": "2026-05-05T23:45:44.983Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -15463,7 +16559,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.046Z",
+          "evaluatedAt": "2026-05-05T23:45:44.983Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -15481,7 +16577,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.046Z",
+          "evaluatedAt": "2026-05-05T23:45:44.983Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -15494,8 +16590,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/competitor-alternatives",
-      "relPath": ".gemini/skills/competitor-alternatives",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/competitor-alternatives",
+      "relPath": "marketing-skill/skills/competitor-alternatives",
       "verified": true,
       "tokenCount": 2820,
       "evalSummary": {
@@ -15545,7 +16641,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.048Z",
+        "evaluatedAt": "2026-05-05T23:45:44.985Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -15600,7 +16696,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.048Z",
+          "evaluatedAt": "2026-05-05T23:45:44.985Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -15618,7 +16714,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.048Z",
+          "evaluatedAt": "2026-05-05T23:45:44.985Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -15682,7 +16778,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.050Z",
+        "evaluatedAt": "2026-05-05T23:45:44.987Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15737,7 +16833,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.050Z",
+          "evaluatedAt": "2026-05-05T23:45:44.987Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15755,7 +16851,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.050Z",
+          "evaluatedAt": "2026-05-05T23:45:44.987Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15768,8 +16864,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/confluence-expert",
-      "relPath": ".gemini/skills/confluence-expert",
+      "installUrl": "github:alirezarezvani/claude-skills:project-management/skills/confluence-expert",
+      "relPath": "project-management/skills/confluence-expert",
       "verified": true,
       "tokenCount": 2291,
       "evalSummary": {
@@ -15819,7 +16915,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.052Z",
+        "evaluatedAt": "2026-05-05T23:45:44.989Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15874,7 +16970,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.052Z",
+          "evaluatedAt": "2026-05-05T23:45:44.989Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15892,7 +16988,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.052Z",
+          "evaluatedAt": "2026-05-05T23:45:44.989Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15956,7 +17052,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.053Z",
+        "evaluatedAt": "2026-05-05T23:45:44.990Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16011,7 +17107,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.053Z",
+          "evaluatedAt": "2026-05-05T23:45:44.990Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16029,7 +17125,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.053Z",
+          "evaluatedAt": "2026-05-05T23:45:44.990Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16093,7 +17189,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.054Z",
+        "evaluatedAt": "2026-05-05T23:45:44.991Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -16148,7 +17244,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.054Z",
+          "evaluatedAt": "2026-05-05T23:45:44.991Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -16166,7 +17262,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.054Z",
+          "evaluatedAt": "2026-05-05T23:45:44.991Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -16179,8 +17275,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-creator",
-      "relPath": ".gemini/skills/content-creator",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/content-creator",
+      "relPath": "marketing-skill/skills/content-creator",
       "verified": true,
       "tokenCount": 711,
       "evalSummary": {
@@ -16230,7 +17326,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.055Z",
+        "evaluatedAt": "2026-05-05T23:45:44.992Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -16285,7 +17381,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.055Z",
+          "evaluatedAt": "2026-05-05T23:45:44.992Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -16303,7 +17399,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.055Z",
+          "evaluatedAt": "2026-05-05T23:45:44.992Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -16367,7 +17463,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.057Z",
+        "evaluatedAt": "2026-05-05T23:45:44.993Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -16422,7 +17518,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.057Z",
+          "evaluatedAt": "2026-05-05T23:45:44.993Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -16440,7 +17536,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.057Z",
+          "evaluatedAt": "2026-05-05T23:45:44.993Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -16453,8 +17549,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-humanizer",
-      "relPath": ".gemini/skills/content-humanizer",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/content-humanizer",
+      "relPath": "marketing-skill/skills/content-humanizer",
       "verified": true,
       "tokenCount": 4227,
       "evalSummary": {
@@ -16504,7 +17600,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.059Z",
+        "evaluatedAt": "2026-05-05T23:45:44.996Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -16559,7 +17655,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.059Z",
+          "evaluatedAt": "2026-05-05T23:45:44.996Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -16577,7 +17673,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.059Z",
+          "evaluatedAt": "2026-05-05T23:45:44.996Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -16641,7 +17737,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.061Z",
+        "evaluatedAt": "2026-05-05T23:45:44.998Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -16696,7 +17792,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.061Z",
+          "evaluatedAt": "2026-05-05T23:45:44.998Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -16714,7 +17810,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.061Z",
+          "evaluatedAt": "2026-05-05T23:45:44.998Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -16727,8 +17823,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-production",
-      "relPath": ".gemini/skills/content-production",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/content-production",
+      "relPath": "marketing-skill/skills/content-production",
       "verified": true,
       "tokenCount": 3152,
       "evalSummary": {
@@ -16778,7 +17874,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.063Z",
+        "evaluatedAt": "2026-05-05T23:45:45.000Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -16833,7 +17929,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.063Z",
+          "evaluatedAt": "2026-05-05T23:45:45.000Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -16851,7 +17947,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.063Z",
+          "evaluatedAt": "2026-05-05T23:45:45.000Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -16915,7 +18011,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.065Z",
+        "evaluatedAt": "2026-05-05T23:45:45.002Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -16970,7 +18066,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.065Z",
+          "evaluatedAt": "2026-05-05T23:45:45.002Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -16988,7 +18084,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.065Z",
+          "evaluatedAt": "2026-05-05T23:45:45.002Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -17001,8 +18097,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/content-strategy",
-      "relPath": ".gemini/skills/content-strategy",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/content-strategy",
+      "relPath": "marketing-skill/skills/content-strategy",
       "verified": true,
       "tokenCount": 1627,
       "evalSummary": {
@@ -17052,7 +18148,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.066Z",
+        "evaluatedAt": "2026-05-05T23:45:45.003Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -17107,7 +18203,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.066Z",
+          "evaluatedAt": "2026-05-05T23:45:45.003Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -17125,7 +18221,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.066Z",
+          "evaluatedAt": "2026-05-05T23:45:45.003Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -17189,7 +18285,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.067Z",
+        "evaluatedAt": "2026-05-05T23:45:45.004Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -17244,7 +18340,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.068Z",
+          "evaluatedAt": "2026-05-05T23:45:45.004Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -17262,7 +18358,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.068Z",
+          "evaluatedAt": "2026-05-05T23:45:45.004Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -17275,8 +18371,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/context-engine",
-      "relPath": ".gemini/skills/context-engine",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/context-engine",
+      "relPath": "c-level-advisor/skills/context-engine",
       "verified": true,
       "tokenCount": 1242,
       "evalSummary": {
@@ -17326,7 +18422,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.069Z",
+        "evaluatedAt": "2026-05-05T23:45:45.005Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -17381,7 +18477,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.069Z",
+          "evaluatedAt": "2026-05-05T23:45:45.005Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -17399,7 +18495,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.069Z",
+          "evaluatedAt": "2026-05-05T23:45:45.005Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -17463,7 +18559,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.070Z",
+        "evaluatedAt": "2026-05-05T23:45:45.007Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17518,7 +18614,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.070Z",
+          "evaluatedAt": "2026-05-05T23:45:45.007Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17536,7 +18632,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.070Z",
+          "evaluatedAt": "2026-05-05T23:45:45.007Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17549,8 +18645,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/contract-and-proposal-writer",
-      "relPath": ".gemini/skills/contract-and-proposal-writer",
+      "installUrl": "github:alirezarezvani/claude-skills:business-growth/skills/contract-and-proposal-writer",
+      "relPath": "business-growth/skills/contract-and-proposal-writer",
       "verified": true,
       "tokenCount": 3659,
       "evalSummary": {
@@ -17600,7 +18696,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.072Z",
+        "evaluatedAt": "2026-05-05T23:45:45.009Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17655,7 +18751,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.072Z",
+          "evaluatedAt": "2026-05-05T23:45:45.009Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17673,7 +18769,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.072Z",
+          "evaluatedAt": "2026-05-05T23:45:45.009Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17737,7 +18833,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.074Z",
+        "evaluatedAt": "2026-05-05T23:45:45.011Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -17792,7 +18888,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.074Z",
+          "evaluatedAt": "2026-05-05T23:45:45.011Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -17810,7 +18906,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.074Z",
+          "evaluatedAt": "2026-05-05T23:45:45.011Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -17823,8 +18919,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/coo-advisor",
-      "relPath": ".gemini/skills/coo-advisor",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/coo-advisor",
+      "relPath": "c-level-advisor/skills/coo-advisor",
       "verified": true,
       "tokenCount": 1829,
       "evalSummary": {
@@ -17874,7 +18970,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.075Z",
+        "evaluatedAt": "2026-05-05T23:45:45.012Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -17929,7 +19025,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.075Z",
+          "evaluatedAt": "2026-05-05T23:45:45.012Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -17947,7 +19043,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.075Z",
+          "evaluatedAt": "2026-05-05T23:45:45.012Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -18011,7 +19107,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.077Z",
+        "evaluatedAt": "2026-05-05T23:45:45.015Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -18066,7 +19162,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.077Z",
+          "evaluatedAt": "2026-05-05T23:45:45.015Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -18084,7 +19180,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.077Z",
+          "evaluatedAt": "2026-05-05T23:45:45.015Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -18097,8 +19193,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/copy-editing",
-      "relPath": ".gemini/skills/copy-editing",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/copy-editing",
+      "relPath": "marketing-skill/skills/copy-editing",
       "verified": true,
       "tokenCount": 4743,
       "evalSummary": {
@@ -18148,7 +19244,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.080Z",
+        "evaluatedAt": "2026-05-05T23:45:45.017Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -18203,7 +19299,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.080Z",
+          "evaluatedAt": "2026-05-05T23:45:45.017Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -18221,7 +19317,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.080Z",
+          "evaluatedAt": "2026-05-05T23:45:45.017Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -18285,7 +19381,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.082Z",
+        "evaluatedAt": "2026-05-05T23:45:45.020Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -18340,7 +19436,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.082Z",
+          "evaluatedAt": "2026-05-05T23:45:45.020Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -18358,7 +19454,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.082Z",
+          "evaluatedAt": "2026-05-05T23:45:45.020Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -18371,8 +19467,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/copywriting",
-      "relPath": ".gemini/skills/copywriting",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/copywriting",
+      "relPath": "marketing-skill/skills/copywriting",
       "verified": true,
       "tokenCount": 2776,
       "evalSummary": {
@@ -18422,7 +19518,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.084Z",
+        "evaluatedAt": "2026-05-05T23:45:45.022Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -18477,7 +19573,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.084Z",
+          "evaluatedAt": "2026-05-05T23:45:45.022Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -18495,8 +19591,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.084Z",
+          "evaluatedAt": "2026-05-05T23:45:45.022Z",
           "evaluatedVersion": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "coverage",
+      "description": "Analyze test coverage gaps. Use when user says \"test coverage\", \"what's not tested\", \"coverage gaps\", \"missing tests\", \"coverage report\", or \"what needs testing\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/coverage",
+      "relPath": ".codex/skills/playwright-pro/skills/coverage",
+      "verified": true,
+      "tokenCount": 792,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.024Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.024Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.024Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -18559,7 +19792,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.086Z",
+        "evaluatedAt": "2026-05-05T23:45:45.025Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18614,7 +19847,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.086Z",
+          "evaluatedAt": "2026-05-05T23:45:45.025Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18632,7 +19865,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.086Z",
+          "evaluatedAt": "2026-05-05T23:45:45.025Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "coverage",
+      "description": "Analyze test coverage gaps. Use when user says \"test coverage\", \"what's not tested\", \"coverage gaps\", \"missing tests\", \"coverage report\", or \"what needs testing\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/playwright-pro/skills/coverage",
+      "relPath": "engineering-team/playwright-pro/skills/coverage",
+      "verified": true,
+      "tokenCount": 792,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.026Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.026Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.026Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18696,7 +20066,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.087Z",
+        "evaluatedAt": "2026-05-05T23:45:45.028Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -18751,7 +20121,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.087Z",
+          "evaluatedAt": "2026-05-05T23:45:45.028Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -18769,7 +20139,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.087Z",
+          "evaluatedAt": "2026-05-05T23:45:45.028Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -18782,8 +20152,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cpo-advisor",
-      "relPath": ".gemini/skills/cpo-advisor",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/cpo-advisor",
+      "relPath": "c-level-advisor/skills/cpo-advisor",
       "verified": true,
       "tokenCount": 2647,
       "evalSummary": {
@@ -18833,7 +20203,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.089Z",
+        "evaluatedAt": "2026-05-05T23:45:45.030Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -18888,7 +20258,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.089Z",
+          "evaluatedAt": "2026-05-05T23:45:45.030Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -18906,7 +20276,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.089Z",
+          "evaluatedAt": "2026-05-05T23:45:45.030Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -18970,7 +20340,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.090Z",
+        "evaluatedAt": "2026-05-05T23:45:45.032Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -19025,7 +20395,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.090Z",
+          "evaluatedAt": "2026-05-05T23:45:45.035Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -19043,7 +20413,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.091Z",
+          "evaluatedAt": "2026-05-05T23:45:45.035Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -19056,8 +20426,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cro-advisor",
-      "relPath": ".gemini/skills/cro-advisor",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/cro-advisor",
+      "relPath": "c-level-advisor/skills/cro-advisor",
       "verified": true,
       "tokenCount": 2547,
       "evalSummary": {
@@ -19107,7 +20477,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.092Z",
+        "evaluatedAt": "2026-05-05T23:45:45.037Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -19162,7 +20532,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.092Z",
+          "evaluatedAt": "2026-05-05T23:45:45.038Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -19180,7 +20550,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.092Z",
+          "evaluatedAt": "2026-05-05T23:45:45.038Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -19244,7 +20614,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.094Z",
+        "evaluatedAt": "2026-05-05T23:45:45.040Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19299,7 +20669,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.094Z",
+          "evaluatedAt": "2026-05-05T23:45:45.040Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19317,7 +20687,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.094Z",
+          "evaluatedAt": "2026-05-05T23:45:45.040Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19381,7 +20751,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.097Z",
+        "evaluatedAt": "2026-05-05T23:45:45.042Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19436,7 +20806,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.097Z",
+          "evaluatedAt": "2026-05-05T23:45:45.042Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19454,7 +20824,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.097Z",
+          "evaluatedAt": "2026-05-05T23:45:45.042Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19518,7 +20888,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.099Z",
+        "evaluatedAt": "2026-05-05T23:45:45.045Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19573,7 +20943,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.099Z",
+          "evaluatedAt": "2026-05-05T23:45:45.045Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19591,7 +20961,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.099Z",
+          "evaluatedAt": "2026-05-05T23:45:45.045Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19655,7 +21025,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.101Z",
+        "evaluatedAt": "2026-05-05T23:45:45.047Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19710,7 +21080,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.101Z",
+          "evaluatedAt": "2026-05-05T23:45:45.047Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19728,7 +21098,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.101Z",
+          "evaluatedAt": "2026-05-05T23:45:45.047Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19792,7 +21162,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.104Z",
+        "evaluatedAt": "2026-05-05T23:45:45.050Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19847,7 +21217,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.104Z",
+          "evaluatedAt": "2026-05-05T23:45:45.050Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19865,7 +21235,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.104Z",
+          "evaluatedAt": "2026-05-05T23:45:45.050Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19929,7 +21299,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.105Z",
+        "evaluatedAt": "2026-05-05T23:45:45.053Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19984,7 +21354,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.105Z",
+          "evaluatedAt": "2026-05-05T23:45:45.053Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20002,7 +21372,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.105Z",
+          "evaluatedAt": "2026-05-05T23:45:45.053Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20066,7 +21436,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.106Z",
+        "evaluatedAt": "2026-05-05T23:45:45.054Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20121,7 +21491,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.106Z",
+          "evaluatedAt": "2026-05-05T23:45:45.054Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20139,7 +21509,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.106Z",
+          "evaluatedAt": "2026-05-05T23:45:45.054Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20203,7 +21573,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.107Z",
+        "evaluatedAt": "2026-05-05T23:45:45.055Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20258,7 +21628,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.107Z",
+          "evaluatedAt": "2026-05-05T23:45:45.055Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20276,7 +21646,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.107Z",
+          "evaluatedAt": "2026-05-05T23:45:45.055Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20340,7 +21710,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.108Z",
+        "evaluatedAt": "2026-05-05T23:45:45.057Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20395,7 +21765,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.108Z",
+          "evaluatedAt": "2026-05-05T23:45:45.057Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20413,7 +21783,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.108Z",
+          "evaluatedAt": "2026-05-05T23:45:45.057Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20477,7 +21847,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.109Z",
+        "evaluatedAt": "2026-05-05T23:45:45.058Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -20532,7 +21902,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.109Z",
+          "evaluatedAt": "2026-05-05T23:45:45.058Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -20550,7 +21920,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.109Z",
+          "evaluatedAt": "2026-05-05T23:45:45.058Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -20563,8 +21933,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cs-onboard",
-      "relPath": ".gemini/skills/cs-onboard",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/cs-onboard",
+      "relPath": "c-level-advisor/skills/cs-onboard",
       "verified": true,
       "tokenCount": 1269,
       "evalSummary": {
@@ -20614,7 +21984,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.110Z",
+        "evaluatedAt": "2026-05-05T23:45:45.059Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -20669,7 +22039,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.110Z",
+          "evaluatedAt": "2026-05-05T23:45:45.059Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -20687,7 +22057,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.110Z",
+          "evaluatedAt": "2026-05-05T23:45:45.059Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -20751,7 +22121,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.111Z",
+        "evaluatedAt": "2026-05-05T23:45:45.060Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20806,7 +22176,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.111Z",
+          "evaluatedAt": "2026-05-05T23:45:45.060Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20824,7 +22194,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.111Z",
+          "evaluatedAt": "2026-05-05T23:45:45.060Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20888,7 +22258,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.113Z",
+        "evaluatedAt": "2026-05-05T23:45:45.063Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20943,7 +22313,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.113Z",
+          "evaluatedAt": "2026-05-05T23:45:45.063Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20961,7 +22331,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.113Z",
+          "evaluatedAt": "2026-05-05T23:45:45.063Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21025,7 +22395,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.116Z",
+        "evaluatedAt": "2026-05-05T23:45:45.066Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21080,7 +22450,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.117Z",
+          "evaluatedAt": "2026-05-05T23:45:45.066Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21098,7 +22468,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.117Z",
+          "evaluatedAt": "2026-05-05T23:45:45.066Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21162,7 +22532,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.119Z",
+        "evaluatedAt": "2026-05-05T23:45:45.070Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21217,7 +22587,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.119Z",
+          "evaluatedAt": "2026-05-05T23:45:45.070Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21235,7 +22605,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.119Z",
+          "evaluatedAt": "2026-05-05T23:45:45.070Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21299,7 +22669,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.121Z",
+        "evaluatedAt": "2026-05-05T23:45:45.073Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21354,7 +22724,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.121Z",
+          "evaluatedAt": "2026-05-05T23:45:45.073Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21372,7 +22742,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.121Z",
+          "evaluatedAt": "2026-05-05T23:45:45.073Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21436,7 +22806,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.122Z",
+        "evaluatedAt": "2026-05-05T23:45:45.074Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21491,7 +22861,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.122Z",
+          "evaluatedAt": "2026-05-05T23:45:45.074Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21509,7 +22879,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.122Z",
+          "evaluatedAt": "2026-05-05T23:45:45.074Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21573,7 +22943,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.124Z",
+        "evaluatedAt": "2026-05-05T23:45:45.076Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21628,7 +22998,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.124Z",
+          "evaluatedAt": "2026-05-05T23:45:45.076Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21646,7 +23016,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.124Z",
+          "evaluatedAt": "2026-05-05T23:45:45.076Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21710,7 +23080,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.126Z",
+        "evaluatedAt": "2026-05-05T23:45:45.078Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21765,7 +23135,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.126Z",
+          "evaluatedAt": "2026-05-05T23:45:45.078Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21783,7 +23153,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.126Z",
+          "evaluatedAt": "2026-05-05T23:45:45.078Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21847,7 +23217,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.127Z",
+        "evaluatedAt": "2026-05-05T23:45:45.079Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21902,7 +23272,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.127Z",
+          "evaluatedAt": "2026-05-05T23:45:45.079Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21920,7 +23290,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.127Z",
+          "evaluatedAt": "2026-05-05T23:45:45.079Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21984,7 +23354,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.128Z",
+        "evaluatedAt": "2026-05-05T23:45:45.080Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22039,7 +23409,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.128Z",
+          "evaluatedAt": "2026-05-05T23:45:45.080Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22057,7 +23427,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.128Z",
+          "evaluatedAt": "2026-05-05T23:45:45.080Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22121,7 +23491,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.130Z",
+        "evaluatedAt": "2026-05-05T23:45:45.082Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22176,7 +23546,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.130Z",
+          "evaluatedAt": "2026-05-05T23:45:45.082Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22194,7 +23564,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.130Z",
+          "evaluatedAt": "2026-05-05T23:45:45.082Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22258,7 +23628,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.131Z",
+        "evaluatedAt": "2026-05-05T23:45:45.083Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -22313,7 +23683,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.131Z",
+          "evaluatedAt": "2026-05-05T23:45:45.083Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -22331,7 +23701,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.131Z",
+          "evaluatedAt": "2026-05-05T23:45:45.083Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -22344,8 +23714,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/cto-advisor",
-      "relPath": ".gemini/skills/cto-advisor",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/cto-advisor",
+      "relPath": "c-level-advisor/skills/cto-advisor",
       "verified": true,
       "tokenCount": 3622,
       "evalSummary": {
@@ -22395,7 +23765,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.133Z",
+        "evaluatedAt": "2026-05-05T23:45:45.085Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -22450,7 +23820,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.133Z",
+          "evaluatedAt": "2026-05-05T23:45:45.086Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -22468,7 +23838,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.133Z",
+          "evaluatedAt": "2026-05-05T23:45:45.086Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -22532,7 +23902,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.135Z",
+        "evaluatedAt": "2026-05-05T23:45:45.088Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -22587,7 +23957,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.135Z",
+          "evaluatedAt": "2026-05-05T23:45:45.088Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -22605,7 +23975,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.135Z",
+          "evaluatedAt": "2026-05-05T23:45:45.088Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -22618,8 +23988,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/culture-architect",
-      "relPath": ".gemini/skills/culture-architect",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/culture-architect",
+      "relPath": "c-level-advisor/skills/culture-architect",
       "verified": true,
       "tokenCount": 2564,
       "evalSummary": {
@@ -22669,7 +24039,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.137Z",
+        "evaluatedAt": "2026-05-05T23:45:45.089Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -22724,7 +24094,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.137Z",
+          "evaluatedAt": "2026-05-05T23:45:45.089Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -22742,7 +24112,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.137Z",
+          "evaluatedAt": "2026-05-05T23:45:45.089Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -22806,7 +24176,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.138Z",
+        "evaluatedAt": "2026-05-05T23:45:45.091Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -22861,7 +24231,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.138Z",
+          "evaluatedAt": "2026-05-05T23:45:45.091Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -22879,7 +24249,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.138Z",
+          "evaluatedAt": "2026-05-05T23:45:45.091Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -22892,8 +24262,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/customer-success-manager",
-      "relPath": ".gemini/skills/customer-success-manager",
+      "installUrl": "github:alirezarezvani/claude-skills:business-growth/skills/customer-success-manager",
+      "relPath": "business-growth/skills/customer-success-manager",
       "verified": true,
       "tokenCount": 1977,
       "evalSummary": {
@@ -22943,7 +24313,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.140Z",
+        "evaluatedAt": "2026-05-05T23:45:45.092Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -22998,7 +24368,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.140Z",
+          "evaluatedAt": "2026-05-05T23:45:45.093Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -23016,7 +24386,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.140Z",
+          "evaluatedAt": "2026-05-05T23:45:45.093Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -23029,8 +24399,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/data-quality-auditor",
-      "relPath": ".codex/skills/data-quality-auditor",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/data-quality-auditor/skills/data-quality-auditor",
+      "relPath": ".codex/skills/data-quality-auditor/skills/data-quality-auditor",
       "verified": true,
       "tokenCount": 2384,
       "evalSummary": {
@@ -23080,7 +24450,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.141Z",
+        "evaluatedAt": "2026-05-05T23:45:45.094Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23135,7 +24505,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.141Z",
+          "evaluatedAt": "2026-05-05T23:45:45.094Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23153,7 +24523,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.141Z",
+          "evaluatedAt": "2026-05-05T23:45:45.094Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23166,8 +24536,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/data-quality-auditor",
-      "relPath": ".gemini/skills/data-quality-auditor",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/data-quality-auditor/skills/data-quality-auditor",
+      "relPath": "engineering/data-quality-auditor/skills/data-quality-auditor",
       "verified": true,
       "tokenCount": 2384,
       "evalSummary": {
@@ -23217,7 +24587,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.143Z",
+        "evaluatedAt": "2026-05-05T23:45:45.096Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23272,7 +24642,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.143Z",
+          "evaluatedAt": "2026-05-05T23:45:45.096Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23290,7 +24660,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.143Z",
+          "evaluatedAt": "2026-05-05T23:45:45.096Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23354,7 +24724,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.145Z",
+        "evaluatedAt": "2026-05-05T23:45:45.098Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23409,7 +24779,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.145Z",
+          "evaluatedAt": "2026-05-05T23:45:45.098Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23427,7 +24797,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.145Z",
+          "evaluatedAt": "2026-05-05T23:45:45.098Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23440,8 +24810,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/database-designer",
-      "relPath": ".gemini/skills/database-designer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/database-designer",
+      "relPath": "engineering/skills/database-designer",
       "verified": true,
       "tokenCount": 3162,
       "evalSummary": {
@@ -23491,7 +24861,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.147Z",
+        "evaluatedAt": "2026-05-05T23:45:45.100Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23546,7 +24916,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.147Z",
+          "evaluatedAt": "2026-05-05T23:45:45.100Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23564,7 +24934,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.147Z",
+          "evaluatedAt": "2026-05-05T23:45:45.100Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23628,7 +24998,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.148Z",
+        "evaluatedAt": "2026-05-05T23:45:45.102Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23683,7 +25053,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.148Z",
+          "evaluatedAt": "2026-05-05T23:45:45.102Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23701,7 +25071,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.148Z",
+          "evaluatedAt": "2026-05-05T23:45:45.102Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23714,8 +25084,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/database-schema-designer",
-      "relPath": ".gemini/skills/database-schema-designer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/database-schema-designer",
+      "relPath": "engineering/skills/database-schema-designer",
       "verified": true,
       "tokenCount": 2134,
       "evalSummary": {
@@ -23765,7 +25135,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.150Z",
+        "evaluatedAt": "2026-05-05T23:45:45.104Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23820,7 +25190,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.150Z",
+          "evaluatedAt": "2026-05-05T23:45:45.104Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23838,7 +25208,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.150Z",
+          "evaluatedAt": "2026-05-05T23:45:45.104Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23902,7 +25272,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.151Z",
+        "evaluatedAt": "2026-05-05T23:45:45.105Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -23957,7 +25327,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.151Z",
+          "evaluatedAt": "2026-05-05T23:45:45.105Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -23975,7 +25345,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.151Z",
+          "evaluatedAt": "2026-05-05T23:45:45.105Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -23988,8 +25358,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/decision-logger",
-      "relPath": ".gemini/skills/decision-logger",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/decision-logger",
+      "relPath": "c-level-advisor/skills/decision-logger",
       "verified": true,
       "tokenCount": 1247,
       "evalSummary": {
@@ -24039,7 +25409,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.152Z",
+        "evaluatedAt": "2026-05-05T23:45:45.107Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -24094,7 +25464,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.152Z",
+          "evaluatedAt": "2026-05-05T23:45:45.107Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -24112,7 +25482,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.152Z",
+          "evaluatedAt": "2026-05-05T23:45:45.107Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -24125,8 +25495,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/demo-video",
-      "relPath": ".codex/skills/demo-video",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/demo-video/skills/demo-video",
+      "relPath": ".codex/skills/demo-video/skills/demo-video",
       "verified": true,
       "tokenCount": 1555,
       "evalSummary": {
@@ -24176,7 +25546,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.153Z",
+        "evaluatedAt": "2026-05-05T23:45:45.108Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24231,7 +25601,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.153Z",
+          "evaluatedAt": "2026-05-05T23:45:45.108Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24249,7 +25619,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.153Z",
+          "evaluatedAt": "2026-05-05T23:45:45.108Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24262,8 +25632,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/demo-video",
-      "relPath": ".gemini/skills/demo-video",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/demo-video/skills/demo-video",
+      "relPath": "engineering/demo-video/skills/demo-video",
       "verified": true,
       "tokenCount": 1555,
       "evalSummary": {
@@ -24313,7 +25683,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.154Z",
+        "evaluatedAt": "2026-05-05T23:45:45.109Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24368,7 +25738,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.154Z",
+          "evaluatedAt": "2026-05-05T23:45:45.109Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24386,7 +25756,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.154Z",
+          "evaluatedAt": "2026-05-05T23:45:45.109Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24450,7 +25820,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.156Z",
+        "evaluatedAt": "2026-05-05T23:45:45.111Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24505,7 +25875,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.156Z",
+          "evaluatedAt": "2026-05-05T23:45:45.111Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24523,7 +25893,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.156Z",
+          "evaluatedAt": "2026-05-05T23:45:45.111Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24536,8 +25906,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/dependency-auditor",
-      "relPath": ".gemini/skills/dependency-auditor",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/dependency-auditor",
+      "relPath": "engineering/skills/dependency-auditor",
       "verified": true,
       "tokenCount": 2833,
       "evalSummary": {
@@ -24587,7 +25957,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.158Z",
+        "evaluatedAt": "2026-05-05T23:45:45.113Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24642,7 +26012,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.158Z",
+          "evaluatedAt": "2026-05-05T23:45:45.113Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24660,7 +26030,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.158Z",
+          "evaluatedAt": "2026-05-05T23:45:45.113Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24724,7 +26094,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.159Z",
+        "evaluatedAt": "2026-05-05T23:45:45.115Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24779,7 +26149,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.159Z",
+          "evaluatedAt": "2026-05-05T23:45:45.115Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24797,7 +26167,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.159Z",
+          "evaluatedAt": "2026-05-05T23:45:45.115Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24810,8 +26180,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/docker-development",
-      "relPath": ".codex/skills/docker-development",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/docker-development/skills/docker-development",
+      "relPath": ".codex/skills/docker-development/skills/docker-development",
       "verified": true,
       "tokenCount": 3204,
       "evalSummary": {
@@ -24861,7 +26231,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.161Z",
+        "evaluatedAt": "2026-05-05T23:45:45.117Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -24916,7 +26286,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.161Z",
+          "evaluatedAt": "2026-05-05T23:45:45.117Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -24934,7 +26304,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.161Z",
+          "evaluatedAt": "2026-05-05T23:45:45.117Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -24947,8 +26317,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/docker-development",
-      "relPath": ".gemini/skills/docker-development",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/docker-development/skills/docker-development",
+      "relPath": "engineering/docker-development/skills/docker-development",
       "verified": true,
       "tokenCount": 3204,
       "evalSummary": {
@@ -24998,7 +26368,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.163Z",
+        "evaluatedAt": "2026-05-05T23:45:45.119Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -25053,7 +26423,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.163Z",
+          "evaluatedAt": "2026-05-05T23:45:45.119Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -25071,7 +26441,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.163Z",
+          "evaluatedAt": "2026-05-05T23:45:45.119Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -25135,7 +26505,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.165Z",
+        "evaluatedAt": "2026-05-05T23:45:45.121Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -25190,7 +26560,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.165Z",
+          "evaluatedAt": "2026-05-05T23:45:45.121Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -25208,7 +26578,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.165Z",
+          "evaluatedAt": "2026-05-05T23:45:45.121Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -25221,8 +26591,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/email-sequence",
-      "relPath": ".gemini/skills/email-sequence",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/email-sequence",
+      "relPath": "marketing-skill/skills/email-sequence",
       "verified": true,
       "tokenCount": 1559,
       "evalSummary": {
@@ -25272,7 +26642,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.166Z",
+        "evaluatedAt": "2026-05-05T23:45:45.122Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -25327,7 +26697,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.166Z",
+          "evaluatedAt": "2026-05-05T23:45:45.122Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -25345,7 +26715,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.166Z",
+          "evaluatedAt": "2026-05-05T23:45:45.122Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -25409,7 +26779,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.168Z",
+        "evaluatedAt": "2026-05-05T23:45:45.124Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25464,7 +26834,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.168Z",
+          "evaluatedAt": "2026-05-05T23:45:45.124Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25482,7 +26852,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.168Z",
+          "evaluatedAt": "2026-05-05T23:45:45.124Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25495,8 +26865,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/email-template-builder",
-      "relPath": ".gemini/skills/email-template-builder",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/email-template-builder",
+      "relPath": "engineering-team/skills/email-template-builder",
       "verified": true,
       "tokenCount": 4293,
       "evalSummary": {
@@ -25546,7 +26916,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.170Z",
+        "evaluatedAt": "2026-05-05T23:45:45.127Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25601,7 +26971,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.170Z",
+          "evaluatedAt": "2026-05-05T23:45:45.127Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25619,7 +26989,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.170Z",
+          "evaluatedAt": "2026-05-05T23:45:45.127Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25632,13 +27002,13 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/engineering-bundle",
-      "relPath": ".gemini/skills/engineering-bundle",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/engineering-advanced-skills",
+      "relPath": ".codex/skills/engineering-advanced-skills",
       "verified": true,
       "tokenCount": 747,
       "evalSummary": {
-        "overallScore": 64,
-        "grade": "D",
+        "overallScore": 66,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
@@ -25679,11 +27049,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
+            "score": 10,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.171Z",
+        "evaluatedAt": "2026-05-05T23:45:45.129Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -25692,8 +27062,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 64,
-          "grade": "D",
+          "overallScore": 66,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
@@ -25734,11 +27104,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.171Z",
+          "evaluatedAt": "2026-05-05T23:45:45.129Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -25746,17 +27116,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 62,
-          "grade": "D",
+          "overallScore": 69,
+          "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 8,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.171Z",
+          "evaluatedAt": "2026-05-05T23:45:45.129Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -25769,13 +27139,13 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/engineering-main",
-      "relPath": ".gemini/skills/engineering-main",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/engineering-advanced-skills",
+      "relPath": "engineering/skills/engineering-advanced-skills",
       "verified": true,
       "tokenCount": 747,
       "evalSummary": {
-        "overallScore": 64,
-        "grade": "D",
+        "overallScore": 66,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
@@ -25816,148 +27186,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:32.173Z",
-        "evaluatedVersion": "1.1.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 64,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 6,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 5,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 1,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 9,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:32.173Z",
-          "evaluatedVersion": "1.1.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 62,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 8,
-              "max": 13
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:32.173Z",
-          "evaluatedVersion": "1.1.0"
-        }
-      }
-    },
-    {
-      "name": "engineering-advanced-skills",
-      "description": "25 advanced engineering agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. Agent design, RAG, MCP servers, CI/CD, database design, observability, security auditing, release management, platform ops.",
-      "version": "1.1.0",
-      "license": "MIT",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:engineering",
-      "relPath": "engineering",
-      "verified": true,
-      "tokenCount": 747,
-      "evalSummary": {
-        "overallScore": 64,
-        "grade": "D",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
             "score": 10,
             "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 6,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 5,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 1,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.173Z",
+        "evaluatedAt": "2026-05-05T23:45:45.130Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -25966,8 +27199,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 64,
-          "grade": "D",
+          "overallScore": 66,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
@@ -26008,11 +27241,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.173Z",
+          "evaluatedAt": "2026-05-05T23:45:45.130Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -26020,17 +27253,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 62,
-          "grade": "D",
+          "overallScore": 69,
+          "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 8,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.173Z",
+          "evaluatedAt": "2026-05-05T23:45:45.130Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -26043,12 +27276,12 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/engineering-team-bundle",
-      "relPath": ".gemini/skills/engineering-team-bundle",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/engineering-skills",
+      "relPath": ".codex/skills/engineering-skills",
       "verified": true,
       "tokenCount": 873,
       "evalSummary": {
-        "overallScore": 70,
+        "overallScore": 71,
         "grade": "C",
         "categories": [
           {
@@ -26090,11 +27323,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
+            "score": 10,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.175Z",
+        "evaluatedAt": "2026-05-05T23:45:45.131Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -26103,7 +27336,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 70,
+          "overallScore": 71,
           "grade": "C",
           "categories": [
             {
@@ -26145,11 +27378,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.175Z",
+          "evaluatedAt": "2026-05-05T23:45:45.131Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -26157,17 +27390,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 54,
+          "overallScore": 62,
           "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 7,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.175Z",
+          "evaluatedAt": "2026-05-05T23:45:45.131Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -26180,12 +27413,12 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:engineering-team",
-      "relPath": "engineering-team",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/engineering-skills",
+      "relPath": "engineering-team/skills/engineering-skills",
       "verified": true,
       "tokenCount": 873,
       "evalSummary": {
-        "overallScore": 70,
+        "overallScore": 71,
         "grade": "C",
         "categories": [
           {
@@ -26227,11 +27460,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
+            "score": 10,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.176Z",
+        "evaluatedAt": "2026-05-05T23:45:45.132Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -26240,7 +27473,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 70,
+          "overallScore": 71,
           "grade": "C",
           "categories": [
             {
@@ -26282,11 +27515,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.176Z",
+          "evaluatedAt": "2026-05-05T23:45:45.132Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -26294,17 +27527,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 54,
+          "overallScore": 62,
           "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 7,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.176Z",
+          "evaluatedAt": "2026-05-05T23:45:45.132Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -26368,7 +27601,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.177Z",
+        "evaluatedAt": "2026-05-05T23:45:45.134Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26423,7 +27656,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.177Z",
+          "evaluatedAt": "2026-05-05T23:45:45.134Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26441,7 +27674,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.177Z",
+          "evaluatedAt": "2026-05-05T23:45:45.134Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26454,8 +27687,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/env-secrets-manager",
-      "relPath": ".gemini/skills/env-secrets-manager",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/env-secrets-manager",
+      "relPath": "engineering/skills/env-secrets-manager",
       "verified": true,
       "tokenCount": 2690,
       "evalSummary": {
@@ -26505,7 +27738,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.179Z",
+        "evaluatedAt": "2026-05-05T23:45:45.135Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26560,7 +27793,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.179Z",
+          "evaluatedAt": "2026-05-05T23:45:45.136Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26578,7 +27811,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.179Z",
+          "evaluatedAt": "2026-05-05T23:45:45.136Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26642,7 +27875,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.181Z",
+        "evaluatedAt": "2026-05-05T23:45:45.138Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -26697,7 +27930,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.181Z",
+          "evaluatedAt": "2026-05-05T23:45:45.138Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -26715,7 +27948,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.181Z",
+          "evaluatedAt": "2026-05-05T23:45:45.138Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -26728,8 +27961,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/epic-design",
-      "relPath": ".gemini/skills/epic-design",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/epic-design",
+      "relPath": "engineering-team/skills/epic-design",
       "verified": true,
       "tokenCount": 4777,
       "evalSummary": {
@@ -26779,7 +28012,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.184Z",
+        "evaluatedAt": "2026-05-05T23:45:45.141Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -26834,7 +28067,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.184Z",
+          "evaluatedAt": "2026-05-05T23:45:45.141Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -26852,8 +28085,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.184Z",
+          "evaluatedAt": "2026-05-05T23:45:45.141Z",
           "evaluatedVersion": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "eval",
+      "description": "Evaluate and rank agent results by metric or LLM judge for an AgentHub session.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/eval",
+      "relPath": ".codex/skills/agenthub/skills/eval",
+      "verified": true,
+      "tokenCount": 802,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.143Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 63,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.143Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.143Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -26916,7 +28286,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.186Z",
+        "evaluatedAt": "2026-05-05T23:45:45.144Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26971,7 +28341,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.186Z",
+          "evaluatedAt": "2026-05-05T23:45:45.144Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26989,7 +28359,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.186Z",
+          "evaluatedAt": "2026-05-05T23:45:45.144Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "eval",
+      "description": "Evaluate and rank agent results by metric or LLM judge for an AgentHub session.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/agenthub/skills/eval",
+      "relPath": "engineering/agenthub/skills/eval",
+      "verified": true,
+      "tokenCount": 802,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.145Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 63,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.145Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.145Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27002,8 +28509,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor",
-      "relPath": ".codex/skills/executive-mentor",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/executive-mentor",
+      "relPath": ".codex/skills/executive-mentor/skills/executive-mentor",
       "verified": true,
       "tokenCount": 1980,
       "evalSummary": {
@@ -27053,7 +28560,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.187Z",
+        "evaluatedAt": "2026-05-05T23:45:45.146Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -27108,7 +28615,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.187Z",
+          "evaluatedAt": "2026-05-05T23:45:45.146Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -27126,7 +28633,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.187Z",
+          "evaluatedAt": "2026-05-05T23:45:45.146Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -27139,8 +28646,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/executive-mentor",
-      "relPath": ".gemini/skills/executive-mentor",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/executive-mentor/skills/executive-mentor",
+      "relPath": "c-level-advisor/executive-mentor/skills/executive-mentor",
       "verified": true,
       "tokenCount": 1980,
       "evalSummary": {
@@ -27190,7 +28697,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.188Z",
+        "evaluatedAt": "2026-05-05T23:45:45.147Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -27245,7 +28752,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.188Z",
+          "evaluatedAt": "2026-05-05T23:45:45.147Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -27263,7 +28770,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.188Z",
+          "evaluatedAt": "2026-05-05T23:45:45.147Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -27327,7 +28834,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.189Z",
+        "evaluatedAt": "2026-05-05T23:45:45.149Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27382,7 +28889,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.189Z",
+          "evaluatedAt": "2026-05-05T23:45:45.149Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27400,7 +28907,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.189Z",
+          "evaluatedAt": "2026-05-05T23:45:45.149Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27413,8 +28920,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/experiment-designer",
-      "relPath": ".gemini/skills/experiment-designer",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/experiment-designer",
+      "relPath": "product-team/skills/experiment-designer",
       "verified": true,
       "tokenCount": 776,
       "evalSummary": {
@@ -27464,7 +28971,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.190Z",
+        "evaluatedAt": "2026-05-05T23:45:45.149Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27519,7 +29026,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.190Z",
+          "evaluatedAt": "2026-05-05T23:45:45.149Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27537,7 +29044,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.190Z",
+          "evaluatedAt": "2026-05-05T23:45:45.149Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27601,7 +29108,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.191Z",
+        "evaluatedAt": "2026-05-05T23:45:45.150Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27656,7 +29163,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.191Z",
+          "evaluatedAt": "2026-05-05T23:45:45.150Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27674,7 +29181,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.191Z",
+          "evaluatedAt": "2026-05-05T23:45:45.150Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27738,7 +29245,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.192Z",
+        "evaluatedAt": "2026-05-05T23:45:45.152Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27793,7 +29300,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.192Z",
+          "evaluatedAt": "2026-05-05T23:45:45.152Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27811,7 +29318,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.192Z",
+          "evaluatedAt": "2026-05-05T23:45:45.152Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "extract",
+      "description": "Turn a proven pattern or debugging solution into a standalone reusable skill with SKILL.md, reference docs, and examples.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/self-improving-agent/skills/extract",
+      "relPath": "engineering-team/self-improving-agent/skills/extract",
+      "verified": true,
+      "tokenCount": 1401,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.153Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.153Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.153Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27875,7 +29519,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.193Z",
+        "evaluatedAt": "2026-05-05T23:45:45.154Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27930,7 +29574,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.193Z",
+          "evaluatedAt": "2026-05-05T23:45:45.154Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27948,7 +29592,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.193Z",
+          "evaluatedAt": "2026-05-05T23:45:45.154Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27961,8 +29605,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/fda-consultant-specialist",
-      "relPath": ".gemini/skills/fda-consultant-specialist",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/fda-consultant-specialist",
+      "relPath": "ra-qm-team/skills/fda-consultant-specialist",
       "verified": true,
       "tokenCount": 2514,
       "evalSummary": {
@@ -28012,7 +29656,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.195Z",
+        "evaluatedAt": "2026-05-05T23:45:45.156Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28067,7 +29711,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.195Z",
+          "evaluatedAt": "2026-05-05T23:45:45.156Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28085,7 +29729,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.195Z",
+          "evaluatedAt": "2026-05-05T23:45:45.156Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28149,7 +29793,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.196Z",
+        "evaluatedAt": "2026-05-05T23:45:45.157Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28204,7 +29848,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.196Z",
+          "evaluatedAt": "2026-05-05T23:45:45.157Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28222,7 +29866,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.196Z",
+          "evaluatedAt": "2026-05-05T23:45:45.157Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28235,13 +29879,13 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/finance-bundle",
-      "relPath": ".gemini/skills/finance-bundle",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/finance-skills",
+      "relPath": ".codex/skills/finance-skills",
       "verified": true,
       "tokenCount": 271,
       "evalSummary": {
-        "overallScore": 64,
-        "grade": "D",
+        "overallScore": 66,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
@@ -28282,11 +29926,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
+            "score": 10,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.197Z",
+        "evaluatedAt": "2026-05-05T23:45:45.158Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -28295,8 +29939,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 64,
-          "grade": "D",
+          "overallScore": 66,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
@@ -28337,11 +29981,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.197Z",
+          "evaluatedAt": "2026-05-05T23:45:45.158Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -28349,17 +29993,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 62,
-          "grade": "D",
+          "overallScore": 69,
+          "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 8,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.197Z",
+          "evaluatedAt": "2026-05-05T23:45:45.158Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -28372,13 +30016,13 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:finance",
-      "relPath": "finance",
+      "installUrl": "github:alirezarezvani/claude-skills:finance/skills/finance-skills",
+      "relPath": "finance/skills/finance-skills",
       "verified": true,
       "tokenCount": 271,
       "evalSummary": {
-        "overallScore": 64,
-        "grade": "D",
+        "overallScore": 66,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
@@ -28419,11 +30063,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
+            "score": 10,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.198Z",
+        "evaluatedAt": "2026-05-05T23:45:45.159Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -28432,8 +30076,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 64,
-          "grade": "D",
+          "overallScore": 66,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
@@ -28474,11 +30118,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.198Z",
+          "evaluatedAt": "2026-05-05T23:45:45.159Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -28486,17 +30130,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 62,
-          "grade": "D",
+          "overallScore": 69,
+          "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 8,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.198Z",
+          "evaluatedAt": "2026-05-05T23:45:45.159Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -28560,7 +30204,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.199Z",
+        "evaluatedAt": "2026-05-05T23:45:45.160Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28615,7 +30259,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.199Z",
+          "evaluatedAt": "2026-05-05T23:45:45.160Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28633,7 +30277,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.199Z",
+          "evaluatedAt": "2026-05-05T23:45:45.160Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28646,8 +30290,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/financial-analyst",
-      "relPath": ".gemini/skills/financial-analyst",
+      "installUrl": "github:alirezarezvani/claude-skills:finance/skills/financial-analyst",
+      "relPath": "finance/skills/financial-analyst",
       "verified": true,
       "tokenCount": 1410,
       "evalSummary": {
@@ -28697,7 +30341,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.200Z",
+        "evaluatedAt": "2026-05-05T23:45:45.161Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28752,7 +30396,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.200Z",
+          "evaluatedAt": "2026-05-05T23:45:45.161Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28770,7 +30414,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.200Z",
+          "evaluatedAt": "2026-05-05T23:45:45.161Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28834,7 +30478,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.201Z",
+        "evaluatedAt": "2026-05-05T23:45:45.162Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28889,7 +30533,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.201Z",
+          "evaluatedAt": "2026-05-05T23:45:45.162Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28907,7 +30551,144 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.201Z",
+          "evaluatedAt": "2026-05-05T23:45:45.162Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "fix",
+      "description": "Fix failing or flaky Playwright tests. Use when user says \"fix test\", \"flaky test\", \"test failing\", \"debug test\", \"test broken\", \"test passes sometimes\", or \"intermittent failure\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/fix",
+      "relPath": ".codex/skills/playwright-pro/skills/fix",
+      "verified": true,
+      "tokenCount": 850,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.162Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 80,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.162Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.162Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28971,7 +30752,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.201Z",
+        "evaluatedAt": "2026-05-05T23:45:45.163Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29026,7 +30807,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.201Z",
+          "evaluatedAt": "2026-05-05T23:45:45.163Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29044,7 +30825,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.201Z",
+          "evaluatedAt": "2026-05-05T23:45:45.163Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "fix",
+      "description": "Fix failing or flaky Playwright tests. Use when user says \"fix test\", \"flaky test\", \"test failing\", \"debug test\", \"test broken\", \"test passes sometimes\", or \"intermittent failure\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/playwright-pro/skills/fix",
+      "relPath": "engineering-team/playwright-pro/skills/fix",
+      "verified": true,
+      "tokenCount": 850,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.164Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 80,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.164Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.164Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29108,7 +31026,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.203Z",
+        "evaluatedAt": "2026-05-05T23:45:45.165Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29163,7 +31081,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.203Z",
+          "evaluatedAt": "2026-05-05T23:45:45.165Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29181,7 +31099,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.203Z",
+          "evaluatedAt": "2026-05-05T23:45:45.165Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29245,7 +31163,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.204Z",
+        "evaluatedAt": "2026-05-05T23:45:45.167Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29300,7 +31218,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.204Z",
+          "evaluatedAt": "2026-05-05T23:45:45.167Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29318,7 +31236,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.204Z",
+          "evaluatedAt": "2026-05-05T23:45:45.167Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29331,8 +31249,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/focused-fix",
-      "relPath": ".gemini/skills/focused-fix",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/focused-fix",
+      "relPath": "engineering/skills/focused-fix",
       "verified": true,
       "tokenCount": 4315,
       "evalSummary": {
@@ -29382,7 +31300,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.206Z",
+        "evaluatedAt": "2026-05-05T23:45:45.168Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29437,7 +31355,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.206Z",
+          "evaluatedAt": "2026-05-05T23:45:45.169Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29455,7 +31373,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.206Z",
+          "evaluatedAt": "2026-05-05T23:45:45.169Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29519,7 +31437,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.208Z",
+        "evaluatedAt": "2026-05-05T23:45:45.171Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -29574,7 +31492,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.208Z",
+          "evaluatedAt": "2026-05-05T23:45:45.171Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -29592,7 +31510,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.208Z",
+          "evaluatedAt": "2026-05-05T23:45:45.171Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -29605,8 +31523,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/form-cro",
-      "relPath": ".gemini/skills/form-cro",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/form-cro",
+      "relPath": "marketing-skill/skills/form-cro",
       "verified": true,
       "tokenCount": 2315,
       "evalSummary": {
@@ -29656,7 +31574,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.209Z",
+        "evaluatedAt": "2026-05-05T23:45:45.172Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -29711,7 +31629,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.209Z",
+          "evaluatedAt": "2026-05-05T23:45:45.172Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -29729,7 +31647,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.209Z",
+          "evaluatedAt": "2026-05-05T23:45:45.172Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -29793,7 +31711,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.211Z",
+        "evaluatedAt": "2026-05-05T23:45:45.174Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -29848,7 +31766,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.211Z",
+          "evaluatedAt": "2026-05-05T23:45:45.174Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -29866,7 +31784,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.211Z",
+          "evaluatedAt": "2026-05-05T23:45:45.174Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -29879,8 +31797,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/founder-coach",
-      "relPath": ".gemini/skills/founder-coach",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/founder-coach",
+      "relPath": "c-level-advisor/skills/founder-coach",
       "verified": true,
       "tokenCount": 4254,
       "evalSummary": {
@@ -29930,7 +31848,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.214Z",
+        "evaluatedAt": "2026-05-05T23:45:45.177Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -29985,7 +31903,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.214Z",
+          "evaluatedAt": "2026-05-05T23:45:45.177Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -30003,7 +31921,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.214Z",
+          "evaluatedAt": "2026-05-05T23:45:45.177Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -30067,7 +31985,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.216Z",
+        "evaluatedAt": "2026-05-05T23:45:45.180Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -30122,7 +32040,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.216Z",
+          "evaluatedAt": "2026-05-05T23:45:45.180Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -30140,7 +32058,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.216Z",
+          "evaluatedAt": "2026-05-05T23:45:45.180Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -30153,8 +32071,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/free-tool-strategy",
-      "relPath": ".gemini/skills/free-tool-strategy",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/free-tool-strategy",
+      "relPath": "marketing-skill/skills/free-tool-strategy",
       "verified": true,
       "tokenCount": 3758,
       "evalSummary": {
@@ -30204,7 +32122,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.219Z",
+        "evaluatedAt": "2026-05-05T23:45:45.182Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -30259,7 +32177,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.219Z",
+          "evaluatedAt": "2026-05-05T23:45:45.182Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -30277,7 +32195,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.219Z",
+          "evaluatedAt": "2026-05-05T23:45:45.182Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -30341,7 +32259,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.220Z",
+        "evaluatedAt": "2026-05-05T23:45:45.184Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30396,7 +32314,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.220Z",
+          "evaluatedAt": "2026-05-05T23:45:45.184Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30414,7 +32332,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.220Z",
+          "evaluatedAt": "2026-05-05T23:45:45.184Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "full-page-screenshot",
+      "description": "Use when the user asks to capture a full-page screenshot, long screenshot, or complete page capture of a web page. Handles SPA scroll containers, lazy-loaded images, and very tall pages via Chrome DevTools Protocol with zero external dependencies.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/full-page-screenshot",
+      "relPath": "engineering/skills/full-page-screenshot",
+      "verified": true,
+      "tokenCount": 1503,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.185Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 74,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.185Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.185Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30478,7 +32533,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.222Z",
+        "evaluatedAt": "2026-05-05T23:45:45.187Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30533,7 +32588,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.222Z",
+          "evaluatedAt": "2026-05-05T23:45:45.187Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30551,7 +32606,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.222Z",
+          "evaluatedAt": "2026-05-05T23:45:45.187Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30564,8 +32619,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/gcp-cloud-architect",
-      "relPath": ".gemini/skills/gcp-cloud-architect",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/gcp-cloud-architect",
+      "relPath": "engineering-team/skills/gcp-cloud-architect",
       "verified": true,
       "tokenCount": 3311,
       "evalSummary": {
@@ -30615,7 +32670,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.224Z",
+        "evaluatedAt": "2026-05-05T23:45:45.189Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30670,7 +32725,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.224Z",
+          "evaluatedAt": "2026-05-05T23:45:45.189Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30688,7 +32743,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.224Z",
+          "evaluatedAt": "2026-05-05T23:45:45.189Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30752,7 +32807,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.226Z",
+        "evaluatedAt": "2026-05-05T23:45:45.190Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30807,7 +32862,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.226Z",
+          "evaluatedAt": "2026-05-05T23:45:45.190Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30825,7 +32880,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.226Z",
+          "evaluatedAt": "2026-05-05T23:45:45.191Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30838,8 +32893,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/gdpr-dsgvo-expert",
-      "relPath": ".gemini/skills/gdpr-dsgvo-expert",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/gdpr-dsgvo-expert",
+      "relPath": "ra-qm-team/skills/gdpr-dsgvo-expert",
       "verified": true,
       "tokenCount": 2017,
       "evalSummary": {
@@ -30889,7 +32944,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.227Z",
+        "evaluatedAt": "2026-05-05T23:45:45.192Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30944,7 +32999,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.227Z",
+          "evaluatedAt": "2026-05-05T23:45:45.192Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30962,7 +33017,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.227Z",
+          "evaluatedAt": "2026-05-05T23:45:45.192Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "generate",
+      "description": "Generate Playwright tests. Use when user says \"write tests\", \"generate tests\", \"add tests for\", \"test this component\", \"e2e test\", \"create test for\", \"test this page\", or \"test this feature\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/generate",
+      "relPath": ".codex/skills/playwright-pro/skills/generate",
+      "verified": true,
+      "tokenCount": 1232,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.193Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.193Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.193Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31026,7 +33218,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.228Z",
+        "evaluatedAt": "2026-05-05T23:45:45.195Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31081,7 +33273,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.228Z",
+          "evaluatedAt": "2026-05-05T23:45:45.195Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31099,7 +33291,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.228Z",
+          "evaluatedAt": "2026-05-05T23:45:45.195Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "generate",
+      "description": "Generate Playwright tests. Use when user says \"write tests\", \"generate tests\", \"add tests for\", \"test this component\", \"e2e test\", \"create test for\", \"test this page\", or \"test this feature\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/playwright-pro/skills/generate",
+      "relPath": "engineering-team/playwright-pro/skills/generate",
+      "verified": true,
+      "tokenCount": 1232,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.196Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.196Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.196Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31163,7 +33492,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.229Z",
+        "evaluatedAt": "2026-05-05T23:45:45.197Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31218,7 +33547,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.229Z",
+          "evaluatedAt": "2026-05-05T23:45:45.197Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31236,7 +33565,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.229Z",
+          "evaluatedAt": "2026-05-05T23:45:45.197Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31249,8 +33578,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/git-worktree-manager",
-      "relPath": ".gemini/skills/git-worktree-manager",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/git-worktree-manager",
+      "relPath": "engineering/skills/git-worktree-manager",
       "verified": true,
       "tokenCount": 1794,
       "evalSummary": {
@@ -31300,7 +33629,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.231Z",
+        "evaluatedAt": "2026-05-05T23:45:45.198Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31355,7 +33684,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.231Z",
+          "evaluatedAt": "2026-05-05T23:45:45.198Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31373,7 +33702,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.231Z",
+          "evaluatedAt": "2026-05-05T23:45:45.198Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31437,7 +33766,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.232Z",
+        "evaluatedAt": "2026-05-05T23:45:45.199Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31492,7 +33821,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.232Z",
+          "evaluatedAt": "2026-05-05T23:45:45.199Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31510,7 +33839,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.232Z",
+          "evaluatedAt": "2026-05-05T23:45:45.199Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31523,8 +33852,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/google-workspace-cli",
-      "relPath": ".codex/skills/google-workspace-cli",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/google-workspace-cli/skills/google-workspace-cli",
+      "relPath": ".codex/skills/google-workspace-cli/skills/google-workspace-cli",
       "verified": true,
       "tokenCount": 2559,
       "evalSummary": {
@@ -31574,7 +33903,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.233Z",
+        "evaluatedAt": "2026-05-05T23:45:45.200Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31629,7 +33958,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.233Z",
+          "evaluatedAt": "2026-05-05T23:45:45.200Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31647,7 +33976,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.233Z",
+          "evaluatedAt": "2026-05-05T23:45:45.200Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31660,8 +33989,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/google-workspace-cli",
-      "relPath": ".gemini/skills/google-workspace-cli",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/google-workspace-cli/skills/google-workspace-cli",
+      "relPath": "engineering-team/google-workspace-cli/skills/google-workspace-cli",
       "verified": true,
       "tokenCount": 2559,
       "evalSummary": {
@@ -31711,7 +34040,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.235Z",
+        "evaluatedAt": "2026-05-05T23:45:45.202Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31766,7 +34095,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.235Z",
+          "evaluatedAt": "2026-05-05T23:45:45.202Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31784,7 +34113,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.235Z",
+          "evaluatedAt": "2026-05-05T23:45:45.202Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31848,7 +34177,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.237Z",
+        "evaluatedAt": "2026-05-05T23:45:45.204Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31903,7 +34232,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.237Z",
+          "evaluatedAt": "2026-05-05T23:45:45.204Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31921,7 +34250,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.237Z",
+          "evaluatedAt": "2026-05-05T23:45:45.204Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "hard-call",
+      "description": "/em -hard-call — Framework for Decisions With No Good Options",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/hard-call",
+      "relPath": ".codex/skills/executive-mentor/skills/hard-call",
+      "verified": true,
+      "tokenCount": 2312,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.206Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 60,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.206Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.206Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31985,7 +34451,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.238Z",
+        "evaluatedAt": "2026-05-05T23:45:45.207Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32040,7 +34506,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.238Z",
+          "evaluatedAt": "2026-05-05T23:45:45.207Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32058,7 +34524,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.238Z",
+          "evaluatedAt": "2026-05-05T23:45:45.207Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "hard-call",
+      "description": "/em -hard-call — Framework for Decisions With No Good Options",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/executive-mentor/skills/hard-call",
+      "relPath": "c-level-advisor/executive-mentor/skills/hard-call",
+      "verified": true,
+      "tokenCount": 2312,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.209Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 60,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.209Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.209Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32071,8 +34674,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/helm-chart-builder",
-      "relPath": ".codex/skills/helm-chart-builder",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/helm-chart-builder/skills/helm-chart-builder",
+      "relPath": ".codex/skills/helm-chart-builder/skills/helm-chart-builder",
       "verified": true,
       "tokenCount": 4452,
       "evalSummary": {
@@ -32122,7 +34725,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.240Z",
+        "evaluatedAt": "2026-05-05T23:45:45.211Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -32177,7 +34780,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.240Z",
+          "evaluatedAt": "2026-05-05T23:45:45.211Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -32195,7 +34798,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.240Z",
+          "evaluatedAt": "2026-05-05T23:45:45.211Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -32208,8 +34811,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/helm-chart-builder",
-      "relPath": ".gemini/skills/helm-chart-builder",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/helm-chart-builder/skills/helm-chart-builder",
+      "relPath": "engineering/helm-chart-builder/skills/helm-chart-builder",
       "verified": true,
       "tokenCount": 4452,
       "evalSummary": {
@@ -32259,7 +34862,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.243Z",
+        "evaluatedAt": "2026-05-05T23:45:45.213Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -32314,7 +34917,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.243Z",
+          "evaluatedAt": "2026-05-05T23:45:45.213Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -32332,7 +34935,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.243Z",
+          "evaluatedAt": "2026-05-05T23:45:45.213Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -32396,7 +34999,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.245Z",
+        "evaluatedAt": "2026-05-05T23:45:45.216Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32451,7 +35054,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.245Z",
+          "evaluatedAt": "2026-05-05T23:45:45.216Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32469,7 +35072,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.245Z",
+          "evaluatedAt": "2026-05-05T23:45:45.216Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32482,8 +35085,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/incident-commander",
-      "relPath": ".gemini/skills/incident-commander",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/incident-commander",
+      "relPath": "engineering-team/skills/incident-commander",
       "verified": true,
       "tokenCount": 3958,
       "evalSummary": {
@@ -32533,7 +35136,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.248Z",
+        "evaluatedAt": "2026-05-05T23:45:45.219Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32588,7 +35191,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.248Z",
+          "evaluatedAt": "2026-05-05T23:45:45.219Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32606,7 +35209,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.248Z",
+          "evaluatedAt": "2026-05-05T23:45:45.219Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32670,7 +35273,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.250Z",
+        "evaluatedAt": "2026-05-05T23:45:45.221Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32725,7 +35328,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.250Z",
+          "evaluatedAt": "2026-05-05T23:45:45.221Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32743,7 +35346,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.250Z",
+          "evaluatedAt": "2026-05-05T23:45:45.221Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32756,8 +35359,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/incident-response",
-      "relPath": ".gemini/skills/incident-response",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/incident-response",
+      "relPath": "engineering-team/skills/incident-response",
       "verified": true,
       "tokenCount": 4077,
       "evalSummary": {
@@ -32807,7 +35410,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.252Z",
+        "evaluatedAt": "2026-05-05T23:45:45.224Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32862,7 +35465,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.252Z",
+          "evaluatedAt": "2026-05-05T23:45:45.224Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32880,7 +35483,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.252Z",
+          "evaluatedAt": "2026-05-05T23:45:45.224Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32944,7 +35547,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.255Z",
+        "evaluatedAt": "2026-05-05T23:45:45.226Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32999,7 +35602,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.255Z",
+          "evaluatedAt": "2026-05-05T23:45:45.226Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33017,7 +35620,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.255Z",
+          "evaluatedAt": "2026-05-05T23:45:45.226Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33030,8 +35633,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/information-security-manager-iso27001",
-      "relPath": ".gemini/skills/information-security-manager-iso27001",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/information-security-manager-iso27001",
+      "relPath": "ra-qm-team/skills/information-security-manager-iso27001",
       "verified": true,
       "tokenCount": 2874,
       "evalSummary": {
@@ -33081,7 +35684,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.256Z",
+        "evaluatedAt": "2026-05-05T23:45:45.228Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33136,7 +35739,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.256Z",
+          "evaluatedAt": "2026-05-05T23:45:45.229Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33154,7 +35757,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.256Z",
+          "evaluatedAt": "2026-05-05T23:45:45.229Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "init",
+      "description": "Create a new AgentHub collaboration session with task, agent count, and evaluation criteria.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/init",
+      "relPath": ".codex/skills/agenthub/skills/init",
+      "verified": true,
+      "tokenCount": 808,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.230Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 67,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.230Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.230Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "init",
+      "description": "Set up Playwright in a project. Use when user says \"set up playwright\", \"add e2e tests\", \"configure playwright\", \"testing setup\", \"init playwright\", or \"add test infrastructure\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/init",
+      "relPath": ".codex/skills/playwright-pro/skills/init",
+      "verified": true,
+      "tokenCount": 1293,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.231Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 83,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.231Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.231Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33218,7 +36095,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.258Z",
+        "evaluatedAt": "2026-05-05T23:45:45.232Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33273,7 +36150,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.258Z",
+          "evaluatedAt": "2026-05-05T23:45:45.232Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33291,7 +36168,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.258Z",
+          "evaluatedAt": "2026-05-05T23:45:45.232Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33355,7 +36232,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.259Z",
+        "evaluatedAt": "2026-05-05T23:45:45.233Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33410,7 +36287,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.259Z",
+          "evaluatedAt": "2026-05-05T23:45:45.233Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33428,7 +36305,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.259Z",
+          "evaluatedAt": "2026-05-05T23:45:45.233Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "init",
+      "description": "Create a new AgentHub collaboration session with task, agent count, and evaluation criteria.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/agenthub/skills/init",
+      "relPath": "engineering/agenthub/skills/init",
+      "verified": true,
+      "tokenCount": 808,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.234Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 67,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.234Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.234Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "init",
+      "description": "Set up Playwright in a project. Use when user says \"set up playwright\", \"add e2e tests\", \"configure playwright\", \"testing setup\", \"init playwright\", or \"add test infrastructure\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/playwright-pro/skills/init",
+      "relPath": "engineering-team/playwright-pro/skills/init",
+      "verified": true,
+      "tokenCount": 1293,
+      "evalSummary": {
+        "overallScore": 83,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.235Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 83,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.235Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.235Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33492,7 +36643,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.260Z",
+        "evaluatedAt": "2026-05-05T23:45:45.236Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -33547,7 +36698,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.260Z",
+          "evaluatedAt": "2026-05-05T23:45:45.236Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -33565,7 +36716,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.260Z",
+          "evaluatedAt": "2026-05-05T23:45:45.237Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -33578,8 +36729,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/internal-narrative",
-      "relPath": ".gemini/skills/internal-narrative",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/internal-narrative",
+      "relPath": "c-level-advisor/skills/internal-narrative",
       "verified": true,
       "tokenCount": 3141,
       "evalSummary": {
@@ -33629,7 +36780,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.262Z",
+        "evaluatedAt": "2026-05-05T23:45:45.239Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -33684,7 +36835,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.262Z",
+          "evaluatedAt": "2026-05-05T23:45:45.239Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -33702,7 +36853,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.262Z",
+          "evaluatedAt": "2026-05-05T23:45:45.239Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -33766,7 +36917,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.263Z",
+        "evaluatedAt": "2026-05-05T23:45:45.241Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33821,7 +36972,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.263Z",
+          "evaluatedAt": "2026-05-05T23:45:45.241Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33839,7 +36990,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.263Z",
+          "evaluatedAt": "2026-05-05T23:45:45.241Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33852,8 +37003,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/interview-system-designer",
-      "relPath": ".gemini/skills/interview-system-designer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/interview-system-designer",
+      "relPath": "engineering/skills/interview-system-designer",
       "verified": true,
       "tokenCount": 522,
       "evalSummary": {
@@ -33903,7 +37054,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.264Z",
+        "evaluatedAt": "2026-05-05T23:45:45.241Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33958,7 +37109,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.264Z",
+          "evaluatedAt": "2026-05-05T23:45:45.242Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33976,7 +37127,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.264Z",
+          "evaluatedAt": "2026-05-05T23:45:45.242Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34040,7 +37191,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.265Z",
+        "evaluatedAt": "2026-05-05T23:45:45.243Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -34095,7 +37246,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.265Z",
+          "evaluatedAt": "2026-05-05T23:45:45.243Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -34113,7 +37264,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.265Z",
+          "evaluatedAt": "2026-05-05T23:45:45.243Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -34126,8 +37277,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/intl-expansion",
-      "relPath": ".gemini/skills/intl-expansion",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/intl-expansion",
+      "relPath": "c-level-advisor/skills/intl-expansion",
       "verified": true,
       "tokenCount": 1341,
       "evalSummary": {
@@ -34177,7 +37328,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.266Z",
+        "evaluatedAt": "2026-05-05T23:45:45.244Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -34232,7 +37383,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.266Z",
+          "evaluatedAt": "2026-05-05T23:45:45.244Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -34250,7 +37401,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.266Z",
+          "evaluatedAt": "2026-05-05T23:45:45.244Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -34314,7 +37465,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.267Z",
+        "evaluatedAt": "2026-05-05T23:45:45.245Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34369,7 +37520,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.267Z",
+          "evaluatedAt": "2026-05-05T23:45:45.245Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34387,7 +37538,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.267Z",
+          "evaluatedAt": "2026-05-05T23:45:45.245Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34400,8 +37551,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/isms-audit-expert",
-      "relPath": ".gemini/skills/isms-audit-expert",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/isms-audit-expert",
+      "relPath": "ra-qm-team/skills/isms-audit-expert",
       "verified": true,
       "tokenCount": 1950,
       "evalSummary": {
@@ -34451,7 +37602,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.268Z",
+        "evaluatedAt": "2026-05-05T23:45:45.246Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34506,7 +37657,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.268Z",
+          "evaluatedAt": "2026-05-05T23:45:45.246Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34524,7 +37675,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.268Z",
+          "evaluatedAt": "2026-05-05T23:45:45.246Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34588,7 +37739,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.270Z",
+        "evaluatedAt": "2026-05-05T23:45:45.248Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34643,7 +37794,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.270Z",
+          "evaluatedAt": "2026-05-05T23:45:45.248Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34661,7 +37812,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.270Z",
+          "evaluatedAt": "2026-05-05T23:45:45.248Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34674,8 +37825,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/jira-expert",
-      "relPath": ".gemini/skills/jira-expert",
+      "installUrl": "github:alirezarezvani/claude-skills:project-management/skills/jira-expert",
+      "relPath": "project-management/skills/jira-expert",
       "verified": true,
       "tokenCount": 2350,
       "evalSummary": {
@@ -34725,7 +37876,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.271Z",
+        "evaluatedAt": "2026-05-05T23:45:45.249Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34780,7 +37931,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.271Z",
+          "evaluatedAt": "2026-05-05T23:45:45.249Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34798,7 +37949,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.271Z",
+          "evaluatedAt": "2026-05-05T23:45:45.249Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34862,7 +38013,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.272Z",
+        "evaluatedAt": "2026-05-05T23:45:45.250Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34917,7 +38068,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.272Z",
+          "evaluatedAt": "2026-05-05T23:45:45.250Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34935,7 +38086,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.272Z",
+          "evaluatedAt": "2026-05-05T23:45:45.250Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34948,8 +38099,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/karpathy-coder",
-      "relPath": ".codex/skills/karpathy-coder",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/karpathy-coder/skills/karpathy-coder",
+      "relPath": ".codex/skills/karpathy-coder/skills/karpathy-coder",
       "verified": true,
       "tokenCount": 1580,
       "evalSummary": {
@@ -34999,7 +38150,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.273Z",
+        "evaluatedAt": "2026-05-05T23:45:45.251Z",
         "evaluatedVersion": "2.3.0"
       },
       "evalSummaries": {
@@ -35054,7 +38205,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.273Z",
+          "evaluatedAt": "2026-05-05T23:45:45.251Z",
           "evaluatedVersion": "2.3.0"
         },
         "skill-best-practice": {
@@ -35072,7 +38223,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.273Z",
+          "evaluatedAt": "2026-05-05T23:45:45.251Z",
           "evaluatedVersion": "2.3.0"
         }
       }
@@ -35085,8 +38236,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/karpathy-coder",
-      "relPath": ".gemini/skills/karpathy-coder",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/karpathy-coder/skills/karpathy-coder",
+      "relPath": "engineering/karpathy-coder/skills/karpathy-coder",
       "verified": true,
       "tokenCount": 1580,
       "evalSummary": {
@@ -35136,7 +38287,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.274Z",
+        "evaluatedAt": "2026-05-05T23:45:45.253Z",
         "evaluatedVersion": "2.3.0"
       },
       "evalSummaries": {
@@ -35191,7 +38342,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.274Z",
+          "evaluatedAt": "2026-05-05T23:45:45.253Z",
           "evaluatedVersion": "2.3.0"
         },
         "skill-best-practice": {
@@ -35209,7 +38360,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.274Z",
+          "evaluatedAt": "2026-05-05T23:45:45.253Z",
           "evaluatedVersion": "2.3.0"
         }
       }
@@ -35273,7 +38424,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.276Z",
+        "evaluatedAt": "2026-05-05T23:45:45.254Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35328,7 +38479,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.276Z",
+          "evaluatedAt": "2026-05-05T23:45:45.254Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35346,7 +38497,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.276Z",
+          "evaluatedAt": "2026-05-05T23:45:45.254Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35359,8 +38510,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/landing-page-generator",
-      "relPath": ".gemini/skills/landing-page-generator",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/landing-page-generator",
+      "relPath": "product-team/skills/landing-page-generator",
       "verified": true,
       "tokenCount": 3025,
       "evalSummary": {
@@ -35410,7 +38561,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.278Z",
+        "evaluatedAt": "2026-05-05T23:45:45.256Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35465,7 +38616,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.278Z",
+          "evaluatedAt": "2026-05-05T23:45:45.256Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35483,7 +38634,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.278Z",
+          "evaluatedAt": "2026-05-05T23:45:45.256Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35547,7 +38698,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.279Z",
+        "evaluatedAt": "2026-05-05T23:45:45.259Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -35602,7 +38753,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.279Z",
+          "evaluatedAt": "2026-05-05T23:45:45.259Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -35620,7 +38771,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.279Z",
+          "evaluatedAt": "2026-05-05T23:45:45.259Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -35633,8 +38784,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/launch-strategy",
-      "relPath": ".gemini/skills/launch-strategy",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/launch-strategy",
+      "relPath": "marketing-skill/skills/launch-strategy",
       "verified": true,
       "tokenCount": 1205,
       "evalSummary": {
@@ -35684,7 +38835,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.280Z",
+        "evaluatedAt": "2026-05-05T23:45:45.261Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -35739,7 +38890,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.280Z",
+          "evaluatedAt": "2026-05-05T23:45:45.261Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -35757,7 +38908,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.280Z",
+          "evaluatedAt": "2026-05-05T23:45:45.261Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -35770,8 +38921,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/llm-cost-optimizer",
-      "relPath": ".codex/skills/llm-cost-optimizer",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/llm-cost-optimizer/skills/llm-cost-optimizer",
+      "relPath": ".codex/skills/llm-cost-optimizer/skills/llm-cost-optimizer",
       "verified": true,
       "tokenCount": 3317,
       "evalSummary": {
@@ -35821,7 +38972,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.281Z",
+        "evaluatedAt": "2026-05-05T23:45:45.262Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35876,7 +39027,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.282Z",
+          "evaluatedAt": "2026-05-05T23:45:45.262Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35894,7 +39045,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.282Z",
+          "evaluatedAt": "2026-05-05T23:45:45.262Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35907,8 +39058,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/llm-cost-optimizer",
-      "relPath": ".gemini/skills/llm-cost-optimizer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/llm-cost-optimizer/skills/llm-cost-optimizer",
+      "relPath": "engineering/llm-cost-optimizer/skills/llm-cost-optimizer",
       "verified": true,
       "tokenCount": 3317,
       "evalSummary": {
@@ -35958,7 +39109,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.283Z",
+        "evaluatedAt": "2026-05-05T23:45:45.264Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36013,7 +39164,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.283Z",
+          "evaluatedAt": "2026-05-05T23:45:45.264Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36031,7 +39182,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.283Z",
+          "evaluatedAt": "2026-05-05T23:45:45.264Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36044,8 +39195,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/llm-wiki",
-      "relPath": ".codex/skills/llm-wiki",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/llm-wiki/skills/llm-wiki",
+      "relPath": ".codex/skills/llm-wiki/skills/llm-wiki",
       "verified": true,
       "tokenCount": 2893,
       "evalSummary": {
@@ -36095,7 +39246,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.285Z",
+        "evaluatedAt": "2026-05-05T23:45:45.266Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -36150,7 +39301,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.285Z",
+          "evaluatedAt": "2026-05-05T23:45:45.266Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -36168,7 +39319,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.285Z",
+          "evaluatedAt": "2026-05-05T23:45:45.266Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -36181,8 +39332,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/llm-wiki",
-      "relPath": ".gemini/skills/llm-wiki",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/llm-wiki/skills/llm-wiki",
+      "relPath": "engineering/llm-wiki/skills/llm-wiki",
       "verified": true,
       "tokenCount": 2893,
       "evalSummary": {
@@ -36232,7 +39383,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.287Z",
+        "evaluatedAt": "2026-05-05T23:45:45.268Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -36287,7 +39438,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.287Z",
+          "evaluatedAt": "2026-05-05T23:45:45.268Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -36305,8 +39456,145 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.287Z",
+          "evaluatedAt": "2026-05-05T23:45:45.268Z",
           "evaluatedVersion": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "loop",
+      "description": "Start an autonomous experiment loop with user-selected interval (10min, 1h, daily, weekly, monthly). Uses CronCreate for scheduling.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/loop",
+      "relPath": ".codex/skills/autoresearch-agent/skills/loop",
+      "verified": true,
+      "tokenCount": 1169,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.270Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 67,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.270Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.270Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -36369,7 +39657,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.288Z",
+        "evaluatedAt": "2026-05-05T23:45:45.271Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36424,7 +39712,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.288Z",
+          "evaluatedAt": "2026-05-05T23:45:45.271Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36442,7 +39730,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.289Z",
+          "evaluatedAt": "2026-05-05T23:45:45.271Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "loop",
+      "description": "Start an autonomous experiment loop with user-selected interval (10min, 1h, daily, weekly, monthly). Uses CronCreate for scheduling.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/autoresearch-agent/skills/loop",
+      "relPath": "engineering/autoresearch-agent/skills/loop",
+      "verified": true,
+      "tokenCount": 1169,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.272Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 67,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.272Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.272Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36506,7 +39931,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.289Z",
+        "evaluatedAt": "2026-05-05T23:45:45.274Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -36561,7 +39986,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.289Z",
+          "evaluatedAt": "2026-05-05T23:45:45.274Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -36579,7 +40004,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.289Z",
+          "evaluatedAt": "2026-05-05T23:45:45.274Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -36592,8 +40017,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ma-playbook",
-      "relPath": ".gemini/skills/ma-playbook",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/ma-playbook",
+      "relPath": "c-level-advisor/skills/ma-playbook",
       "verified": true,
       "tokenCount": 1122,
       "evalSummary": {
@@ -36643,7 +40068,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.290Z",
+        "evaluatedAt": "2026-05-05T23:45:45.275Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -36698,7 +40123,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.291Z",
+          "evaluatedAt": "2026-05-05T23:45:45.275Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -36716,7 +40141,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.291Z",
+          "evaluatedAt": "2026-05-05T23:45:45.275Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -36780,7 +40205,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.292Z",
+        "evaluatedAt": "2026-05-05T23:45:45.276Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -36835,7 +40260,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.292Z",
+          "evaluatedAt": "2026-05-05T23:45:45.276Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -36853,7 +40278,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.292Z",
+          "evaluatedAt": "2026-05-05T23:45:45.276Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -36866,8 +40291,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-context",
-      "relPath": ".gemini/skills/marketing-context",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/marketing-context",
+      "relPath": "marketing-skill/skills/marketing-context",
       "verified": true,
       "tokenCount": 1975,
       "evalSummary": {
@@ -36917,7 +40342,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.293Z",
+        "evaluatedAt": "2026-05-05T23:45:45.278Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -36972,7 +40397,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.293Z",
+          "evaluatedAt": "2026-05-05T23:45:45.278Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -36990,7 +40415,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.293Z",
+          "evaluatedAt": "2026-05-05T23:45:45.278Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -37054,7 +40479,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.295Z",
+        "evaluatedAt": "2026-05-05T23:45:45.280Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -37109,7 +40534,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.295Z",
+          "evaluatedAt": "2026-05-05T23:45:45.280Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -37127,7 +40552,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.295Z",
+          "evaluatedAt": "2026-05-05T23:45:45.280Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -37140,8 +40565,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-demand-acquisition",
-      "relPath": ".gemini/skills/marketing-demand-acquisition",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/marketing-demand-acquisition",
+      "relPath": "marketing-skill/skills/marketing-demand-acquisition",
       "verified": true,
       "tokenCount": 2653,
       "evalSummary": {
@@ -37191,7 +40616,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.296Z",
+        "evaluatedAt": "2026-05-05T23:45:45.282Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -37246,7 +40671,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.296Z",
+          "evaluatedAt": "2026-05-05T23:45:45.282Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -37264,7 +40689,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.296Z",
+          "evaluatedAt": "2026-05-05T23:45:45.282Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -37328,7 +40753,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.298Z",
+        "evaluatedAt": "2026-05-05T23:45:45.284Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -37383,7 +40808,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.298Z",
+          "evaluatedAt": "2026-05-05T23:45:45.284Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -37401,7 +40826,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.298Z",
+          "evaluatedAt": "2026-05-05T23:45:45.284Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -37414,8 +40839,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-ideas",
-      "relPath": ".gemini/skills/marketing-ideas",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/marketing-ideas",
+      "relPath": "marketing-skill/skills/marketing-ideas",
       "verified": true,
       "tokenCount": 2271,
       "evalSummary": {
@@ -37465,7 +40890,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.300Z",
+        "evaluatedAt": "2026-05-05T23:45:45.285Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -37520,7 +40945,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.300Z",
+          "evaluatedAt": "2026-05-05T23:45:45.285Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -37538,7 +40963,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.300Z",
+          "evaluatedAt": "2026-05-05T23:45:45.285Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -37602,7 +41027,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.301Z",
+        "evaluatedAt": "2026-05-05T23:45:45.287Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -37657,7 +41082,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.301Z",
+          "evaluatedAt": "2026-05-05T23:45:45.287Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -37675,7 +41100,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.301Z",
+          "evaluatedAt": "2026-05-05T23:45:45.287Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -37688,8 +41113,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-ops",
-      "relPath": ".gemini/skills/marketing-ops",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/marketing-ops",
+      "relPath": "marketing-skill/skills/marketing-ops",
       "verified": true,
       "tokenCount": 2454,
       "evalSummary": {
@@ -37739,7 +41164,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.303Z",
+        "evaluatedAt": "2026-05-05T23:45:45.289Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -37794,7 +41219,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.303Z",
+          "evaluatedAt": "2026-05-05T23:45:45.289Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -37812,7 +41237,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.303Z",
+          "evaluatedAt": "2026-05-05T23:45:45.289Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -37876,7 +41301,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.304Z",
+        "evaluatedAt": "2026-05-05T23:45:45.290Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -37931,7 +41356,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.304Z",
+          "evaluatedAt": "2026-05-05T23:45:45.290Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -37949,7 +41374,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.304Z",
+          "evaluatedAt": "2026-05-05T23:45:45.290Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -37962,8 +41387,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-psychology",
-      "relPath": ".gemini/skills/marketing-psychology",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/marketing-psychology",
+      "relPath": "marketing-skill/skills/marketing-psychology",
       "verified": true,
       "tokenCount": 1884,
       "evalSummary": {
@@ -38013,7 +41438,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.306Z",
+        "evaluatedAt": "2026-05-05T23:45:45.291Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -38068,7 +41493,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.306Z",
+          "evaluatedAt": "2026-05-05T23:45:45.291Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -38086,7 +41511,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.306Z",
+          "evaluatedAt": "2026-05-05T23:45:45.291Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -38099,12 +41524,12 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-bundle",
-      "relPath": ".gemini/skills/marketing-bundle",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/marketing-skills",
+      "relPath": ".codex/skills/marketing-skills",
       "verified": true,
       "tokenCount": 1105,
       "evalSummary": {
-        "overallScore": 74,
+        "overallScore": 76,
         "grade": "C",
         "categories": [
           {
@@ -38146,11 +41571,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
+            "score": 10,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.307Z",
+        "evaluatedAt": "2026-05-05T23:45:45.293Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -38159,7 +41584,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 74,
+          "overallScore": 76,
           "grade": "C",
           "categories": [
             {
@@ -38201,11 +41626,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.307Z",
+          "evaluatedAt": "2026-05-05T23:45:45.293Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -38213,17 +41638,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 54,
+          "overallScore": 62,
           "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 7,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.307Z",
+          "evaluatedAt": "2026-05-05T23:45:45.293Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -38236,12 +41661,12 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-skill-bundle",
-      "relPath": ".gemini/skills/marketing-skill-bundle",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/marketing-skills",
+      "relPath": "marketing-skill/skills/marketing-skills",
       "verified": true,
       "tokenCount": 1105,
       "evalSummary": {
-        "overallScore": 74,
+        "overallScore": 76,
         "grade": "C",
         "categories": [
           {
@@ -38283,148 +41708,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:32.308Z",
-        "evaluatedVersion": "2.0.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 74,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 8,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 6,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 3,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 9,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:32.308Z",
-          "evaluatedVersion": "2.0.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 54,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 7,
-              "max": 13
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:32.308Z",
-          "evaluatedVersion": "2.0.0"
-        }
-      }
-    },
-    {
-      "name": "marketing-skills",
-      "description": "42 marketing agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw, and 6 more coding agents. 7 pods: content, SEO, CRO, channels, growth, intelligence, sales. Foundation context + orchestration router. 27 Python tools (stdlib-only).",
-      "version": "2.0.0",
-      "license": "MIT",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill",
-      "relPath": "marketing-skill",
-      "verified": true,
-      "tokenCount": 1105,
-      "evalSummary": {
-        "overallScore": 74,
-        "grade": "C",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
             "score": 10,
             "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 8,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 6,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 3,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.309Z",
+        "evaluatedAt": "2026-05-05T23:45:45.294Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -38433,7 +41721,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 74,
+          "overallScore": 76,
           "grade": "C",
           "categories": [
             {
@@ -38475,11 +41763,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.310Z",
+          "evaluatedAt": "2026-05-05T23:45:45.294Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -38487,17 +41775,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 54,
+          "overallScore": 62,
           "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 7,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.310Z",
+          "evaluatedAt": "2026-05-05T23:45:45.294Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -38561,7 +41849,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.311Z",
+        "evaluatedAt": "2026-05-05T23:45:45.295Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38616,7 +41904,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.311Z",
+          "evaluatedAt": "2026-05-05T23:45:45.295Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38634,7 +41922,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.311Z",
+          "evaluatedAt": "2026-05-05T23:45:45.295Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38647,8 +41935,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/marketing-strategy-pmm",
-      "relPath": ".gemini/skills/marketing-strategy-pmm",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/marketing-strategy-pmm",
+      "relPath": "marketing-skill/skills/marketing-strategy-pmm",
       "verified": true,
       "tokenCount": 3475,
       "evalSummary": {
@@ -38698,7 +41986,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.313Z",
+        "evaluatedAt": "2026-05-05T23:45:45.297Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38753,7 +42041,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.313Z",
+          "evaluatedAt": "2026-05-05T23:45:45.297Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38771,7 +42059,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.313Z",
+          "evaluatedAt": "2026-05-05T23:45:45.297Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38835,7 +42123,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.315Z",
+        "evaluatedAt": "2026-05-05T23:45:45.299Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38890,7 +42178,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.315Z",
+          "evaluatedAt": "2026-05-05T23:45:45.299Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38908,7 +42196,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.315Z",
+          "evaluatedAt": "2026-05-05T23:45:45.299Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38921,8 +42209,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/mcp-server-builder",
-      "relPath": ".gemini/skills/mcp-server-builder",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/mcp-server-builder",
+      "relPath": "engineering/skills/mcp-server-builder",
       "verified": true,
       "tokenCount": 1447,
       "evalSummary": {
@@ -38972,7 +42260,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.316Z",
+        "evaluatedAt": "2026-05-05T23:45:45.300Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39027,7 +42315,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.316Z",
+          "evaluatedAt": "2026-05-05T23:45:45.300Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39045,7 +42333,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.316Z",
+          "evaluatedAt": "2026-05-05T23:45:45.300Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39109,7 +42397,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.317Z",
+        "evaluatedAt": "2026-05-05T23:45:45.302Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39164,7 +42452,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.317Z",
+          "evaluatedAt": "2026-05-05T23:45:45.302Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39182,7 +42470,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.317Z",
+          "evaluatedAt": "2026-05-05T23:45:45.302Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39195,8 +42483,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/mdr-745-specialist",
-      "relPath": ".gemini/skills/mdr-745-specialist",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/mdr-745-specialist",
+      "relPath": "ra-qm-team/skills/mdr-745-specialist",
       "verified": true,
       "tokenCount": 2636,
       "evalSummary": {
@@ -39246,7 +42534,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.319Z",
+        "evaluatedAt": "2026-05-05T23:45:45.304Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39301,7 +42589,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.319Z",
+          "evaluatedAt": "2026-05-05T23:45:45.304Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39319,7 +42607,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.319Z",
+          "evaluatedAt": "2026-05-05T23:45:45.304Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39383,7 +42671,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.321Z",
+        "evaluatedAt": "2026-05-05T23:45:45.306Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39438,7 +42726,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.321Z",
+          "evaluatedAt": "2026-05-05T23:45:45.306Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39456,7 +42744,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.321Z",
+          "evaluatedAt": "2026-05-05T23:45:45.306Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39469,8 +42757,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/meeting-analyzer",
-      "relPath": ".gemini/skills/meeting-analyzer",
+      "installUrl": "github:alirezarezvani/claude-skills:project-management/skills/meeting-analyzer",
+      "relPath": "project-management/skills/meeting-analyzer",
       "verified": true,
       "tokenCount": 3442,
       "evalSummary": {
@@ -39520,7 +42808,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.323Z",
+        "evaluatedAt": "2026-05-05T23:45:45.308Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39575,7 +42863,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.323Z",
+          "evaluatedAt": "2026-05-05T23:45:45.308Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39593,7 +42881,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.323Z",
+          "evaluatedAt": "2026-05-05T23:45:45.308Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "merge",
+      "description": "Merge the winning agent's branch into base, archive losers, and clean up worktrees.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/merge",
+      "relPath": ".codex/skills/agenthub/skills/merge",
+      "verified": true,
+      "tokenCount": 579,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.310Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 59,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.310Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.310Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39657,7 +43082,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.325Z",
+        "evaluatedAt": "2026-05-05T23:45:45.310Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39712,7 +43137,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.325Z",
+          "evaluatedAt": "2026-05-05T23:45:45.310Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39730,7 +43155,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.325Z",
+          "evaluatedAt": "2026-05-05T23:45:45.310Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "merge",
+      "description": "Merge the winning agent's branch into base, archive losers, and clean up worktrees.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/agenthub/skills/merge",
+      "relPath": "engineering/agenthub/skills/merge",
+      "verified": true,
+      "tokenCount": 579,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.311Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 59,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.311Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.311Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "migrate",
+      "description": "Migrate from Cypress or Selenium to Playwright. Use when user mentions \"cypress\", \"selenium\", \"migrate tests\", \"convert tests\", \"switch to playwright\", \"move from cypress\", or \"replace selenium\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/migrate",
+      "relPath": ".codex/skills/playwright-pro/skills/migrate",
+      "verified": true,
+      "tokenCount": 1112,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.312Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 73,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.312Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.312Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39794,7 +43493,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.326Z",
+        "evaluatedAt": "2026-05-05T23:45:45.313Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39849,7 +43548,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.326Z",
+          "evaluatedAt": "2026-05-05T23:45:45.313Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39867,7 +43566,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.326Z",
+          "evaluatedAt": "2026-05-05T23:45:45.313Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "migrate",
+      "description": "Migrate from Cypress or Selenium to Playwright. Use when user mentions \"cypress\", \"selenium\", \"migrate tests\", \"convert tests\", \"switch to playwright\", \"move from cypress\", or \"replace selenium\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/playwright-pro/skills/migrate",
+      "relPath": "engineering-team/playwright-pro/skills/migrate",
+      "verified": true,
+      "tokenCount": 1112,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.314Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 73,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.314Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.314Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39931,7 +43767,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.327Z",
+        "evaluatedAt": "2026-05-05T23:45:45.316Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39986,7 +43822,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.327Z",
+          "evaluatedAt": "2026-05-05T23:45:45.316Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40004,7 +43840,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.327Z",
+          "evaluatedAt": "2026-05-05T23:45:45.316Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40017,8 +43853,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/migration-architect",
-      "relPath": ".gemini/skills/migration-architect",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/migration-architect",
+      "relPath": "engineering/skills/migration-architect",
       "verified": true,
       "tokenCount": 4605,
       "evalSummary": {
@@ -40068,7 +43904,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.330Z",
+        "evaluatedAt": "2026-05-05T23:45:45.318Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40123,7 +43959,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.330Z",
+          "evaluatedAt": "2026-05-05T23:45:45.318Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40141,7 +43977,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.330Z",
+          "evaluatedAt": "2026-05-05T23:45:45.318Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40205,7 +44041,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.332Z",
+        "evaluatedAt": "2026-05-05T23:45:45.320Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40260,7 +44096,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.332Z",
+          "evaluatedAt": "2026-05-05T23:45:45.320Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40278,7 +44114,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.332Z",
+          "evaluatedAt": "2026-05-05T23:45:45.320Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40291,8 +44127,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/monorepo-navigator",
-      "relPath": ".gemini/skills/monorepo-navigator",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/monorepo-navigator",
+      "relPath": "engineering/skills/monorepo-navigator",
       "verified": true,
       "tokenCount": 1203,
       "evalSummary": {
@@ -40342,7 +44178,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.333Z",
+        "evaluatedAt": "2026-05-05T23:45:45.321Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40397,7 +44233,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.333Z",
+          "evaluatedAt": "2026-05-05T23:45:45.321Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40415,7 +44251,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.333Z",
+          "evaluatedAt": "2026-05-05T23:45:45.321Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40479,7 +44315,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.334Z",
+        "evaluatedAt": "2026-05-05T23:45:45.323Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40534,7 +44370,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.334Z",
+          "evaluatedAt": "2026-05-05T23:45:45.323Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40552,7 +44388,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.334Z",
+          "evaluatedAt": "2026-05-05T23:45:45.323Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40565,8 +44401,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ms365-tenant-manager",
-      "relPath": ".gemini/skills/ms365-tenant-manager",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/ms365-tenant-manager",
+      "relPath": "engineering-team/skills/ms365-tenant-manager",
       "verified": true,
       "tokenCount": 2154,
       "evalSummary": {
@@ -40616,7 +44452,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.336Z",
+        "evaluatedAt": "2026-05-05T23:45:45.324Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40671,7 +44507,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.336Z",
+          "evaluatedAt": "2026-05-05T23:45:45.324Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40689,7 +44525,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.336Z",
+          "evaluatedAt": "2026-05-05T23:45:45.324Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40753,7 +44589,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.338Z",
+        "evaluatedAt": "2026-05-05T23:45:45.326Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40808,7 +44644,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.338Z",
+          "evaluatedAt": "2026-05-05T23:45:45.326Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40826,7 +44662,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.338Z",
+          "evaluatedAt": "2026-05-05T23:45:45.326Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40839,8 +44675,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/observability-designer",
-      "relPath": ".gemini/skills/observability-designer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/observability-designer",
+      "relPath": "engineering/skills/observability-designer",
       "verified": true,
       "tokenCount": 3024,
       "evalSummary": {
@@ -40890,7 +44726,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.340Z",
+        "evaluatedAt": "2026-05-05T23:45:45.328Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40945,7 +44781,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.340Z",
+          "evaluatedAt": "2026-05-05T23:45:45.328Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40963,7 +44799,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.340Z",
+          "evaluatedAt": "2026-05-05T23:45:45.328Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41027,7 +44863,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.342Z",
+        "evaluatedAt": "2026-05-05T23:45:45.330Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41082,7 +44918,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.342Z",
+          "evaluatedAt": "2026-05-05T23:45:45.330Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41100,7 +44936,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.342Z",
+          "evaluatedAt": "2026-05-05T23:45:45.330Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41164,7 +45000,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.343Z",
+        "evaluatedAt": "2026-05-05T23:45:45.331Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -41219,7 +45055,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.343Z",
+          "evaluatedAt": "2026-05-05T23:45:45.331Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -41237,7 +45073,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.343Z",
+          "evaluatedAt": "2026-05-05T23:45:45.331Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -41250,8 +45086,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/onboarding-cro",
-      "relPath": ".gemini/skills/onboarding-cro",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/onboarding-cro",
+      "relPath": "marketing-skill/skills/onboarding-cro",
       "verified": true,
       "tokenCount": 2487,
       "evalSummary": {
@@ -41301,7 +45137,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.345Z",
+        "evaluatedAt": "2026-05-05T23:45:45.332Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -41356,7 +45192,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.345Z",
+          "evaluatedAt": "2026-05-05T23:45:45.332Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -41374,7 +45210,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.345Z",
+          "evaluatedAt": "2026-05-05T23:45:45.332Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -41438,7 +45274,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.346Z",
+        "evaluatedAt": "2026-05-05T23:45:45.334Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -41493,7 +45329,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.346Z",
+          "evaluatedAt": "2026-05-05T23:45:45.334Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -41511,7 +45347,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.346Z",
+          "evaluatedAt": "2026-05-05T23:45:45.334Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -41524,8 +45360,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/org-health-diagnostic",
-      "relPath": ".gemini/skills/org-health-diagnostic",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/org-health-diagnostic",
+      "relPath": "c-level-advisor/skills/org-health-diagnostic",
       "verified": true,
       "tokenCount": 2414,
       "evalSummary": {
@@ -41575,7 +45411,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.348Z",
+        "evaluatedAt": "2026-05-05T23:45:45.336Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -41630,7 +45466,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.348Z",
+          "evaluatedAt": "2026-05-05T23:45:45.336Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -41648,7 +45484,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.348Z",
+          "evaluatedAt": "2026-05-05T23:45:45.336Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -41712,7 +45548,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.350Z",
+        "evaluatedAt": "2026-05-05T23:45:45.337Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -41767,7 +45603,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.350Z",
+          "evaluatedAt": "2026-05-05T23:45:45.337Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -41785,7 +45621,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.350Z",
+          "evaluatedAt": "2026-05-05T23:45:45.337Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -41798,8 +45634,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/page-cro",
-      "relPath": ".gemini/skills/page-cro",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/page-cro",
+      "relPath": "marketing-skill/skills/page-cro",
       "verified": true,
       "tokenCount": 2610,
       "evalSummary": {
@@ -41849,7 +45685,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.352Z",
+        "evaluatedAt": "2026-05-05T23:45:45.339Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -41904,7 +45740,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.352Z",
+          "evaluatedAt": "2026-05-05T23:45:45.339Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -41922,7 +45758,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.352Z",
+          "evaluatedAt": "2026-05-05T23:45:45.339Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -41986,7 +45822,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.354Z",
+        "evaluatedAt": "2026-05-05T23:45:45.342Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -42041,7 +45877,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.354Z",
+          "evaluatedAt": "2026-05-05T23:45:45.342Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -42059,7 +45895,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.354Z",
+          "evaluatedAt": "2026-05-05T23:45:45.342Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -42072,8 +45908,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/paid-ads",
-      "relPath": ".gemini/skills/paid-ads",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/paid-ads",
+      "relPath": "marketing-skill/skills/paid-ads",
       "verified": true,
       "tokenCount": 3420,
       "evalSummary": {
@@ -42123,7 +45959,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.356Z",
+        "evaluatedAt": "2026-05-05T23:45:45.345Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -42178,7 +46014,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.356Z",
+          "evaluatedAt": "2026-05-05T23:45:45.345Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -42196,7 +46032,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.356Z",
+          "evaluatedAt": "2026-05-05T23:45:45.345Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -42260,7 +46096,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.358Z",
+        "evaluatedAt": "2026-05-05T23:45:45.347Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -42315,7 +46151,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.358Z",
+          "evaluatedAt": "2026-05-05T23:45:45.347Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -42333,7 +46169,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.358Z",
+          "evaluatedAt": "2026-05-05T23:45:45.347Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -42346,8 +46182,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/paywall-upgrade-cro",
-      "relPath": ".gemini/skills/paywall-upgrade-cro",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/paywall-upgrade-cro",
+      "relPath": "marketing-skill/skills/paywall-upgrade-cro",
       "verified": true,
       "tokenCount": 2280,
       "evalSummary": {
@@ -42397,7 +46233,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.360Z",
+        "evaluatedAt": "2026-05-05T23:45:45.349Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -42452,7 +46288,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.360Z",
+          "evaluatedAt": "2026-05-05T23:45:45.349Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -42470,7 +46306,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.360Z",
+          "evaluatedAt": "2026-05-05T23:45:45.349Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -42534,7 +46370,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.362Z",
+        "evaluatedAt": "2026-05-05T23:45:45.350Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42589,7 +46425,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.362Z",
+          "evaluatedAt": "2026-05-05T23:45:45.350Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42607,7 +46443,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.362Z",
+          "evaluatedAt": "2026-05-05T23:45:45.350Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42620,8 +46456,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/performance-profiler",
-      "relPath": ".gemini/skills/performance-profiler",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/performance-profiler",
+      "relPath": "engineering/skills/performance-profiler",
       "verified": true,
       "tokenCount": 1430,
       "evalSummary": {
@@ -42671,7 +46507,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.363Z",
+        "evaluatedAt": "2026-05-05T23:45:45.352Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42726,7 +46562,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.363Z",
+          "evaluatedAt": "2026-05-05T23:45:45.352Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42744,7 +46580,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.363Z",
+          "evaluatedAt": "2026-05-05T23:45:45.352Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42808,7 +46644,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.364Z",
+        "evaluatedAt": "2026-05-05T23:45:45.353Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42863,7 +46699,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.364Z",
+          "evaluatedAt": "2026-05-05T23:45:45.353Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42881,7 +46717,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.364Z",
+          "evaluatedAt": "2026-05-05T23:45:45.354Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42945,7 +46781,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.365Z",
+        "evaluatedAt": "2026-05-05T23:45:45.354Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43000,7 +46836,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.365Z",
+          "evaluatedAt": "2026-05-05T23:45:45.354Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43018,7 +46854,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.365Z",
+          "evaluatedAt": "2026-05-05T23:45:45.354Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43031,12 +46867,12 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro",
-      "relPath": ".codex/skills/playwright-pro",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/pw",
+      "relPath": ".codex/skills/playwright-pro/skills/pw",
       "verified": true,
       "tokenCount": 1357,
       "evalSummary": {
-        "overallScore": 76,
+        "overallScore": 74,
         "grade": "C",
         "categories": [
           {
@@ -43078,11 +46914,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 10,
+            "score": 9,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.365Z",
+        "evaluatedAt": "2026-05-05T23:45:45.355Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43091,7 +46927,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 76,
+          "overallScore": 74,
           "grade": "C",
           "categories": [
             {
@@ -43133,11 +46969,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 10,
+              "score": 9,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.365Z",
+          "evaluatedAt": "2026-05-05T23:45:45.355Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43145,17 +46981,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 69,
-          "grade": "C",
+          "overallScore": 62,
+          "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 9,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.365Z",
+          "evaluatedAt": "2026-05-05T23:45:45.355Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43168,12 +47004,12 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/playwright-pro",
-      "relPath": ".gemini/skills/playwright-pro",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/playwright-pro/skills/pw",
+      "relPath": "engineering-team/playwright-pro/skills/pw",
       "verified": true,
       "tokenCount": 1357,
       "evalSummary": {
-        "overallScore": 76,
+        "overallScore": 74,
         "grade": "C",
         "categories": [
           {
@@ -43215,11 +47051,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 10,
+            "score": 9,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.367Z",
+        "evaluatedAt": "2026-05-05T23:45:45.356Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43228,7 +47064,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 76,
+          "overallScore": 74,
           "grade": "C",
           "categories": [
             {
@@ -43270,11 +47106,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 10,
+              "score": 9,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.367Z",
+          "evaluatedAt": "2026-05-05T23:45:45.356Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43282,17 +47118,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 69,
-          "grade": "C",
+          "overallScore": 62,
+          "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 9,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.367Z",
+          "evaluatedAt": "2026-05-05T23:45:45.356Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43356,7 +47192,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.368Z",
+        "evaluatedAt": "2026-05-05T23:45:45.358Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43411,7 +47247,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.368Z",
+          "evaluatedAt": "2026-05-05T23:45:45.358Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43429,7 +47265,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.368Z",
+          "evaluatedAt": "2026-05-05T23:45:45.358Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43442,13 +47278,13 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/project-management-bundle",
-      "relPath": ".gemini/skills/project-management-bundle",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/pm-skills",
+      "relPath": ".codex/skills/pm-skills",
       "verified": true,
       "tokenCount": 405,
       "evalSummary": {
-        "overallScore": 64,
-        "grade": "D",
+        "overallScore": 66,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
@@ -43489,11 +47325,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
+            "score": 10,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.369Z",
+        "evaluatedAt": "2026-05-05T23:45:45.360Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -43502,8 +47338,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 64,
-          "grade": "D",
+          "overallScore": 66,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
@@ -43544,11 +47380,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.369Z",
+          "evaluatedAt": "2026-05-05T23:45:45.360Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -43556,17 +47392,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 62,
-          "grade": "D",
+          "overallScore": 69,
+          "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 8,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.369Z",
+          "evaluatedAt": "2026-05-05T23:45:45.360Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -43579,13 +47415,13 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:project-management",
-      "relPath": "project-management",
+      "installUrl": "github:alirezarezvani/claude-skills:project-management/skills/pm-skills",
+      "relPath": "project-management/skills/pm-skills",
       "verified": true,
       "tokenCount": 405,
       "evalSummary": {
-        "overallScore": 64,
-        "grade": "D",
+        "overallScore": 66,
+        "grade": "C",
         "categories": [
           {
             "id": "structure",
@@ -43626,11 +47462,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
+            "score": 10,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.370Z",
+        "evaluatedAt": "2026-05-05T23:45:45.360Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -43639,8 +47475,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 64,
-          "grade": "D",
+          "overallScore": 66,
+          "grade": "C",
           "categories": [
             {
               "id": "structure",
@@ -43681,11 +47517,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.370Z",
+          "evaluatedAt": "2026-05-05T23:45:45.360Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -43693,17 +47529,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 62,
-          "grade": "D",
+          "overallScore": 69,
+          "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 8,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.370Z",
+          "evaluatedAt": "2026-05-05T23:45:45.361Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -43767,7 +47603,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.371Z",
+        "evaluatedAt": "2026-05-05T23:45:45.362Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -43822,7 +47658,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.371Z",
+          "evaluatedAt": "2026-05-05T23:45:45.362Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -43840,7 +47676,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.371Z",
+          "evaluatedAt": "2026-05-05T23:45:45.362Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -43853,8 +47689,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/popup-cro",
-      "relPath": ".gemini/skills/popup-cro",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/popup-cro",
+      "relPath": "marketing-skill/skills/popup-cro",
       "verified": true,
       "tokenCount": 2171,
       "evalSummary": {
@@ -43904,7 +47740,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.373Z",
+        "evaluatedAt": "2026-05-05T23:45:45.364Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -43959,7 +47795,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.373Z",
+          "evaluatedAt": "2026-05-05T23:45:45.364Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -43977,8 +47813,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.373Z",
+          "evaluatedAt": "2026-05-05T23:45:45.364Z",
           "evaluatedVersion": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "postmortem",
+      "description": "/em -postmortem — Honest Analysis of What Went Wrong",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/postmortem",
+      "relPath": ".codex/skills/executive-mentor/skills/postmortem",
+      "verified": true,
+      "tokenCount": 2369,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.365Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 70,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.365Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.365Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -44041,7 +48014,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.374Z",
+        "evaluatedAt": "2026-05-05T23:45:45.367Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44096,7 +48069,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.374Z",
+          "evaluatedAt": "2026-05-05T23:45:45.367Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44114,7 +48087,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.374Z",
+          "evaluatedAt": "2026-05-05T23:45:45.367Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "postmortem",
+      "description": "/em -postmortem — Honest Analysis of What Went Wrong",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/executive-mentor/skills/postmortem",
+      "relPath": "c-level-advisor/executive-mentor/skills/postmortem",
+      "verified": true,
+      "tokenCount": 2369,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.369Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 70,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.369Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.369Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44178,7 +48288,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.376Z",
+        "evaluatedAt": "2026-05-05T23:45:45.371Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44233,7 +48343,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.376Z",
+          "evaluatedAt": "2026-05-05T23:45:45.371Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44251,7 +48361,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.376Z",
+          "evaluatedAt": "2026-05-05T23:45:45.371Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44264,8 +48374,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/pr-review-expert",
-      "relPath": ".gemini/skills/pr-review-expert",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/pr-review-expert",
+      "relPath": "engineering/skills/pr-review-expert",
       "verified": true,
       "tokenCount": 3301,
       "evalSummary": {
@@ -44315,7 +48425,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.378Z",
+        "evaluatedAt": "2026-05-05T23:45:45.373Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44370,7 +48480,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.378Z",
+          "evaluatedAt": "2026-05-05T23:45:45.373Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44388,7 +48498,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.378Z",
+          "evaluatedAt": "2026-05-05T23:45:45.373Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44452,7 +48562,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.380Z",
+        "evaluatedAt": "2026-05-05T23:45:45.374Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44507,7 +48617,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.380Z",
+          "evaluatedAt": "2026-05-05T23:45:45.374Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44525,7 +48635,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.380Z",
+          "evaluatedAt": "2026-05-05T23:45:45.374Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44589,7 +48699,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.381Z",
+        "evaluatedAt": "2026-05-05T23:45:45.375Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -44644,7 +48754,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.381Z",
+          "evaluatedAt": "2026-05-05T23:45:45.376Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -44662,7 +48772,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.382Z",
+          "evaluatedAt": "2026-05-05T23:45:45.376Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -44675,8 +48785,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/pricing-strategy",
-      "relPath": ".gemini/skills/pricing-strategy",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/pricing-strategy",
+      "relPath": "marketing-skill/skills/pricing-strategy",
       "verified": true,
       "tokenCount": 4384,
       "evalSummary": {
@@ -44726,7 +48836,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.384Z",
+        "evaluatedAt": "2026-05-05T23:45:45.378Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -44781,7 +48891,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.384Z",
+          "evaluatedAt": "2026-05-05T23:45:45.378Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -44799,7 +48909,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.384Z",
+          "evaluatedAt": "2026-05-05T23:45:45.378Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -44863,7 +48973,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.386Z",
+        "evaluatedAt": "2026-05-05T23:45:45.380Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44918,7 +49028,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.386Z",
+          "evaluatedAt": "2026-05-05T23:45:45.380Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44936,7 +49046,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.386Z",
+          "evaluatedAt": "2026-05-05T23:45:45.380Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45000,7 +49110,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.387Z",
+        "evaluatedAt": "2026-05-05T23:45:45.381Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45055,7 +49165,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.387Z",
+          "evaluatedAt": "2026-05-05T23:45:45.381Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45073,7 +49183,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.387Z",
+          "evaluatedAt": "2026-05-05T23:45:45.381Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45086,8 +49196,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-analytics",
-      "relPath": ".gemini/skills/product-analytics",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/product-analytics",
+      "relPath": "product-team/skills/product-analytics",
       "verified": true,
       "tokenCount": 1336,
       "evalSummary": {
@@ -45137,7 +49247,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.388Z",
+        "evaluatedAt": "2026-05-05T23:45:45.382Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45192,7 +49302,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.389Z",
+          "evaluatedAt": "2026-05-05T23:45:45.382Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45210,7 +49320,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.389Z",
+          "evaluatedAt": "2026-05-05T23:45:45.382Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45274,7 +49384,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.392Z",
+        "evaluatedAt": "2026-05-05T23:45:45.383Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45329,7 +49439,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.392Z",
+          "evaluatedAt": "2026-05-05T23:45:45.383Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45347,7 +49457,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.392Z",
+          "evaluatedAt": "2026-05-05T23:45:45.383Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45360,8 +49470,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-discovery",
-      "relPath": ".gemini/skills/product-discovery",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/product-discovery",
+      "relPath": "product-team/skills/product-discovery",
       "verified": true,
       "tokenCount": 829,
       "evalSummary": {
@@ -45411,7 +49521,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.393Z",
+        "evaluatedAt": "2026-05-05T23:45:45.384Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45466,7 +49576,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.393Z",
+          "evaluatedAt": "2026-05-05T23:45:45.384Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45484,7 +49594,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.393Z",
+          "evaluatedAt": "2026-05-05T23:45:45.384Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45548,7 +49658,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.394Z",
+        "evaluatedAt": "2026-05-05T23:45:45.385Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45603,7 +49713,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.394Z",
+          "evaluatedAt": "2026-05-05T23:45:45.386Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45621,7 +49731,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.394Z",
+          "evaluatedAt": "2026-05-05T23:45:45.386Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45634,8 +49744,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-manager-toolkit",
-      "relPath": ".gemini/skills/product-manager-toolkit",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/product-manager-toolkit",
+      "relPath": "product-team/skills/product-manager-toolkit",
       "verified": true,
       "tokenCount": 2435,
       "evalSummary": {
@@ -45685,7 +49795,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.396Z",
+        "evaluatedAt": "2026-05-05T23:45:45.387Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45740,7 +49850,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.396Z",
+          "evaluatedAt": "2026-05-05T23:45:45.387Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45758,7 +49868,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.396Z",
+          "evaluatedAt": "2026-05-05T23:45:45.387Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45771,12 +49881,12 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-bundle",
-      "relPath": ".gemini/skills/product-bundle",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/product-skills",
+      "relPath": ".codex/skills/product-skills",
       "verified": true,
       "tokenCount": 465,
       "evalSummary": {
-        "overallScore": 69,
+        "overallScore": 70,
         "grade": "C",
         "categories": [
           {
@@ -45818,11 +49928,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
+            "score": 10,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.397Z",
+        "evaluatedAt": "2026-05-05T23:45:45.389Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -45831,7 +49941,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 69,
+          "overallScore": 70,
           "grade": "C",
           "categories": [
             {
@@ -45873,11 +49983,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.397Z",
+          "evaluatedAt": "2026-05-05T23:45:45.389Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -45885,17 +49995,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 54,
+          "overallScore": 62,
           "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 7,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.397Z",
+          "evaluatedAt": "2026-05-05T23:45:45.389Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -45908,12 +50018,12 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-team-bundle",
-      "relPath": ".gemini/skills/product-team-bundle",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/product-skills",
+      "relPath": "product-team/skills/product-skills",
       "verified": true,
       "tokenCount": 465,
       "evalSummary": {
-        "overallScore": 69,
+        "overallScore": 70,
         "grade": "C",
         "categories": [
           {
@@ -45955,148 +50065,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:32.398Z",
-        "evaluatedVersion": "1.1.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 69,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 8,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 2,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 3,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 9,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:32.398Z",
-          "evaluatedVersion": "1.1.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 54,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 7,
-              "max": 13
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:32.398Z",
-          "evaluatedVersion": "1.1.0"
-        }
-      }
-    },
-    {
-      "name": "product-skills",
-      "description": "10 product agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. PM toolkit (RICE), agile PO, product strategist (OKR), UX researcher, UI design system, competitive teardown, landing page generator, SaaS scaffolder, research summarizer. Python tools (stdlib-only).",
-      "version": "1.1.0",
-      "license": "MIT",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:product-team",
-      "relPath": "product-team",
-      "verified": true,
-      "tokenCount": 465,
-      "evalSummary": {
-        "overallScore": 69,
-        "grade": "C",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
             "score": 10,
             "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 8,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 2,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 3,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.399Z",
+        "evaluatedAt": "2026-05-05T23:45:45.389Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -46105,7 +50078,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 69,
+          "overallScore": 70,
           "grade": "C",
           "categories": [
             {
@@ -46147,11 +50120,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.399Z",
+          "evaluatedAt": "2026-05-05T23:45:45.389Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -46159,17 +50132,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 54,
+          "overallScore": 62,
           "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 7,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.399Z",
+          "evaluatedAt": "2026-05-05T23:45:45.389Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -46233,7 +50206,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.400Z",
+        "evaluatedAt": "2026-05-05T23:45:45.390Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46288,7 +50261,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.400Z",
+          "evaluatedAt": "2026-05-05T23:45:45.390Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46306,7 +50279,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.400Z",
+          "evaluatedAt": "2026-05-05T23:45:45.390Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46319,8 +50292,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/product-strategist",
-      "relPath": ".gemini/skills/product-strategist",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/product-strategist",
+      "relPath": "product-team/skills/product-strategist",
       "verified": true,
       "tokenCount": 1930,
       "evalSummary": {
@@ -46370,7 +50343,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.402Z",
+        "evaluatedAt": "2026-05-05T23:45:45.392Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46425,7 +50398,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.402Z",
+          "evaluatedAt": "2026-05-05T23:45:45.392Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46443,7 +50416,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.402Z",
+          "evaluatedAt": "2026-05-05T23:45:45.392Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46507,7 +50480,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.404Z",
+        "evaluatedAt": "2026-05-05T23:45:45.393Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -46562,7 +50535,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.404Z",
+          "evaluatedAt": "2026-05-05T23:45:45.394Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -46580,7 +50553,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.404Z",
+          "evaluatedAt": "2026-05-05T23:45:45.394Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -46593,8 +50566,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/programmatic-seo",
-      "relPath": ".gemini/skills/programmatic-seo",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/programmatic-seo",
+      "relPath": "marketing-skill/skills/programmatic-seo",
       "verified": true,
       "tokenCount": 2913,
       "evalSummary": {
@@ -46644,7 +50617,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.406Z",
+        "evaluatedAt": "2026-05-05T23:45:45.396Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -46699,7 +50672,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.406Z",
+          "evaluatedAt": "2026-05-05T23:45:45.396Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -46717,7 +50690,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.406Z",
+          "evaluatedAt": "2026-05-05T23:45:45.396Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -46781,7 +50754,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.407Z",
+        "evaluatedAt": "2026-05-05T23:45:45.397Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46836,7 +50809,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.407Z",
+          "evaluatedAt": "2026-05-05T23:45:45.397Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46854,7 +50827,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.407Z",
+          "evaluatedAt": "2026-05-05T23:45:45.397Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46918,7 +50891,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.408Z",
+        "evaluatedAt": "2026-05-05T23:45:45.398Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46973,7 +50946,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.408Z",
+          "evaluatedAt": "2026-05-05T23:45:45.398Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46991,7 +50964,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.408Z",
+          "evaluatedAt": "2026-05-05T23:45:45.398Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47055,7 +51028,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.409Z",
+        "evaluatedAt": "2026-05-05T23:45:45.399Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47110,7 +51083,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.409Z",
+          "evaluatedAt": "2026-05-05T23:45:45.399Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47128,7 +51101,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.409Z",
+          "evaluatedAt": "2026-05-05T23:45:45.399Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "promote",
+      "description": "Graduate a proven pattern from auto-memory (MEMORY.md) to CLAUDE.md or .claude/rules/ for permanent enforcement.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/self-improving-agent/skills/promote",
+      "relPath": "engineering-team/self-improving-agent/skills/promote",
+      "verified": true,
+      "tokenCount": 1300,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.400Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 80,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.400Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.400Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47192,7 +51302,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.410Z",
+        "evaluatedAt": "2026-05-05T23:45:45.401Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -47247,7 +51357,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.410Z",
+          "evaluatedAt": "2026-05-05T23:45:45.401Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -47265,7 +51375,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.410Z",
+          "evaluatedAt": "2026-05-05T23:45:45.401Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -47278,8 +51388,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/prompt-engineer-toolkit",
-      "relPath": ".gemini/skills/prompt-engineer-toolkit",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/prompt-engineer-toolkit",
+      "relPath": "marketing-skill/skills/prompt-engineer-toolkit",
       "verified": true,
       "tokenCount": 1273,
       "evalSummary": {
@@ -47329,7 +51439,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.412Z",
+        "evaluatedAt": "2026-05-05T23:45:45.402Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -47384,7 +51494,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.412Z",
+          "evaluatedAt": "2026-05-05T23:45:45.402Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -47402,7 +51512,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.412Z",
+          "evaluatedAt": "2026-05-05T23:45:45.402Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -47415,8 +51525,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/prompt-governance",
-      "relPath": ".codex/skills/prompt-governance",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/prompt-governance/skills/prompt-governance",
+      "relPath": ".codex/skills/prompt-governance/skills/prompt-governance",
       "verified": true,
       "tokenCount": 3267,
       "evalSummary": {
@@ -47466,7 +51576,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.413Z",
+        "evaluatedAt": "2026-05-05T23:45:45.404Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47521,7 +51631,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.413Z",
+          "evaluatedAt": "2026-05-05T23:45:45.404Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47539,7 +51649,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.413Z",
+          "evaluatedAt": "2026-05-05T23:45:45.404Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47552,8 +51662,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/prompt-governance",
-      "relPath": ".gemini/skills/prompt-governance",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/prompt-governance/skills/prompt-governance",
+      "relPath": "engineering/prompt-governance/skills/prompt-governance",
       "verified": true,
       "tokenCount": 3267,
       "evalSummary": {
@@ -47603,7 +51713,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.415Z",
+        "evaluatedAt": "2026-05-05T23:45:45.406Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47658,7 +51768,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.415Z",
+          "evaluatedAt": "2026-05-05T23:45:45.406Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47676,7 +51786,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.416Z",
+          "evaluatedAt": "2026-05-05T23:45:45.406Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47740,7 +51850,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.417Z",
+        "evaluatedAt": "2026-05-05T23:45:45.408Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47795,7 +51905,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.417Z",
+          "evaluatedAt": "2026-05-05T23:45:45.408Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47813,7 +51923,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.417Z",
+          "evaluatedAt": "2026-05-05T23:45:45.408Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47826,8 +51936,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/qms-audit-expert",
-      "relPath": ".gemini/skills/qms-audit-expert",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/qms-audit-expert",
+      "relPath": "ra-qm-team/skills/qms-audit-expert",
       "verified": true,
       "tokenCount": 2583,
       "evalSummary": {
@@ -47877,7 +51987,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.419Z",
+        "evaluatedAt": "2026-05-05T23:45:45.410Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47932,7 +52042,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.420Z",
+          "evaluatedAt": "2026-05-05T23:45:45.410Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47950,7 +52060,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.420Z",
+          "evaluatedAt": "2026-05-05T23:45:45.410Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48014,7 +52124,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.422Z",
+        "evaluatedAt": "2026-05-05T23:45:45.412Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48069,7 +52179,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.422Z",
+          "evaluatedAt": "2026-05-05T23:45:45.412Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48087,7 +52197,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.422Z",
+          "evaluatedAt": "2026-05-05T23:45:45.412Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48100,8 +52210,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/quality-documentation-manager",
-      "relPath": ".gemini/skills/quality-documentation-manager",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/quality-documentation-manager",
+      "relPath": "ra-qm-team/skills/quality-documentation-manager",
       "verified": true,
       "tokenCount": 3844,
       "evalSummary": {
@@ -48151,7 +52261,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.424Z",
+        "evaluatedAt": "2026-05-05T23:45:45.414Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48206,7 +52316,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.424Z",
+          "evaluatedAt": "2026-05-05T23:45:45.414Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48224,7 +52334,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.424Z",
+          "evaluatedAt": "2026-05-05T23:45:45.414Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48288,7 +52398,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.427Z",
+        "evaluatedAt": "2026-05-05T23:45:45.417Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48343,7 +52453,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.427Z",
+          "evaluatedAt": "2026-05-05T23:45:45.417Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48361,7 +52471,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.427Z",
+          "evaluatedAt": "2026-05-05T23:45:45.417Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48374,8 +52484,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/quality-manager-qmr",
-      "relPath": ".gemini/skills/quality-manager-qmr",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/quality-manager-qmr",
+      "relPath": "ra-qm-team/skills/quality-manager-qmr",
       "verified": true,
       "tokenCount": 5042,
       "evalSummary": {
@@ -48425,7 +52535,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.431Z",
+        "evaluatedAt": "2026-05-05T23:45:45.420Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48480,7 +52590,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.431Z",
+          "evaluatedAt": "2026-05-05T23:45:45.420Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48498,7 +52608,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.431Z",
+          "evaluatedAt": "2026-05-05T23:45:45.420Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48562,7 +52672,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.434Z",
+        "evaluatedAt": "2026-05-05T23:45:45.423Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48617,7 +52727,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.434Z",
+          "evaluatedAt": "2026-05-05T23:45:45.423Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48635,7 +52745,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.434Z",
+          "evaluatedAt": "2026-05-05T23:45:45.423Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48648,8 +52758,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/quality-manager-qms-iso13485",
-      "relPath": ".gemini/skills/quality-manager-qms-iso13485",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/quality-manager-qms-iso13485",
+      "relPath": "ra-qm-team/skills/quality-manager-qms-iso13485",
       "verified": true,
       "tokenCount": 4728,
       "evalSummary": {
@@ -48699,7 +52809,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.437Z",
+        "evaluatedAt": "2026-05-05T23:45:45.425Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48754,7 +52864,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.437Z",
+          "evaluatedAt": "2026-05-05T23:45:45.425Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48772,7 +52882,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.437Z",
+          "evaluatedAt": "2026-05-05T23:45:45.425Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48785,12 +52895,12 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ra-qm-team-bundle",
-      "relPath": ".gemini/skills/ra-qm-team-bundle",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/ra-qm-skills",
+      "relPath": ".codex/skills/ra-qm-skills",
       "verified": true,
       "tokenCount": 556,
       "evalSummary": {
-        "overallScore": 67,
+        "overallScore": 69,
         "grade": "C",
         "categories": [
           {
@@ -48832,11 +52942,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
+            "score": 10,
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.439Z",
+        "evaluatedAt": "2026-05-05T23:45:45.427Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -48845,7 +52955,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 67,
+          "overallScore": 69,
           "grade": "C",
           "categories": [
             {
@@ -48887,11 +52997,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.439Z",
+          "evaluatedAt": "2026-05-05T23:45:45.427Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -48899,17 +53009,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 54,
+          "overallScore": 62,
           "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 7,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.439Z",
+          "evaluatedAt": "2026-05-05T23:45:45.427Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -48922,12 +53032,12 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ra-qm-team-main",
-      "relPath": ".gemini/skills/ra-qm-team-main",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/ra-qm-skills",
+      "relPath": "ra-qm-team/skills/ra-qm-skills",
       "verified": true,
       "tokenCount": 556,
       "evalSummary": {
-        "overallScore": 67,
+        "overallScore": 69,
         "grade": "C",
         "categories": [
           {
@@ -48969,148 +53079,11 @@
           {
             "id": "naming",
             "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:32.440Z",
-        "evaluatedVersion": "1.0.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 67,
-          "grade": "C",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 8,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 3,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 1,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 9,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:32.440Z",
-          "evaluatedVersion": "1.0.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 54,
-          "grade": "D",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 7,
-              "max": 13
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:32.440Z",
-          "evaluatedVersion": "1.0.0"
-        }
-      }
-    },
-    {
-      "name": "ra-qm-skills",
-      "description": "12 regulatory & QM agent skills and plugins for Claude Code, Codex, Gemini CLI, Cursor, OpenClaw. ISO 13485 QMS, MDR 2017/745, FDA 510(k)/PMA, ISO 27001 ISMS, GDPR/DSGVO, risk management (ISO 14971), CAPA, document control, auditing. Python tools (stdlib-only).",
-      "version": "1.0.0",
-      "license": "MIT",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team",
-      "relPath": "ra-qm-team",
-      "verified": true,
-      "tokenCount": 556,
-      "evalSummary": {
-        "overallScore": 67,
-        "grade": "C",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
             "score": 10,
             "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 8,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 3,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 1,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 9,
-            "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.441Z",
+        "evaluatedAt": "2026-05-05T23:45:45.428Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -49119,7 +53092,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 67,
+          "overallScore": 69,
           "grade": "C",
           "categories": [
             {
@@ -49161,11 +53134,11 @@
             {
               "id": "naming",
               "name": "Naming & conventions",
-              "score": 9,
+              "score": 10,
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.441Z",
+          "evaluatedAt": "2026-05-05T23:45:45.428Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -49173,17 +53146,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 54,
+          "overallScore": 62,
           "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 7,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.441Z",
+          "evaluatedAt": "2026-05-05T23:45:45.428Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -49247,7 +53220,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.442Z",
+        "evaluatedAt": "2026-05-05T23:45:45.430Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49302,7 +53275,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.442Z",
+          "evaluatedAt": "2026-05-05T23:45:45.430Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49320,7 +53293,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.442Z",
+          "evaluatedAt": "2026-05-05T23:45:45.430Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49333,8 +53306,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/rag-architect",
-      "relPath": ".gemini/skills/rag-architect",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/rag-architect",
+      "relPath": "engineering/skills/rag-architect",
       "verified": true,
       "tokenCount": 3691,
       "evalSummary": {
@@ -49384,7 +53357,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.445Z",
+        "evaluatedAt": "2026-05-05T23:45:45.432Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49439,7 +53412,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.445Z",
+          "evaluatedAt": "2026-05-05T23:45:45.432Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49457,7 +53430,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.445Z",
+          "evaluatedAt": "2026-05-05T23:45:45.432Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49521,7 +53494,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.447Z",
+        "evaluatedAt": "2026-05-05T23:45:45.435Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49576,7 +53549,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.447Z",
+          "evaluatedAt": "2026-05-05T23:45:45.435Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49594,7 +53567,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.447Z",
+          "evaluatedAt": "2026-05-05T23:45:45.435Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49607,8 +53580,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/red-team",
-      "relPath": ".gemini/skills/red-team",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/red-team",
+      "relPath": "engineering-team/skills/red-team",
       "verified": true,
       "tokenCount": 4247,
       "evalSummary": {
@@ -49658,7 +53631,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.450Z",
+        "evaluatedAt": "2026-05-05T23:45:45.438Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49713,7 +53686,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.450Z",
+          "evaluatedAt": "2026-05-05T23:45:45.438Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49731,7 +53704,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.450Z",
+          "evaluatedAt": "2026-05-05T23:45:45.438Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49795,7 +53768,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.453Z",
+        "evaluatedAt": "2026-05-05T23:45:45.440Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -49850,7 +53823,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.453Z",
+          "evaluatedAt": "2026-05-05T23:45:45.440Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -49868,7 +53841,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.453Z",
+          "evaluatedAt": "2026-05-05T23:45:45.440Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -49881,8 +53854,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/referral-program",
-      "relPath": ".gemini/skills/referral-program",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/referral-program",
+      "relPath": "marketing-skill/skills/referral-program",
       "verified": true,
       "tokenCount": 4091,
       "evalSummary": {
@@ -49932,7 +53905,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.455Z",
+        "evaluatedAt": "2026-05-05T23:45:45.443Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -49987,7 +53960,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.455Z",
+          "evaluatedAt": "2026-05-05T23:45:45.443Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -50005,7 +53978,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.455Z",
+          "evaluatedAt": "2026-05-05T23:45:45.443Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -50069,7 +54042,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.458Z",
+        "evaluatedAt": "2026-05-05T23:45:45.446Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50124,7 +54097,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.458Z",
+          "evaluatedAt": "2026-05-05T23:45:45.446Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50142,7 +54115,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.458Z",
+          "evaluatedAt": "2026-05-05T23:45:45.446Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50155,8 +54128,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/regulatory-affairs-head",
-      "relPath": ".gemini/skills/regulatory-affairs-head",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/regulatory-affairs-head",
+      "relPath": "ra-qm-team/skills/regulatory-affairs-head",
       "verified": true,
       "tokenCount": 5864,
       "evalSummary": {
@@ -50206,7 +54179,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.461Z",
+        "evaluatedAt": "2026-05-05T23:45:45.449Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50261,7 +54234,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.461Z",
+          "evaluatedAt": "2026-05-05T23:45:45.449Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50279,7 +54252,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.461Z",
+          "evaluatedAt": "2026-05-05T23:45:45.449Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50343,7 +54316,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.464Z",
+        "evaluatedAt": "2026-05-05T23:45:45.452Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50398,7 +54371,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.464Z",
+          "evaluatedAt": "2026-05-05T23:45:45.452Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50416,7 +54389,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.464Z",
+          "evaluatedAt": "2026-05-05T23:45:45.452Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50429,8 +54402,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/release-manager",
-      "relPath": ".gemini/skills/release-manager",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/release-manager",
+      "relPath": "engineering/skills/release-manager",
       "verified": true,
       "tokenCount": 4071,
       "evalSummary": {
@@ -50480,7 +54453,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.467Z",
+        "evaluatedAt": "2026-05-05T23:45:45.455Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50535,7 +54508,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.467Z",
+          "evaluatedAt": "2026-05-05T23:45:45.455Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50553,7 +54526,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.467Z",
+          "evaluatedAt": "2026-05-05T23:45:45.455Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50617,7 +54590,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.468Z",
+        "evaluatedAt": "2026-05-05T23:45:45.457Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50672,7 +54645,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.469Z",
+          "evaluatedAt": "2026-05-05T23:45:45.457Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50690,7 +54663,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.469Z",
+          "evaluatedAt": "2026-05-05T23:45:45.457Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50754,7 +54727,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.469Z",
+        "evaluatedAt": "2026-05-05T23:45:45.457Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50809,7 +54782,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.469Z",
+          "evaluatedAt": "2026-05-05T23:45:45.457Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50827,7 +54800,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.469Z",
+          "evaluatedAt": "2026-05-05T23:45:45.457Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "remember",
+      "description": "Explicitly save important knowledge to auto-memory with timestamp and context. Use when a discovery is too important to rely on auto-capture.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/self-improving-agent/skills/remember",
+      "relPath": "engineering-team/self-improving-agent/skills/remember",
+      "verified": true,
+      "tokenCount": 922,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.458Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 80,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.458Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.458Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "report",
+      "description": "Generate test report. Use when user says \"test report\", \"results summary\", \"test status\", \"show results\", \"test dashboard\", or \"how did tests go\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/report",
+      "relPath": ".codex/skills/playwright-pro/skills/report",
+      "verified": true,
+      "tokenCount": 844,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.459Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 73,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.459Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.459Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50891,7 +55138,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.470Z",
+        "evaluatedAt": "2026-05-05T23:45:45.460Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50946,7 +55193,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.470Z",
+          "evaluatedAt": "2026-05-05T23:45:45.460Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50964,7 +55211,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.470Z",
+          "evaluatedAt": "2026-05-05T23:45:45.460Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "report",
+      "description": "Generate test report. Use when user says \"test report\", \"results summary\", \"test status\", \"show results\", \"test dashboard\", or \"how did tests go\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/playwright-pro/skills/report",
+      "relPath": "engineering-team/playwright-pro/skills/report",
+      "verified": true,
+      "tokenCount": 844,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.461Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 73,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.461Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.461Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50977,8 +55361,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/research-summarizer",
-      "relPath": ".codex/skills/research-summarizer",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/research-summarizer/skills/research-summarizer",
+      "relPath": ".codex/skills/research-summarizer/skills/research-summarizer",
       "verified": true,
       "tokenCount": 2634,
       "evalSummary": {
@@ -51028,7 +55412,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.471Z",
+        "evaluatedAt": "2026-05-05T23:45:45.462Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -51083,7 +55467,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.472Z",
+          "evaluatedAt": "2026-05-05T23:45:45.462Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -51101,7 +55485,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.472Z",
+          "evaluatedAt": "2026-05-05T23:45:45.462Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -51114,8 +55498,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/research-summarizer",
-      "relPath": ".gemini/skills/research-summarizer",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/research-summarizer/skills/research-summarizer",
+      "relPath": "product-team/research-summarizer/skills/research-summarizer",
       "verified": true,
       "tokenCount": 2634,
       "evalSummary": {
@@ -51165,7 +55549,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.473Z",
+        "evaluatedAt": "2026-05-05T23:45:45.464Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -51220,7 +55604,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.473Z",
+          "evaluatedAt": "2026-05-05T23:45:45.464Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -51238,8 +55622,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.473Z",
+          "evaluatedAt": "2026-05-05T23:45:45.464Z",
           "evaluatedVersion": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "resume",
+      "description": "Resume a paused experiment. Checkout the experiment branch, read results history, continue iterating.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/resume",
+      "relPath": ".codex/skills/autoresearch-agent/skills/resume",
+      "verified": true,
+      "tokenCount": 573,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.465Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 53,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.465Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.465Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -51302,7 +55823,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.475Z",
+        "evaluatedAt": "2026-05-05T23:45:45.466Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51357,7 +55878,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.475Z",
+          "evaluatedAt": "2026-05-05T23:45:45.466Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51375,7 +55896,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.475Z",
+          "evaluatedAt": "2026-05-05T23:45:45.466Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "resume",
+      "description": "Resume a paused experiment. Checkout the experiment branch, read results history, continue iterating.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/autoresearch-agent/skills/resume",
+      "relPath": "engineering/autoresearch-agent/skills/resume",
+      "verified": true,
+      "tokenCount": 573,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.467Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 53,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.467Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.467Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51439,7 +56097,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.475Z",
+        "evaluatedAt": "2026-05-05T23:45:45.468Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51494,7 +56152,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.475Z",
+          "evaluatedAt": "2026-05-05T23:45:45.468Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51512,7 +56170,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.475Z",
+          "evaluatedAt": "2026-05-05T23:45:45.468Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51576,7 +56234,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.476Z",
+        "evaluatedAt": "2026-05-05T23:45:45.469Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51631,7 +56289,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.476Z",
+          "evaluatedAt": "2026-05-05T23:45:45.469Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51649,7 +56307,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.476Z",
+          "evaluatedAt": "2026-05-05T23:45:45.469Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51662,8 +56320,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/revenue-operations",
-      "relPath": ".gemini/skills/revenue-operations",
+      "installUrl": "github:alirezarezvani/claude-skills:business-growth/skills/revenue-operations",
+      "relPath": "business-growth/skills/revenue-operations",
       "verified": true,
       "tokenCount": 2362,
       "evalSummary": {
@@ -51713,7 +56371,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.478Z",
+        "evaluatedAt": "2026-05-05T23:45:45.470Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51768,7 +56426,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.478Z",
+          "evaluatedAt": "2026-05-05T23:45:45.471Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51786,7 +56444,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.478Z",
+          "evaluatedAt": "2026-05-05T23:45:45.471Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "review",
+      "description": "Review Playwright tests for quality. Use when user says \"review tests\", \"check test quality\", \"audit tests\", \"improve tests\", \"test code review\", or \"playwright best practices check\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/review",
+      "relPath": ".codex/skills/playwright-pro/skills/review",
+      "verified": true,
+      "tokenCount": 852,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.472Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 76,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.472Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.472Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51850,7 +56645,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.479Z",
+        "evaluatedAt": "2026-05-05T23:45:45.473Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51905,7 +56700,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.479Z",
+          "evaluatedAt": "2026-05-05T23:45:45.473Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51923,7 +56718,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.479Z",
+          "evaluatedAt": "2026-05-05T23:45:45.473Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51987,7 +56782,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.480Z",
+        "evaluatedAt": "2026-05-05T23:45:45.474Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52042,7 +56837,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.480Z",
+          "evaluatedAt": "2026-05-05T23:45:45.474Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52060,7 +56855,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.480Z",
+          "evaluatedAt": "2026-05-05T23:45:45.474Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52124,7 +56919,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.481Z",
+        "evaluatedAt": "2026-05-05T23:45:45.475Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52179,7 +56974,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.481Z",
+          "evaluatedAt": "2026-05-05T23:45:45.475Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52197,7 +56992,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.481Z",
+          "evaluatedAt": "2026-05-05T23:45:45.475Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "review",
+      "description": "Review Playwright tests for quality. Use when user says \"review tests\", \"check test quality\", \"audit tests\", \"improve tests\", \"test code review\", or \"playwright best practices check\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/playwright-pro/skills/review",
+      "relPath": "engineering-team/playwright-pro/skills/review",
+      "verified": true,
+      "tokenCount": 852,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.476Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 76,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.476Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.476Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "review",
+      "description": "Analyze auto-memory for promotion candidates, stale entries, consolidation opportunities, and health metrics.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/self-improving-agent/skills/review",
+      "relPath": "engineering-team/self-improving-agent/skills/review",
+      "verified": true,
+      "tokenCount": 1161,
+      "evalSummary": {
+        "overallScore": 67,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.477Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 67,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.477Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.477Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52261,7 +57330,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.482Z",
+        "evaluatedAt": "2026-05-05T23:45:45.478Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52316,7 +57385,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.482Z",
+          "evaluatedAt": "2026-05-05T23:45:45.478Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52334,7 +57403,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.482Z",
+          "evaluatedAt": "2026-05-05T23:45:45.478Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52398,7 +57467,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.483Z",
+        "evaluatedAt": "2026-05-05T23:45:45.479Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52453,7 +57522,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.483Z",
+          "evaluatedAt": "2026-05-05T23:45:45.479Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52471,7 +57540,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.483Z",
+          "evaluatedAt": "2026-05-05T23:45:45.479Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52484,8 +57553,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/risk-management-specialist",
-      "relPath": ".gemini/skills/risk-management-specialist",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/risk-management-specialist",
+      "relPath": "ra-qm-team/skills/risk-management-specialist",
       "verified": true,
       "tokenCount": 4612,
       "evalSummary": {
@@ -52535,7 +57604,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.485Z",
+        "evaluatedAt": "2026-05-05T23:45:45.482Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52590,7 +57659,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.485Z",
+          "evaluatedAt": "2026-05-05T23:45:45.482Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52608,7 +57677,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.486Z",
+          "evaluatedAt": "2026-05-05T23:45:45.482Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52672,7 +57741,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.487Z",
+        "evaluatedAt": "2026-05-05T23:45:45.484Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52727,7 +57796,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.487Z",
+          "evaluatedAt": "2026-05-05T23:45:45.484Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52745,7 +57814,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.487Z",
+          "evaluatedAt": "2026-05-05T23:45:45.484Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52758,8 +57827,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/roadmap-communicator",
-      "relPath": ".gemini/skills/roadmap-communicator",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/roadmap-communicator",
+      "relPath": "product-team/skills/roadmap-communicator",
       "verified": true,
       "tokenCount": 666,
       "evalSummary": {
@@ -52809,7 +57878,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.488Z",
+        "evaluatedAt": "2026-05-05T23:45:45.485Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52864,7 +57933,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.488Z",
+          "evaluatedAt": "2026-05-05T23:45:45.485Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52882,7 +57951,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.488Z",
+          "evaluatedAt": "2026-05-05T23:45:45.485Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "run",
+      "description": "One-shot lifecycle command that chains init → baseline → spawn → eval → merge in a single invocation.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/run",
+      "relPath": ".codex/skills/agenthub/skills/run",
+      "verified": true,
+      "tokenCount": 1035,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.486Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 70,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.486Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.486Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "run",
+      "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/run",
+      "relPath": ".codex/skills/autoresearch-agent/skills/run",
+      "verified": true,
+      "tokenCount": 649,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.487Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 66,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.487Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.487Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52946,7 +58289,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.489Z",
+        "evaluatedAt": "2026-05-05T23:45:45.488Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53001,7 +58344,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.489Z",
+          "evaluatedAt": "2026-05-05T23:45:45.488Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53019,7 +58362,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.489Z",
+          "evaluatedAt": "2026-05-05T23:45:45.488Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53083,7 +58426,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.490Z",
+        "evaluatedAt": "2026-05-05T23:45:45.489Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53138,7 +58481,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.490Z",
+          "evaluatedAt": "2026-05-05T23:45:45.489Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53156,7 +58499,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.490Z",
+          "evaluatedAt": "2026-05-05T23:45:45.489Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "run",
+      "description": "One-shot lifecycle command that chains init → baseline → spawn → eval → merge in a single invocation.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/agenthub/skills/run",
+      "relPath": "engineering/agenthub/skills/run",
+      "verified": true,
+      "tokenCount": 1035,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.490Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 70,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.490Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.490Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "run",
+      "description": "Run a single experiment iteration. Edit the target file, evaluate, keep or discard.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/autoresearch-agent/skills/run",
+      "relPath": "engineering/autoresearch-agent/skills/run",
+      "verified": true,
+      "tokenCount": 649,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.491Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 66,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.491Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.491Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53220,7 +58837,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.490Z",
+        "evaluatedAt": "2026-05-05T23:45:45.491Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53275,7 +58892,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.490Z",
+          "evaluatedAt": "2026-05-05T23:45:45.491Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53293,7 +58910,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.490Z",
+          "evaluatedAt": "2026-05-05T23:45:45.491Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53306,8 +58923,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/runbook-generator",
-      "relPath": ".gemini/skills/runbook-generator",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/runbook-generator",
+      "relPath": "engineering/skills/runbook-generator",
       "verified": true,
       "tokenCount": 431,
       "evalSummary": {
@@ -53357,7 +58974,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.491Z",
+        "evaluatedAt": "2026-05-05T23:45:45.492Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53412,7 +59029,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.491Z",
+          "evaluatedAt": "2026-05-05T23:45:45.492Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53430,7 +59047,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.491Z",
+          "evaluatedAt": "2026-05-05T23:45:45.492Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53494,7 +59111,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.491Z",
+        "evaluatedAt": "2026-05-05T23:45:45.493Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53549,7 +59166,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.491Z",
+          "evaluatedAt": "2026-05-05T23:45:45.493Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53567,7 +59184,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.491Z",
+          "evaluatedAt": "2026-05-05T23:45:45.493Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53631,7 +59248,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.492Z",
+        "evaluatedAt": "2026-05-05T23:45:45.494Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -53686,7 +59303,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.492Z",
+          "evaluatedAt": "2026-05-05T23:45:45.494Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -53704,7 +59321,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.492Z",
+          "evaluatedAt": "2026-05-05T23:45:45.494Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -53717,8 +59334,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/saas-metrics-coach",
-      "relPath": ".gemini/skills/saas-metrics-coach",
+      "installUrl": "github:alirezarezvani/claude-skills:finance/skills/saas-metrics-coach",
+      "relPath": "finance/skills/saas-metrics-coach",
       "verified": true,
       "tokenCount": 1563,
       "evalSummary": {
@@ -53768,7 +59385,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.493Z",
+        "evaluatedAt": "2026-05-05T23:45:45.496Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -53823,7 +59440,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.494Z",
+          "evaluatedAt": "2026-05-05T23:45:45.496Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -53841,7 +59458,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.494Z",
+          "evaluatedAt": "2026-05-05T23:45:45.496Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -53905,7 +59522,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.495Z",
+        "evaluatedAt": "2026-05-05T23:45:45.497Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53960,7 +59577,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.495Z",
+          "evaluatedAt": "2026-05-05T23:45:45.497Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53978,7 +59595,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.495Z",
+          "evaluatedAt": "2026-05-05T23:45:45.497Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53991,8 +59608,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/saas-scaffolder",
-      "relPath": ".gemini/skills/saas-scaffolder",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/saas-scaffolder",
+      "relPath": "product-team/skills/saas-scaffolder",
       "verified": true,
       "tokenCount": 2684,
       "evalSummary": {
@@ -54042,7 +59659,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.497Z",
+        "evaluatedAt": "2026-05-05T23:45:45.499Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54097,7 +59714,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.497Z",
+          "evaluatedAt": "2026-05-05T23:45:45.499Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54115,7 +59732,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.497Z",
+          "evaluatedAt": "2026-05-05T23:45:45.499Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54179,7 +59796,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.498Z",
+        "evaluatedAt": "2026-05-05T23:45:45.501Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54234,7 +59851,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.498Z",
+          "evaluatedAt": "2026-05-05T23:45:45.501Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54252,7 +59869,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.498Z",
+          "evaluatedAt": "2026-05-05T23:45:45.501Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54265,8 +59882,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/sales-engineer",
-      "relPath": ".gemini/skills/sales-engineer",
+      "installUrl": "github:alirezarezvani/claude-skills:business-growth/skills/sales-engineer",
+      "relPath": "business-growth/skills/sales-engineer",
       "verified": true,
       "tokenCount": 2054,
       "evalSummary": {
@@ -54316,7 +59933,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.500Z",
+        "evaluatedAt": "2026-05-05T23:45:45.503Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54371,7 +59988,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.500Z",
+          "evaluatedAt": "2026-05-05T23:45:45.503Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54389,144 +60006,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.500Z",
-          "evaluatedVersion": "0.0.0"
-        }
-      }
-    },
-    {
-      "name": "sample-skill",
-      "description": "",
-      "version": "0.0.0",
-      "license": "",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/sample-skill",
-      "relPath": ".gemini/skills/sample-skill",
-      "verified": false,
-      "tokenCount": 1357,
-      "evalSummary": {
-        "overallScore": 49,
-        "grade": "F",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
-            "score": 2,
-            "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 0,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 6,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 9,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 3,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 5,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:32.501Z",
-        "evaluatedVersion": "0.0.0"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 49,
-          "grade": "F",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 2,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 0,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 6,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 9,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 3,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 5,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:32.501Z",
-          "evaluatedVersion": "0.0.0"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": false,
-          "overallScore": 0,
-          "grade": "F",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 0,
-              "max": 1
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:32.501Z",
+          "evaluatedAt": "2026-05-05T23:45:45.503Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54590,7 +60070,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.502Z",
+        "evaluatedAt": "2026-05-05T23:45:45.505Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -54645,7 +60125,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.502Z",
+          "evaluatedAt": "2026-05-05T23:45:45.505Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -54663,7 +60143,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.502Z",
+          "evaluatedAt": "2026-05-05T23:45:45.505Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -54676,8 +60156,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/scenario-war-room",
-      "relPath": ".gemini/skills/scenario-war-room",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/scenario-war-room",
+      "relPath": "c-level-advisor/skills/scenario-war-room",
       "verified": true,
       "tokenCount": 2391,
       "evalSummary": {
@@ -54727,7 +60207,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.504Z",
+        "evaluatedAt": "2026-05-05T23:45:45.507Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -54782,7 +60262,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.504Z",
+          "evaluatedAt": "2026-05-05T23:45:45.507Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -54800,7 +60280,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.504Z",
+          "evaluatedAt": "2026-05-05T23:45:45.507Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -54864,7 +60344,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.506Z",
+        "evaluatedAt": "2026-05-05T23:45:45.508Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -54919,7 +60399,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.506Z",
+          "evaluatedAt": "2026-05-05T23:45:45.508Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -54937,7 +60417,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.506Z",
+          "evaluatedAt": "2026-05-05T23:45:45.508Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -54950,8 +60430,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/schema-markup",
-      "relPath": ".gemini/skills/schema-markup",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/schema-markup",
+      "relPath": "marketing-skill/skills/schema-markup",
       "verified": true,
       "tokenCount": 3431,
       "evalSummary": {
@@ -55001,7 +60481,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.508Z",
+        "evaluatedAt": "2026-05-05T23:45:45.511Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -55056,7 +60536,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.508Z",
+          "evaluatedAt": "2026-05-05T23:45:45.511Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -55074,7 +60554,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.508Z",
+          "evaluatedAt": "2026-05-05T23:45:45.511Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -55138,7 +60618,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.510Z",
+        "evaluatedAt": "2026-05-05T23:45:45.513Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -55193,7 +60673,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.510Z",
+          "evaluatedAt": "2026-05-05T23:45:45.513Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -55211,7 +60691,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.510Z",
+          "evaluatedAt": "2026-05-05T23:45:45.513Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -55224,8 +60704,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/scrum-master",
-      "relPath": ".gemini/skills/scrum-master",
+      "installUrl": "github:alirezarezvani/claude-skills:project-management/skills/scrum-master",
+      "relPath": "project-management/skills/scrum-master",
       "verified": true,
       "tokenCount": 2374,
       "evalSummary": {
@@ -55275,7 +60755,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.512Z",
+        "evaluatedAt": "2026-05-05T23:45:45.514Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -55330,7 +60810,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.512Z",
+          "evaluatedAt": "2026-05-05T23:45:45.514Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -55348,7 +60828,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.512Z",
+          "evaluatedAt": "2026-05-05T23:45:45.514Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -55412,7 +60892,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.514Z",
+        "evaluatedAt": "2026-05-05T23:45:45.517Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55467,7 +60947,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.514Z",
+          "evaluatedAt": "2026-05-05T23:45:45.517Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55485,7 +60965,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.514Z",
+          "evaluatedAt": "2026-05-05T23:45:45.517Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55498,8 +60978,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/secrets-vault-manager",
-      "relPath": ".gemini/skills/secrets-vault-manager",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/secrets-vault-manager",
+      "relPath": "engineering/skills/secrets-vault-manager",
       "verified": true,
       "tokenCount": 3720,
       "evalSummary": {
@@ -55549,7 +61029,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.516Z",
+        "evaluatedAt": "2026-05-05T23:45:45.519Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55604,7 +61084,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.516Z",
+          "evaluatedAt": "2026-05-05T23:45:45.519Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55622,7 +61102,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.516Z",
+          "evaluatedAt": "2026-05-05T23:45:45.519Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55686,7 +61166,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.518Z",
+        "evaluatedAt": "2026-05-05T23:45:45.522Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55741,7 +61221,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.518Z",
+          "evaluatedAt": "2026-05-05T23:45:45.522Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55759,7 +61239,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.518Z",
+          "evaluatedAt": "2026-05-05T23:45:45.522Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55772,8 +61252,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/security-pen-testing",
-      "relPath": ".gemini/skills/security-pen-testing",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/security-pen-testing",
+      "relPath": "engineering-team/skills/security-pen-testing",
       "verified": true,
       "tokenCount": 3279,
       "evalSummary": {
@@ -55823,7 +61303,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.520Z",
+        "evaluatedAt": "2026-05-05T23:45:45.524Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55878,7 +61358,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.520Z",
+          "evaluatedAt": "2026-05-05T23:45:45.524Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55896,7 +61376,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.520Z",
+          "evaluatedAt": "2026-05-05T23:45:45.524Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55960,7 +61440,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.522Z",
+        "evaluatedAt": "2026-05-05T23:45:45.525Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56015,7 +61495,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.522Z",
+          "evaluatedAt": "2026-05-05T23:45:45.525Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56033,7 +61513,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.522Z",
+          "evaluatedAt": "2026-05-05T23:45:45.525Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56046,8 +61526,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/self-eval",
-      "relPath": ".gemini/skills/self-eval",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/self-eval",
+      "relPath": "engineering/skills/self-eval",
       "verified": true,
       "tokenCount": 2427,
       "evalSummary": {
@@ -56097,7 +61577,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.524Z",
+        "evaluatedAt": "2026-05-05T23:45:45.527Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56152,7 +61632,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.524Z",
+          "evaluatedAt": "2026-05-05T23:45:45.527Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56170,7 +61650,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.524Z",
+          "evaluatedAt": "2026-05-05T23:45:45.527Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56234,7 +61714,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.526Z",
+        "evaluatedAt": "2026-05-05T23:45:45.529Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56289,7 +61769,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.526Z",
+          "evaluatedAt": "2026-05-05T23:45:45.529Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56307,7 +61787,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.526Z",
+          "evaluatedAt": "2026-05-05T23:45:45.529Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "self-improving-agent",
+      "description": "Curate Claude Code's auto-memory into durable project knowledge. Analyze MEMORY.md for patterns, promote proven learnings to CLAUDE.md and .claude/rules/, extract recurring solutions into reusable skills. Use when: (1) reviewing what Claude has learned about your project, (2) graduating a pattern from notes to enforced rules, (3) turning a debugging solution into a skill, (4) checking memory health and capacity.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/self-improving-agent/skills/self-improving-agent",
+      "relPath": "engineering-team/self-improving-agent/skills/self-improving-agent",
+      "verified": true,
+      "tokenCount": 1782,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.530Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 70,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.530Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.530Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56371,7 +61988,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.527Z",
+        "evaluatedAt": "2026-05-05T23:45:45.532Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56426,7 +62043,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.527Z",
+          "evaluatedAt": "2026-05-05T23:45:45.532Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56444,7 +62061,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.527Z",
+          "evaluatedAt": "2026-05-05T23:45:45.532Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56457,8 +62074,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-architect",
-      "relPath": ".gemini/skills/senior-architect",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-architect",
+      "relPath": "engineering-team/skills/senior-architect",
       "verified": true,
       "tokenCount": 2487,
       "evalSummary": {
@@ -56508,7 +62125,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.529Z",
+        "evaluatedAt": "2026-05-05T23:45:45.534Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56563,7 +62180,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.530Z",
+          "evaluatedAt": "2026-05-05T23:45:45.534Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56581,7 +62198,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.530Z",
+          "evaluatedAt": "2026-05-05T23:45:45.534Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56645,7 +62262,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.532Z",
+        "evaluatedAt": "2026-05-05T23:45:45.536Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56700,7 +62317,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.532Z",
+          "evaluatedAt": "2026-05-05T23:45:45.536Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56718,7 +62335,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.532Z",
+          "evaluatedAt": "2026-05-05T23:45:45.536Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56731,8 +62348,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-backend",
-      "relPath": ".gemini/skills/senior-backend",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-backend",
+      "relPath": "engineering-team/skills/senior-backend",
       "verified": true,
       "tokenCount": 2343,
       "evalSummary": {
@@ -56782,7 +62399,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.533Z",
+        "evaluatedAt": "2026-05-05T23:45:45.538Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56837,7 +62454,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.533Z",
+          "evaluatedAt": "2026-05-05T23:45:45.538Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56855,7 +62472,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.533Z",
+          "evaluatedAt": "2026-05-05T23:45:45.538Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56919,7 +62536,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.535Z",
+        "evaluatedAt": "2026-05-05T23:45:45.540Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56974,7 +62591,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.535Z",
+          "evaluatedAt": "2026-05-05T23:45:45.540Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56992,7 +62609,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.535Z",
+          "evaluatedAt": "2026-05-05T23:45:45.540Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57005,8 +62622,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-computer-vision",
-      "relPath": ".gemini/skills/senior-computer-vision",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-computer-vision",
+      "relPath": "engineering-team/skills/senior-computer-vision",
       "verified": true,
       "tokenCount": 3507,
       "evalSummary": {
@@ -57056,7 +62673,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.537Z",
+        "evaluatedAt": "2026-05-05T23:45:45.542Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57111,7 +62728,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.537Z",
+          "evaluatedAt": "2026-05-05T23:45:45.542Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57129,7 +62746,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.537Z",
+          "evaluatedAt": "2026-05-05T23:45:45.542Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57193,7 +62810,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.539Z",
+        "evaluatedAt": "2026-05-05T23:45:45.544Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57248,7 +62865,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.539Z",
+          "evaluatedAt": "2026-05-05T23:45:45.544Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57266,7 +62883,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.539Z",
+          "evaluatedAt": "2026-05-05T23:45:45.544Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57279,8 +62896,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-data-engineer",
-      "relPath": ".gemini/skills/senior-data-engineer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-data-engineer",
+      "relPath": "engineering-team/skills/senior-data-engineer",
       "verified": true,
       "tokenCount": 1529,
       "evalSummary": {
@@ -57330,7 +62947,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.540Z",
+        "evaluatedAt": "2026-05-05T23:45:45.545Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57385,7 +63002,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.540Z",
+          "evaluatedAt": "2026-05-05T23:45:45.545Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57403,7 +63020,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.540Z",
+          "evaluatedAt": "2026-05-05T23:45:45.545Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57467,7 +63084,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.542Z",
+        "evaluatedAt": "2026-05-05T23:45:45.547Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57522,7 +63139,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.542Z",
+          "evaluatedAt": "2026-05-05T23:45:45.547Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57540,7 +63157,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.542Z",
+          "evaluatedAt": "2026-05-05T23:45:45.547Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57553,8 +63170,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-data-scientist",
-      "relPath": ".gemini/skills/senior-data-scientist",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-data-scientist",
+      "relPath": "engineering-team/skills/senior-data-scientist",
       "verified": true,
       "tokenCount": 2508,
       "evalSummary": {
@@ -57604,7 +63221,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.544Z",
+        "evaluatedAt": "2026-05-05T23:45:45.548Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57659,7 +63276,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.544Z",
+          "evaluatedAt": "2026-05-05T23:45:45.549Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57677,7 +63294,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.544Z",
+          "evaluatedAt": "2026-05-05T23:45:45.549Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57741,7 +63358,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.546Z",
+        "evaluatedAt": "2026-05-05T23:45:45.550Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57796,7 +63413,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.546Z",
+          "evaluatedAt": "2026-05-05T23:45:45.550Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57814,7 +63431,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.546Z",
+          "evaluatedAt": "2026-05-05T23:45:45.550Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57827,8 +63444,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-devops",
-      "relPath": ".gemini/skills/senior-devops",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-devops",
+      "relPath": "engineering-team/skills/senior-devops",
       "verified": true,
       "tokenCount": 2883,
       "evalSummary": {
@@ -57878,7 +63495,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.548Z",
+        "evaluatedAt": "2026-05-05T23:45:45.552Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57933,7 +63550,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.548Z",
+          "evaluatedAt": "2026-05-05T23:45:45.552Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57951,7 +63568,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.548Z",
+          "evaluatedAt": "2026-05-05T23:45:45.552Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58015,7 +63632,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.550Z",
+        "evaluatedAt": "2026-05-05T23:45:45.554Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58070,7 +63687,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.550Z",
+          "evaluatedAt": "2026-05-05T23:45:45.555Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58088,7 +63705,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.550Z",
+          "evaluatedAt": "2026-05-05T23:45:45.555Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58101,8 +63718,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-frontend",
-      "relPath": ".gemini/skills/senior-frontend",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-frontend",
+      "relPath": "engineering-team/skills/senior-frontend",
       "verified": true,
       "tokenCount": 2800,
       "evalSummary": {
@@ -58152,7 +63769,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.552Z",
+        "evaluatedAt": "2026-05-05T23:45:45.557Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58207,7 +63824,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.552Z",
+          "evaluatedAt": "2026-05-05T23:45:45.557Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58225,7 +63842,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.552Z",
+          "evaluatedAt": "2026-05-05T23:45:45.557Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58289,7 +63906,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.554Z",
+        "evaluatedAt": "2026-05-05T23:45:45.558Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58344,7 +63961,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.554Z",
+          "evaluatedAt": "2026-05-05T23:45:45.558Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58362,7 +63979,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.554Z",
+          "evaluatedAt": "2026-05-05T23:45:45.558Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58375,8 +63992,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-fullstack",
-      "relPath": ".gemini/skills/senior-fullstack",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-fullstack",
+      "relPath": "engineering-team/skills/senior-fullstack",
       "verified": true,
       "tokenCount": 1977,
       "evalSummary": {
@@ -58426,7 +64043,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.555Z",
+        "evaluatedAt": "2026-05-05T23:45:45.560Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58481,7 +64098,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.555Z",
+          "evaluatedAt": "2026-05-05T23:45:45.560Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58499,7 +64116,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.555Z",
+          "evaluatedAt": "2026-05-05T23:45:45.560Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58563,7 +64180,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.557Z",
+        "evaluatedAt": "2026-05-05T23:45:45.562Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58618,7 +64235,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.557Z",
+          "evaluatedAt": "2026-05-05T23:45:45.562Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58636,7 +64253,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.557Z",
+          "evaluatedAt": "2026-05-05T23:45:45.562Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58649,8 +64266,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-ml-engineer",
-      "relPath": ".gemini/skills/senior-ml-engineer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-ml-engineer",
+      "relPath": "engineering-team/skills/senior-ml-engineer",
       "verified": true,
       "tokenCount": 2365,
       "evalSummary": {
@@ -58700,7 +64317,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.558Z",
+        "evaluatedAt": "2026-05-05T23:45:45.564Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58755,7 +64372,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.558Z",
+          "evaluatedAt": "2026-05-05T23:45:45.564Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58773,7 +64390,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.558Z",
+          "evaluatedAt": "2026-05-05T23:45:45.564Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58837,7 +64454,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.561Z",
+        "evaluatedAt": "2026-05-05T23:45:45.566Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58892,7 +64509,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.561Z",
+          "evaluatedAt": "2026-05-05T23:45:45.566Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58910,7 +64527,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.561Z",
+          "evaluatedAt": "2026-05-05T23:45:45.566Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58923,8 +64540,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-pm",
-      "relPath": ".gemini/skills/senior-pm",
+      "installUrl": "github:alirezarezvani/claude-skills:project-management/skills/senior-pm",
+      "relPath": "project-management/skills/senior-pm",
       "verified": true,
       "tokenCount": 3863,
       "evalSummary": {
@@ -58974,7 +64591,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.563Z",
+        "evaluatedAt": "2026-05-05T23:45:45.569Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59029,7 +64646,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.563Z",
+          "evaluatedAt": "2026-05-05T23:45:45.569Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59047,7 +64664,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.563Z",
+          "evaluatedAt": "2026-05-05T23:45:45.569Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59111,7 +64728,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.566Z",
+        "evaluatedAt": "2026-05-05T23:45:45.572Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59166,7 +64783,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.566Z",
+          "evaluatedAt": "2026-05-05T23:45:45.572Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59184,7 +64801,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.566Z",
+          "evaluatedAt": "2026-05-05T23:45:45.572Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59197,8 +64814,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-prompt-engineer",
-      "relPath": ".gemini/skills/senior-prompt-engineer",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-prompt-engineer",
+      "relPath": "engineering-team/skills/senior-prompt-engineer",
       "verified": true,
       "tokenCount": 3048,
       "evalSummary": {
@@ -59248,7 +64865,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.568Z",
+        "evaluatedAt": "2026-05-05T23:45:45.574Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59303,7 +64920,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.568Z",
+          "evaluatedAt": "2026-05-05T23:45:45.574Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59321,7 +64938,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.568Z",
+          "evaluatedAt": "2026-05-05T23:45:45.574Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59385,7 +65002,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.570Z",
+        "evaluatedAt": "2026-05-05T23:45:45.575Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59440,7 +65057,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.570Z",
+          "evaluatedAt": "2026-05-05T23:45:45.575Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59458,7 +65075,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.570Z",
+          "evaluatedAt": "2026-05-05T23:45:45.575Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59471,8 +65088,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-qa",
-      "relPath": ".gemini/skills/senior-qa",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-qa",
+      "relPath": "engineering-team/skills/senior-qa",
       "verified": true,
       "tokenCount": 1955,
       "evalSummary": {
@@ -59522,7 +65139,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.571Z",
+        "evaluatedAt": "2026-05-05T23:45:45.577Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59577,7 +65194,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.571Z",
+          "evaluatedAt": "2026-05-05T23:45:45.577Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59595,7 +65212,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.571Z",
+          "evaluatedAt": "2026-05-05T23:45:45.577Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59659,7 +65276,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.573Z",
+        "evaluatedAt": "2026-05-05T23:45:45.579Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59714,7 +65331,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.573Z",
+          "evaluatedAt": "2026-05-05T23:45:45.579Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59732,7 +65349,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.573Z",
+          "evaluatedAt": "2026-05-05T23:45:45.579Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59745,8 +65362,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-secops",
-      "relPath": ".gemini/skills/senior-secops",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-secops",
+      "relPath": "engineering-team/skills/senior-secops",
       "verified": false,
       "tokenCount": 4070,
       "evalSummary": {
@@ -59796,7 +65413,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.576Z",
+        "evaluatedAt": "2026-05-05T23:45:45.582Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59851,7 +65468,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.576Z",
+          "evaluatedAt": "2026-05-05T23:45:45.582Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59869,7 +65486,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.576Z",
+          "evaluatedAt": "2026-05-05T23:45:45.582Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59933,7 +65550,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.578Z",
+        "evaluatedAt": "2026-05-05T23:45:45.584Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59988,7 +65605,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.578Z",
+          "evaluatedAt": "2026-05-05T23:45:45.584Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60006,7 +65623,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.578Z",
+          "evaluatedAt": "2026-05-05T23:45:45.584Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60019,8 +65636,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/senior-security",
-      "relPath": ".gemini/skills/senior-security",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/senior-security",
+      "relPath": "engineering-team/skills/senior-security",
       "verified": true,
       "tokenCount": 4076,
       "evalSummary": {
@@ -60070,7 +65687,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.581Z",
+        "evaluatedAt": "2026-05-05T23:45:45.587Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60125,7 +65742,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.581Z",
+          "evaluatedAt": "2026-05-05T23:45:45.587Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60143,7 +65760,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.581Z",
+          "evaluatedAt": "2026-05-05T23:45:45.587Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60207,7 +65824,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.583Z",
+        "evaluatedAt": "2026-05-05T23:45:45.589Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -60262,7 +65879,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.583Z",
+          "evaluatedAt": "2026-05-05T23:45:45.589Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -60280,7 +65897,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.583Z",
+          "evaluatedAt": "2026-05-05T23:45:45.589Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -60293,8 +65910,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/seo-audit",
-      "relPath": ".gemini/skills/seo-audit",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/seo-audit",
+      "relPath": "marketing-skill/skills/seo-audit",
       "verified": true,
       "tokenCount": 1723,
       "evalSummary": {
@@ -60344,7 +65961,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.584Z",
+        "evaluatedAt": "2026-05-05T23:45:45.591Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -60399,7 +66016,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.584Z",
+          "evaluatedAt": "2026-05-05T23:45:45.591Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -60417,7 +66034,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.584Z",
+          "evaluatedAt": "2026-05-05T23:45:45.591Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -60481,7 +66098,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.586Z",
+        "evaluatedAt": "2026-05-05T23:45:45.593Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60536,7 +66153,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.586Z",
+          "evaluatedAt": "2026-05-05T23:45:45.593Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60554,7 +66171,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.586Z",
+          "evaluatedAt": "2026-05-05T23:45:45.593Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "setup",
+      "description": "Set up a new autoresearch experiment interactively. Collects domain, target file, eval command, metric, direction, and evaluator.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/setup",
+      "relPath": ".codex/skills/autoresearch-agent/skills/setup",
+      "verified": true,
+      "tokenCount": 780,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.595Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 66,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.595Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.595Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60618,7 +66372,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.588Z",
+        "evaluatedAt": "2026-05-05T23:45:45.596Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60673,7 +66427,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.588Z",
+          "evaluatedAt": "2026-05-05T23:45:45.596Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60691,7 +66445,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.588Z",
+          "evaluatedAt": "2026-05-05T23:45:45.596Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "setup",
+      "description": "Set up a new autoresearch experiment interactively. Collects domain, target file, eval command, metric, direction, and evaluator.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/autoresearch-agent/skills/setup",
+      "relPath": "engineering/autoresearch-agent/skills/setup",
+      "verified": true,
+      "tokenCount": 780,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.597Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 66,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.597Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.597Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60755,7 +66646,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.589Z",
+        "evaluatedAt": "2026-05-05T23:45:45.598Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -60810,7 +66701,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.589Z",
+          "evaluatedAt": "2026-05-05T23:45:45.598Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -60828,7 +66719,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.589Z",
+          "evaluatedAt": "2026-05-05T23:45:45.598Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -60841,8 +66732,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/signup-flow-cro",
-      "relPath": ".gemini/skills/signup-flow-cro",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/signup-flow-cro",
+      "relPath": "marketing-skill/skills/signup-flow-cro",
       "verified": true,
       "tokenCount": 2604,
       "evalSummary": {
@@ -60892,7 +66783,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.591Z",
+        "evaluatedAt": "2026-05-05T23:45:45.600Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -60947,7 +66838,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.591Z",
+          "evaluatedAt": "2026-05-05T23:45:45.600Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -60965,7 +66856,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.591Z",
+          "evaluatedAt": "2026-05-05T23:45:45.600Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -61029,7 +66920,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.593Z",
+        "evaluatedAt": "2026-05-05T23:45:45.603Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -61084,7 +66975,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.593Z",
+          "evaluatedAt": "2026-05-05T23:45:45.603Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -61102,7 +66993,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.593Z",
+          "evaluatedAt": "2026-05-05T23:45:45.603Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -61115,8 +67006,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/site-architecture",
-      "relPath": ".gemini/skills/site-architecture",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/site-architecture",
+      "relPath": "marketing-skill/skills/site-architecture",
       "verified": true,
       "tokenCount": 4221,
       "evalSummary": {
@@ -61166,7 +67057,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.595Z",
+        "evaluatedAt": "2026-05-05T23:45:45.605Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -61221,7 +67112,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.595Z",
+          "evaluatedAt": "2026-05-05T23:45:45.605Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -61239,7 +67130,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.595Z",
+          "evaluatedAt": "2026-05-05T23:45:45.605Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -61303,7 +67194,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.597Z",
+        "evaluatedAt": "2026-05-05T23:45:45.607Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61358,7 +67249,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.597Z",
+          "evaluatedAt": "2026-05-05T23:45:45.607Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61376,7 +67267,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.597Z",
+          "evaluatedAt": "2026-05-05T23:45:45.608Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61389,8 +67280,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/skill-security-auditor",
-      "relPath": ".gemini/skills/skill-security-auditor",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/skill-security-auditor",
+      "relPath": "engineering/skills/skill-security-auditor",
       "verified": true,
       "tokenCount": 2029,
       "evalSummary": {
@@ -61440,7 +67331,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.599Z",
+        "evaluatedAt": "2026-05-05T23:45:45.609Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61495,7 +67386,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.599Z",
+          "evaluatedAt": "2026-05-05T23:45:45.609Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61513,7 +67404,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.599Z",
+          "evaluatedAt": "2026-05-05T23:45:45.609Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61577,7 +67468,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.600Z",
+        "evaluatedAt": "2026-05-05T23:45:45.611Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61632,7 +67523,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.600Z",
+          "evaluatedAt": "2026-05-05T23:45:45.611Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61650,7 +67541,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.600Z",
+          "evaluatedAt": "2026-05-05T23:45:45.611Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61663,8 +67554,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/skill-tester",
-      "relPath": ".gemini/skills/skill-tester",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/skill-tester",
+      "relPath": "engineering/skills/skill-tester",
       "verified": true,
       "tokenCount": 3883,
       "evalSummary": {
@@ -61714,7 +67605,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.603Z",
+        "evaluatedAt": "2026-05-05T23:45:45.614Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61769,7 +67660,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.603Z",
+          "evaluatedAt": "2026-05-05T23:45:45.614Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61787,7 +67678,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.603Z",
+          "evaluatedAt": "2026-05-05T23:45:45.614Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61800,8 +67691,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/snowflake-development",
-      "relPath": ".codex/skills/snowflake-development",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/snowflake-development/skills/snowflake-development",
+      "relPath": ".codex/skills/snowflake-development/skills/snowflake-development",
       "verified": true,
       "tokenCount": 3310,
       "evalSummary": {
@@ -61851,7 +67742,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.605Z",
+        "evaluatedAt": "2026-05-05T23:45:45.616Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61906,7 +67797,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.605Z",
+          "evaluatedAt": "2026-05-05T23:45:45.616Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61924,7 +67815,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.605Z",
+          "evaluatedAt": "2026-05-05T23:45:45.616Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61937,8 +67828,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/snowflake-development",
-      "relPath": ".gemini/skills/snowflake-development",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/snowflake-development/skills/snowflake-development",
+      "relPath": "engineering-team/snowflake-development/skills/snowflake-development",
       "verified": true,
       "tokenCount": 3310,
       "evalSummary": {
@@ -61988,7 +67879,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.607Z",
+        "evaluatedAt": "2026-05-05T23:45:45.618Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62043,7 +67934,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.607Z",
+          "evaluatedAt": "2026-05-05T23:45:45.618Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62061,7 +67952,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.607Z",
+          "evaluatedAt": "2026-05-05T23:45:45.618Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62125,7 +68016,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.610Z",
+        "evaluatedAt": "2026-05-05T23:45:45.621Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62180,7 +68071,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.610Z",
+          "evaluatedAt": "2026-05-05T23:45:45.621Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62198,7 +68089,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.610Z",
+          "evaluatedAt": "2026-05-05T23:45:45.621Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62211,8 +68102,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/soc2-compliance",
-      "relPath": ".gemini/skills/soc2-compliance",
+      "installUrl": "github:alirezarezvani/claude-skills:ra-qm-team/skills/soc2-compliance",
+      "relPath": "ra-qm-team/skills/soc2-compliance",
       "verified": true,
       "tokenCount": 5016,
       "evalSummary": {
@@ -62262,7 +68153,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.613Z",
+        "evaluatedAt": "2026-05-05T23:45:45.624Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62317,7 +68208,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.613Z",
+          "evaluatedAt": "2026-05-05T23:45:45.624Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62335,7 +68226,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.613Z",
+          "evaluatedAt": "2026-05-05T23:45:45.624Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62399,7 +68290,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.615Z",
+        "evaluatedAt": "2026-05-05T23:45:45.626Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -62454,7 +68345,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.615Z",
+          "evaluatedAt": "2026-05-05T23:45:45.626Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -62472,7 +68363,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.615Z",
+          "evaluatedAt": "2026-05-05T23:45:45.626Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -62485,8 +68376,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/social-content",
-      "relPath": ".gemini/skills/social-content",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/social-content",
+      "relPath": "marketing-skill/skills/social-content",
       "verified": true,
       "tokenCount": 3227,
       "evalSummary": {
@@ -62536,7 +68427,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.617Z",
+        "evaluatedAt": "2026-05-05T23:45:45.629Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -62591,7 +68482,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.617Z",
+          "evaluatedAt": "2026-05-05T23:45:45.629Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -62609,7 +68500,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.617Z",
+          "evaluatedAt": "2026-05-05T23:45:45.629Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -62673,7 +68564,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.619Z",
+        "evaluatedAt": "2026-05-05T23:45:45.631Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62728,7 +68619,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.619Z",
+          "evaluatedAt": "2026-05-05T23:45:45.631Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62746,7 +68637,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.619Z",
+          "evaluatedAt": "2026-05-05T23:45:45.631Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62759,8 +68650,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/social-media-analyzer",
-      "relPath": ".gemini/skills/social-media-analyzer",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/social-media-analyzer",
+      "relPath": "marketing-skill/skills/social-media-analyzer",
       "verified": true,
       "tokenCount": 2444,
       "evalSummary": {
@@ -62810,7 +68701,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.621Z",
+        "evaluatedAt": "2026-05-05T23:45:45.632Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62865,7 +68756,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.621Z",
+          "evaluatedAt": "2026-05-05T23:45:45.632Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62883,7 +68774,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.621Z",
+          "evaluatedAt": "2026-05-05T23:45:45.632Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62947,7 +68838,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.623Z",
+        "evaluatedAt": "2026-05-05T23:45:45.634Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -63002,7 +68893,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.623Z",
+          "evaluatedAt": "2026-05-05T23:45:45.634Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -63020,7 +68911,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.623Z",
+          "evaluatedAt": "2026-05-05T23:45:45.634Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -63033,8 +68924,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/social-media-manager",
-      "relPath": ".gemini/skills/social-media-manager",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/social-media-manager",
+      "relPath": "marketing-skill/skills/social-media-manager",
       "verified": true,
       "tokenCount": 2643,
       "evalSummary": {
@@ -63084,7 +68975,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.624Z",
+        "evaluatedAt": "2026-05-05T23:45:45.636Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -63139,7 +69030,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.624Z",
+          "evaluatedAt": "2026-05-05T23:45:45.636Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -63157,7 +69048,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.624Z",
+          "evaluatedAt": "2026-05-05T23:45:45.636Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -63221,7 +69112,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.626Z",
+        "evaluatedAt": "2026-05-05T23:45:45.638Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -63276,7 +69167,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.626Z",
+          "evaluatedAt": "2026-05-05T23:45:45.638Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -63294,7 +69185,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.626Z",
+          "evaluatedAt": "2026-05-05T23:45:45.638Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "spawn",
+      "description": "Launch N parallel subagents in isolated git worktrees to compete on the session task.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/spawn",
+      "relPath": ".codex/skills/agenthub/skills/spawn",
+      "verified": true,
+      "tokenCount": 957,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.639Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 60,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.639Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.639Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -63358,7 +69386,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.628Z",
+        "evaluatedAt": "2026-05-05T23:45:45.640Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -63413,7 +69441,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.628Z",
+          "evaluatedAt": "2026-05-05T23:45:45.640Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -63431,7 +69459,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.628Z",
+          "evaluatedAt": "2026-05-05T23:45:45.640Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "spawn",
+      "description": "Launch N parallel subagents in isolated git worktrees to compete on the session task.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/agenthub/skills/spawn",
+      "relPath": "engineering/agenthub/skills/spawn",
+      "verified": true,
+      "tokenCount": 957,
+      "evalSummary": {
+        "overallScore": 60,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.641Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 60,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.641Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.641Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -63495,7 +69660,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.629Z",
+        "evaluatedAt": "2026-05-05T23:45:45.643Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -63550,7 +69715,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.629Z",
+          "evaluatedAt": "2026-05-05T23:45:45.643Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -63568,7 +69733,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.629Z",
+          "evaluatedAt": "2026-05-05T23:45:45.643Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -63581,8 +69746,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/spec-driven-workflow",
-      "relPath": ".gemini/skills/spec-driven-workflow",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/spec-driven-workflow",
+      "relPath": "engineering/skills/spec-driven-workflow",
       "verified": true,
       "tokenCount": 4317,
       "evalSummary": {
@@ -63632,7 +69797,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.632Z",
+        "evaluatedAt": "2026-05-05T23:45:45.645Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -63687,7 +69852,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.632Z",
+          "evaluatedAt": "2026-05-05T23:45:45.645Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -63705,7 +69870,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.632Z",
+          "evaluatedAt": "2026-05-05T23:45:45.645Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -63769,7 +69934,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.634Z",
+        "evaluatedAt": "2026-05-05T23:45:45.647Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -63824,7 +69989,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.634Z",
+          "evaluatedAt": "2026-05-05T23:45:45.647Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -63842,7 +70007,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.634Z",
+          "evaluatedAt": "2026-05-05T23:45:45.647Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -63855,8 +70020,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/spec-to-repo",
-      "relPath": ".gemini/skills/spec-to-repo",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/spec-to-repo",
+      "relPath": "product-team/skills/spec-to-repo",
       "verified": true,
       "tokenCount": 3272,
       "evalSummary": {
@@ -63906,7 +70071,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.636Z",
+        "evaluatedAt": "2026-05-05T23:45:45.649Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -63961,7 +70126,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.636Z",
+          "evaluatedAt": "2026-05-05T23:45:45.649Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -63979,7 +70144,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.636Z",
+          "evaluatedAt": "2026-05-05T23:45:45.649Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -64043,7 +70208,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.637Z",
+        "evaluatedAt": "2026-05-05T23:45:45.650Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -64098,7 +70263,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.637Z",
+          "evaluatedAt": "2026-05-05T23:45:45.650Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -64116,7 +70281,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.637Z",
+          "evaluatedAt": "2026-05-05T23:45:45.650Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -64180,7 +70345,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.638Z",
+        "evaluatedAt": "2026-05-05T23:45:45.650Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -64235,7 +70400,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.638Z",
+          "evaluatedAt": "2026-05-05T23:45:45.650Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -64253,7 +70418,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.638Z",
+          "evaluatedAt": "2026-05-05T23:45:45.650Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -64317,7 +70482,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.640Z",
+        "evaluatedAt": "2026-05-05T23:45:45.652Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -64372,7 +70537,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.640Z",
+          "evaluatedAt": "2026-05-05T23:45:45.652Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -64390,7 +70555,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.640Z",
+          "evaluatedAt": "2026-05-05T23:45:45.652Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -64403,8 +70568,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/sql-database-assistant",
-      "relPath": ".gemini/skills/sql-database-assistant",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/sql-database-assistant",
+      "relPath": "engineering/skills/sql-database-assistant",
       "verified": true,
       "tokenCount": 4247,
       "evalSummary": {
@@ -64454,7 +70619,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.643Z",
+        "evaluatedAt": "2026-05-05T23:45:45.655Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -64509,7 +70674,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.643Z",
+          "evaluatedAt": "2026-05-05T23:45:45.655Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -64527,7 +70692,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.643Z",
+          "evaluatedAt": "2026-05-05T23:45:45.655Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -64591,7 +70756,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.646Z",
+        "evaluatedAt": "2026-05-05T23:45:45.657Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -64646,7 +70811,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.646Z",
+          "evaluatedAt": "2026-05-05T23:45:45.657Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -64664,7 +70829,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.646Z",
+          "evaluatedAt": "2026-05-05T23:45:45.657Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -64677,8 +70842,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/statistical-analyst",
-      "relPath": ".codex/skills/statistical-analyst",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/statistical-analyst/skills/statistical-analyst",
+      "relPath": ".codex/skills/statistical-analyst/skills/statistical-analyst",
       "verified": true,
       "tokenCount": 2825,
       "evalSummary": {
@@ -64728,7 +70893,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.648Z",
+        "evaluatedAt": "2026-05-05T23:45:45.658Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -64783,7 +70948,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.648Z",
+          "evaluatedAt": "2026-05-05T23:45:45.659Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -64801,7 +70966,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.648Z",
+          "evaluatedAt": "2026-05-05T23:45:45.659Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -64814,8 +70979,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/statistical-analyst",
-      "relPath": ".gemini/skills/statistical-analyst",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/statistical-analyst/skills/statistical-analyst",
+      "relPath": "engineering/statistical-analyst/skills/statistical-analyst",
       "verified": true,
       "tokenCount": 2825,
       "evalSummary": {
@@ -64865,7 +71030,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.650Z",
+        "evaluatedAt": "2026-05-05T23:45:45.660Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -64920,7 +71085,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.650Z",
+          "evaluatedAt": "2026-05-05T23:45:45.660Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -64938,7 +71103,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.650Z",
+          "evaluatedAt": "2026-05-05T23:45:45.660Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "status",
+      "description": "Show DAG state, agent progress, and branch status for an AgentHub session.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/agenthub/skills/status",
+      "relPath": ".codex/skills/agenthub/skills/status",
+      "verified": true,
+      "tokenCount": 719,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.662Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 74,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.662Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.662Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "status",
+      "description": "Show experiment dashboard with results, active loops, and progress.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/autoresearch-agent/skills/status",
+      "relPath": ".codex/skills/autoresearch-agent/skills/status",
+      "verified": true,
+      "tokenCount": 591,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.662Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 56,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.662Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.662Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -65002,7 +71441,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.651Z",
+        "evaluatedAt": "2026-05-05T23:45:45.663Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -65057,7 +71496,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.651Z",
+          "evaluatedAt": "2026-05-05T23:45:45.663Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -65075,7 +71514,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.651Z",
+          "evaluatedAt": "2026-05-05T23:45:45.663Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -65139,7 +71578,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.652Z",
+        "evaluatedAt": "2026-05-05T23:45:45.664Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -65194,7 +71633,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.652Z",
+          "evaluatedAt": "2026-05-05T23:45:45.664Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -65212,7 +71651,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.652Z",
+          "evaluatedAt": "2026-05-05T23:45:45.664Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -65276,7 +71715,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.653Z",
+        "evaluatedAt": "2026-05-05T23:45:45.665Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -65331,7 +71770,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.653Z",
+          "evaluatedAt": "2026-05-05T23:45:45.665Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -65349,7 +71788,418 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.653Z",
+          "evaluatedAt": "2026-05-05T23:45:45.665Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "status",
+      "description": "Show DAG state, agent progress, and branch status for an AgentHub session.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/agenthub/skills/status",
+      "relPath": "engineering/agenthub/skills/status",
+      "verified": true,
+      "tokenCount": 719,
+      "evalSummary": {
+        "overallScore": 74,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.665Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 74,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.665Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.665Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "status",
+      "description": "Show experiment dashboard with results, active loops, and progress.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/autoresearch-agent/skills/status",
+      "relPath": "engineering/autoresearch-agent/skills/status",
+      "verified": true,
+      "tokenCount": 591,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.666Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 56,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.666Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.666Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "status",
+      "description": "Memory health dashboard showing line counts, topic files, capacity, stale entries, and recommendations.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/self-improving-agent/skills/status",
+      "relPath": "engineering-team/self-improving-agent/skills/status",
+      "verified": true,
+      "tokenCount": 818,
+      "evalSummary": {
+        "overallScore": 56,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.667Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 56,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.667Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.667Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -65413,7 +72263,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.654Z",
+        "evaluatedAt": "2026-05-05T23:45:45.668Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -65468,7 +72318,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.654Z",
+          "evaluatedAt": "2026-05-05T23:45:45.668Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -65486,7 +72336,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.654Z",
+          "evaluatedAt": "2026-05-05T23:45:45.668Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -65499,8 +72349,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/strategic-alignment",
-      "relPath": ".gemini/skills/strategic-alignment",
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/skills/strategic-alignment",
+      "relPath": "c-level-advisor/skills/strategic-alignment",
       "verified": true,
       "tokenCount": 2757,
       "evalSummary": {
@@ -65550,7 +72400,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.656Z",
+        "evaluatedAt": "2026-05-05T23:45:45.670Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -65605,7 +72455,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.656Z",
+          "evaluatedAt": "2026-05-05T23:45:45.670Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -65623,8 +72473,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.656Z",
+          "evaluatedAt": "2026-05-05T23:45:45.670Z",
           "evaluatedVersion": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "stress-test",
+      "description": "/em -stress-test — Business Assumption Stress Testing",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/executive-mentor/skills/stress-test",
+      "relPath": ".codex/skills/executive-mentor/skills/stress-test",
+      "verified": true,
+      "tokenCount": 2323,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.672Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 61,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.672Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.672Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -65687,7 +72674,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.658Z",
+        "evaluatedAt": "2026-05-05T23:45:45.674Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -65742,7 +72729,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.658Z",
+          "evaluatedAt": "2026-05-05T23:45:45.674Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -65760,7 +72747,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.658Z",
+          "evaluatedAt": "2026-05-05T23:45:45.674Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "stress-test",
+      "description": "/em -stress-test — Business Assumption Stress Testing",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:c-level-advisor/executive-mentor/skills/stress-test",
+      "relPath": "c-level-advisor/executive-mentor/skills/stress-test",
+      "verified": true,
+      "tokenCount": 2323,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.675Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 61,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.675Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.675Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -65824,7 +72948,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.660Z",
+        "evaluatedAt": "2026-05-05T23:45:45.677Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -65879,7 +73003,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.660Z",
+          "evaluatedAt": "2026-05-05T23:45:45.677Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -65897,7 +73021,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.660Z",
+          "evaluatedAt": "2026-05-05T23:45:45.677Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -65910,8 +73034,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/stripe-integration-expert",
-      "relPath": ".gemini/skills/stripe-integration-expert",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/stripe-integration-expert",
+      "relPath": "engineering-team/skills/stripe-integration-expert",
       "verified": true,
       "tokenCount": 3903,
       "evalSummary": {
@@ -65961,7 +73085,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.662Z",
+        "evaluatedAt": "2026-05-05T23:45:45.680Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -66016,7 +73140,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.662Z",
+          "evaluatedAt": "2026-05-05T23:45:45.680Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -66034,7 +73158,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.662Z",
+          "evaluatedAt": "2026-05-05T23:45:45.680Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -66098,7 +73222,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.664Z",
+        "evaluatedAt": "2026-05-05T23:45:45.681Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -66153,7 +73277,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.664Z",
+          "evaluatedAt": "2026-05-05T23:45:45.682Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -66171,7 +73295,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.664Z",
+          "evaluatedAt": "2026-05-05T23:45:45.682Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -66235,7 +73359,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.666Z",
+        "evaluatedAt": "2026-05-05T23:45:45.683Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -66290,7 +73414,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.666Z",
+          "evaluatedAt": "2026-05-05T23:45:45.683Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -66308,7 +73432,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.666Z",
+          "evaluatedAt": "2026-05-05T23:45:45.683Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -66321,8 +73445,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tc-tracker",
-      "relPath": ".gemini/skills/tc-tracker",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/tc-tracker",
+      "relPath": "engineering/skills/tc-tracker",
       "verified": true,
       "tokenCount": 2838,
       "evalSummary": {
@@ -66372,7 +73496,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.667Z",
+        "evaluatedAt": "2026-05-05T23:45:45.685Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -66427,7 +73551,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.667Z",
+          "evaluatedAt": "2026-05-05T23:45:45.685Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -66445,7 +73569,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.667Z",
+          "evaluatedAt": "2026-05-05T23:45:45.685Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -66509,7 +73633,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.669Z",
+        "evaluatedAt": "2026-05-05T23:45:45.686Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -66564,7 +73688,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.669Z",
+          "evaluatedAt": "2026-05-05T23:45:45.686Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -66582,7 +73706,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.669Z",
+          "evaluatedAt": "2026-05-05T23:45:45.686Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -66646,7 +73770,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.670Z",
+        "evaluatedAt": "2026-05-05T23:45:45.688Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -66701,7 +73825,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.670Z",
+          "evaluatedAt": "2026-05-05T23:45:45.688Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -66719,7 +73843,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.670Z",
+          "evaluatedAt": "2026-05-05T23:45:45.688Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -66732,8 +73856,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tdd-guide",
-      "relPath": ".gemini/skills/tdd-guide",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/tdd-guide",
+      "relPath": "engineering-team/skills/tdd-guide",
       "verified": true,
       "tokenCount": 3721,
       "evalSummary": {
@@ -66783,7 +73907,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.672Z",
+        "evaluatedAt": "2026-05-05T23:45:45.690Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -66838,7 +73962,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.672Z",
+          "evaluatedAt": "2026-05-05T23:45:45.690Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -66856,7 +73980,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.672Z",
+          "evaluatedAt": "2026-05-05T23:45:45.690Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -66920,7 +74044,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.674Z",
+        "evaluatedAt": "2026-05-05T23:45:45.691Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -66975,7 +74099,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.674Z",
+          "evaluatedAt": "2026-05-05T23:45:45.691Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -66993,7 +74117,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.674Z",
+          "evaluatedAt": "2026-05-05T23:45:45.691Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -67006,8 +74130,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/team-communications",
-      "relPath": ".gemini/skills/team-communications",
+      "installUrl": "github:alirezarezvani/claude-skills:project-management/skills/team-communications",
+      "relPath": "project-management/skills/team-communications",
       "verified": true,
       "tokenCount": 1264,
       "evalSummary": {
@@ -67057,7 +74181,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.675Z",
+        "evaluatedAt": "2026-05-05T23:45:45.692Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -67112,7 +74236,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.675Z",
+          "evaluatedAt": "2026-05-05T23:45:45.692Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -67130,7 +74254,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.675Z",
+          "evaluatedAt": "2026-05-05T23:45:45.692Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -67194,7 +74318,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.675Z",
+        "evaluatedAt": "2026-05-05T23:45:45.693Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -67249,7 +74373,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.675Z",
+          "evaluatedAt": "2026-05-05T23:45:45.693Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -67267,7 +74391,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.675Z",
+          "evaluatedAt": "2026-05-05T23:45:45.693Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -67331,7 +74455,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.676Z",
+        "evaluatedAt": "2026-05-05T23:45:45.694Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -67386,7 +74510,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.676Z",
+          "evaluatedAt": "2026-05-05T23:45:45.694Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -67404,7 +74528,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.676Z",
+          "evaluatedAt": "2026-05-05T23:45:45.694Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -67417,8 +74541,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tech-debt-tracker",
-      "relPath": ".gemini/skills/tech-debt-tracker",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/skills/tech-debt-tracker",
+      "relPath": "engineering/skills/tech-debt-tracker",
       "verified": true,
       "tokenCount": 1146,
       "evalSummary": {
@@ -67468,7 +74592,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.677Z",
+        "evaluatedAt": "2026-05-05T23:45:45.695Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -67523,7 +74647,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.677Z",
+          "evaluatedAt": "2026-05-05T23:45:45.695Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -67541,7 +74665,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.677Z",
+          "evaluatedAt": "2026-05-05T23:45:45.695Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -67605,7 +74729,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.678Z",
+        "evaluatedAt": "2026-05-05T23:45:45.696Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -67660,7 +74784,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.678Z",
+          "evaluatedAt": "2026-05-05T23:45:45.696Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -67678,7 +74802,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.678Z",
+          "evaluatedAt": "2026-05-05T23:45:45.696Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -67691,8 +74815,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/tech-stack-evaluator",
-      "relPath": ".gemini/skills/tech-stack-evaluator",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/tech-stack-evaluator",
+      "relPath": "engineering-team/skills/tech-stack-evaluator",
       "verified": true,
       "tokenCount": 1008,
       "evalSummary": {
@@ -67742,7 +74866,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.679Z",
+        "evaluatedAt": "2026-05-05T23:45:45.697Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -67797,7 +74921,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.679Z",
+          "evaluatedAt": "2026-05-05T23:45:45.697Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -67815,7 +74939,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.679Z",
+          "evaluatedAt": "2026-05-05T23:45:45.697Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -67828,8 +74952,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/terraform-patterns",
-      "relPath": ".codex/skills/terraform-patterns",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/terraform-patterns/skills/terraform-patterns",
+      "relPath": ".codex/skills/terraform-patterns/skills/terraform-patterns",
       "verified": true,
       "tokenCount": 6331,
       "evalSummary": {
@@ -67879,7 +75003,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.682Z",
+        "evaluatedAt": "2026-05-05T23:45:45.699Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -67934,7 +75058,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.682Z",
+          "evaluatedAt": "2026-05-05T23:45:45.699Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -67952,7 +75076,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.682Z",
+          "evaluatedAt": "2026-05-05T23:45:45.699Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -67965,8 +75089,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/terraform-patterns",
-      "relPath": ".gemini/skills/terraform-patterns",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering/terraform-patterns/skills/terraform-patterns",
+      "relPath": "engineering/terraform-patterns/skills/terraform-patterns",
       "verified": true,
       "tokenCount": 6331,
       "evalSummary": {
@@ -68016,7 +75140,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.685Z",
+        "evaluatedAt": "2026-05-05T23:45:45.703Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -68071,7 +75195,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.685Z",
+          "evaluatedAt": "2026-05-05T23:45:45.703Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -68089,8 +75213,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.685Z",
+          "evaluatedAt": "2026-05-05T23:45:45.703Z",
           "evaluatedVersion": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "testrail",
+      "description": "Sync tests with TestRail. Use when user mentions \"testrail\", \"test management\", \"test cases\", \"test run\", \"sync test cases\", \"push results to testrail\", or \"import from testrail\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/playwright-pro/skills/testrail",
+      "relPath": ".codex/skills/playwright-pro/skills/testrail",
+      "verified": true,
+      "tokenCount": 949,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.705Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 80,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.705Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.705Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -68153,7 +75414,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.688Z",
+        "evaluatedAt": "2026-05-05T23:45:45.706Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -68208,7 +75469,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.688Z",
+          "evaluatedAt": "2026-05-05T23:45:45.706Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -68226,7 +75487,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.688Z",
+          "evaluatedAt": "2026-05-05T23:45:45.706Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "testrail",
+      "description": "Sync tests with TestRail. Use when user mentions \"testrail\", \"test management\", \"test cases\", \"test run\", \"sync test cases\", \"push results to testrail\", or \"import from testrail\".",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/playwright-pro/skills/testrail",
+      "relPath": "engineering-team/playwright-pro/skills/testrail",
+      "verified": true,
+      "tokenCount": 949,
+      "evalSummary": {
+        "overallScore": 80,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:45.707Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 80,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.707Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:45.707Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -68290,7 +75688,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.689Z",
+        "evaluatedAt": "2026-05-05T23:45:45.709Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -68345,7 +75743,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.689Z",
+          "evaluatedAt": "2026-05-05T23:45:45.709Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -68363,7 +75761,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.689Z",
+          "evaluatedAt": "2026-05-05T23:45:45.709Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -68376,8 +75774,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/threat-detection",
-      "relPath": ".gemini/skills/threat-detection",
+      "installUrl": "github:alirezarezvani/claude-skills:engineering-team/skills/threat-detection",
+      "relPath": "engineering-team/skills/threat-detection",
       "verified": true,
       "tokenCount": 3798,
       "evalSummary": {
@@ -68427,7 +75825,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.692Z",
+        "evaluatedAt": "2026-05-05T23:45:45.711Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -68482,7 +75880,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.692Z",
+          "evaluatedAt": "2026-05-05T23:45:45.711Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -68500,7 +75898,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.692Z",
+          "evaluatedAt": "2026-05-05T23:45:45.711Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -68564,7 +75962,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.694Z",
+        "evaluatedAt": "2026-05-05T23:45:45.713Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -68619,7 +76017,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.694Z",
+          "evaluatedAt": "2026-05-05T23:45:45.713Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -68637,7 +76035,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.694Z",
+          "evaluatedAt": "2026-05-05T23:45:45.713Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -68650,8 +76048,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ui-design-system",
-      "relPath": ".gemini/skills/ui-design-system",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/ui-design-system",
+      "relPath": "product-team/skills/ui-design-system",
       "verified": true,
       "tokenCount": 3181,
       "evalSummary": {
@@ -68701,7 +76099,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.696Z",
+        "evaluatedAt": "2026-05-05T23:45:45.715Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -68756,7 +76154,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.696Z",
+          "evaluatedAt": "2026-05-05T23:45:45.715Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -68774,7 +76172,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.696Z",
+          "evaluatedAt": "2026-05-05T23:45:45.715Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -68838,7 +76236,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.697Z",
+        "evaluatedAt": "2026-05-05T23:45:45.716Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -68893,7 +76291,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.697Z",
+          "evaluatedAt": "2026-05-05T23:45:45.716Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -68911,7 +76309,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.697Z",
+          "evaluatedAt": "2026-05-05T23:45:45.716Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -68975,7 +76373,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.699Z",
+        "evaluatedAt": "2026-05-05T23:45:45.717Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -69030,7 +76428,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.699Z",
+          "evaluatedAt": "2026-05-05T23:45:45.717Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -69048,7 +76446,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.699Z",
+          "evaluatedAt": "2026-05-05T23:45:45.717Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -69061,8 +76459,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/ux-researcher-designer",
-      "relPath": ".gemini/skills/ux-researcher-designer",
+      "installUrl": "github:alirezarezvani/claude-skills:product-team/skills/ux-researcher-designer",
+      "relPath": "product-team/skills/ux-researcher-designer",
       "verified": true,
       "tokenCount": 3573,
       "evalSummary": {
@@ -69112,7 +76510,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.701Z",
+        "evaluatedAt": "2026-05-05T23:45:45.719Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -69167,7 +76565,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.701Z",
+          "evaluatedAt": "2026-05-05T23:45:45.719Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -69185,7 +76583,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.701Z",
+          "evaluatedAt": "2026-05-05T23:45:45.719Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -69198,8 +76596,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/video-content-strategist",
-      "relPath": ".codex/skills/video-content-strategist",
+      "installUrl": "github:alirezarezvani/claude-skills:.codex/skills/video-content-strategist/skills/video-content-strategist",
+      "relPath": ".codex/skills/video-content-strategist/skills/video-content-strategist",
       "verified": true,
       "tokenCount": 3402,
       "evalSummary": {
@@ -69249,7 +76647,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.703Z",
+        "evaluatedAt": "2026-05-05T23:45:45.721Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -69304,7 +76702,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.703Z",
+          "evaluatedAt": "2026-05-05T23:45:45.721Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -69322,7 +76720,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.703Z",
+          "evaluatedAt": "2026-05-05T23:45:45.721Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -69335,8 +76733,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/video-content-strategist",
-      "relPath": ".gemini/skills/video-content-strategist",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/video-content-strategist/skills/video-content-strategist",
+      "relPath": "marketing-skill/video-content-strategist/skills/video-content-strategist",
       "verified": true,
       "tokenCount": 3402,
       "evalSummary": {
@@ -69386,7 +76784,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.705Z",
+        "evaluatedAt": "2026-05-05T23:45:45.723Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -69441,7 +76839,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.705Z",
+          "evaluatedAt": "2026-05-05T23:45:45.723Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -69459,7 +76857,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.705Z",
+          "evaluatedAt": "2026-05-05T23:45:45.723Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -69523,7 +76921,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.706Z",
+        "evaluatedAt": "2026-05-05T23:45:45.725Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -69578,7 +76976,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.706Z",
+          "evaluatedAt": "2026-05-05T23:45:45.725Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -69596,7 +76994,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.707Z",
+          "evaluatedAt": "2026-05-05T23:45:45.725Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -69660,7 +77058,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.707Z",
+        "evaluatedAt": "2026-05-05T23:45:45.725Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -69715,7 +77113,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.707Z",
+          "evaluatedAt": "2026-05-05T23:45:45.725Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -69733,7 +77131,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.707Z",
+          "evaluatedAt": "2026-05-05T23:45:45.725Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -69797,7 +77195,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.708Z",
+        "evaluatedAt": "2026-05-05T23:45:45.726Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -69852,7 +77250,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.708Z",
+          "evaluatedAt": "2026-05-05T23:45:45.726Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -69870,7 +77268,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.708Z",
+          "evaluatedAt": "2026-05-05T23:45:45.726Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -69934,7 +77332,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.709Z",
+        "evaluatedAt": "2026-05-05T23:45:45.727Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -69989,7 +77387,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.709Z",
+          "evaluatedAt": "2026-05-05T23:45:45.727Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -70007,7 +77405,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.709Z",
+          "evaluatedAt": "2026-05-05T23:45:45.727Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -70071,7 +77469,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.710Z",
+        "evaluatedAt": "2026-05-05T23:45:45.727Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -70126,7 +77524,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.710Z",
+          "evaluatedAt": "2026-05-05T23:45:45.727Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -70144,7 +77542,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.710Z",
+          "evaluatedAt": "2026-05-05T23:45:45.727Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -70208,7 +77606,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.711Z",
+        "evaluatedAt": "2026-05-05T23:45:45.729Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -70263,7 +77661,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.711Z",
+          "evaluatedAt": "2026-05-05T23:45:45.729Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -70281,7 +77679,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.711Z",
+          "evaluatedAt": "2026-05-05T23:45:45.729Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -70294,8 +77692,8 @@
       "creator": "",
       "compatibility": "",
       "allowedTools": [],
-      "installUrl": "github:alirezarezvani/claude-skills:.gemini/skills/x-twitter-growth",
-      "relPath": ".gemini/skills/x-twitter-growth",
+      "installUrl": "github:alirezarezvani/claude-skills:marketing-skill/skills/x-twitter-growth",
+      "relPath": "marketing-skill/skills/x-twitter-growth",
       "verified": true,
       "tokenCount": 2569,
       "evalSummary": {
@@ -70345,7 +77743,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:32.713Z",
+        "evaluatedAt": "2026-05-05T23:45:45.730Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -70400,7 +77798,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.713Z",
+          "evaluatedAt": "2026-05-05T23:45:45.730Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -70418,7 +77816,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:32.713Z",
+          "evaluatedAt": "2026-05-05T23:45:45.730Z",
           "evaluatedVersion": "1.0.0"
         }
       }

--- a/data/skill-index/anthropics_skills.json
+++ b/data/skill-index/anthropics_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/anthropics/skills.git",
   "owner": "anthropics",
   "repo": "skills",
-  "updatedAt": "2026-04-30T23:04:50.667Z",
+  "updatedAt": "2026-05-05T23:45:04.039Z",
   "skillCount": 18,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.618Z",
+        "evaluatedAt": "2026-05-05T23:45:03.994Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.620Z",
+          "evaluatedAt": "2026-05-05T23:45:03.995Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.621Z",
+          "evaluatedAt": "2026-05-05T23:45:03.997Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.628Z",
+        "evaluatedAt": "2026-05-05T23:45:04.003Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.629Z",
+          "evaluatedAt": "2026-05-05T23:45:04.003Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.629Z",
+          "evaluatedAt": "2026-05-05T23:45:04.003Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.631Z",
+        "evaluatedAt": "2026-05-05T23:45:04.005Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.631Z",
+          "evaluatedAt": "2026-05-05T23:45:04.005Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.631Z",
+          "evaluatedAt": "2026-05-05T23:45:04.005Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.635Z",
+        "evaluatedAt": "2026-05-05T23:45:04.009Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.635Z",
+          "evaluatedAt": "2026-05-05T23:45:04.009Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.636Z",
+          "evaluatedAt": "2026-05-05T23:45:04.009Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.640Z",
+        "evaluatedAt": "2026-05-05T23:45:04.013Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.640Z",
+          "evaluatedAt": "2026-05-05T23:45:04.013Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.640Z",
+          "evaluatedAt": "2026-05-05T23:45:04.013Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.643Z",
+        "evaluatedAt": "2026-05-05T23:45:04.016Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.643Z",
+          "evaluatedAt": "2026-05-05T23:45:04.016Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.643Z",
+          "evaluatedAt": "2026-05-05T23:45:04.016Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.646Z",
+        "evaluatedAt": "2026-05-05T23:45:04.019Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.646Z",
+          "evaluatedAt": "2026-05-05T23:45:04.019Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.646Z",
+          "evaluatedAt": "2026-05-05T23:45:04.019Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.647Z",
+        "evaluatedAt": "2026-05-05T23:45:04.020Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.647Z",
+          "evaluatedAt": "2026-05-05T23:45:04.020Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.647Z",
+          "evaluatedAt": "2026-05-05T23:45:04.020Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.648Z",
+        "evaluatedAt": "2026-05-05T23:45:04.021Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.648Z",
+          "evaluatedAt": "2026-05-05T23:45:04.021Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.648Z",
+          "evaluatedAt": "2026-05-05T23:45:04.021Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.651Z",
+        "evaluatedAt": "2026-05-05T23:45:04.023Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.651Z",
+          "evaluatedAt": "2026-05-05T23:45:04.024Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.651Z",
+          "evaluatedAt": "2026-05-05T23:45:04.024Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.653Z",
+        "evaluatedAt": "2026-05-05T23:45:04.025Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.653Z",
+          "evaluatedAt": "2026-05-05T23:45:04.026Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.653Z",
+          "evaluatedAt": "2026-05-05T23:45:04.026Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.657Z",
+        "evaluatedAt": "2026-05-05T23:45:04.029Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.657Z",
+          "evaluatedAt": "2026-05-05T23:45:04.029Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.657Z",
+          "evaluatedAt": "2026-05-05T23:45:04.029Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.660Z",
+        "evaluatedAt": "2026-05-05T23:45:04.032Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.660Z",
+          "evaluatedAt": "2026-05-05T23:45:04.032Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.660Z",
+          "evaluatedAt": "2026-05-05T23:45:04.032Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.662Z",
+        "evaluatedAt": "2026-05-05T23:45:04.033Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.662Z",
+          "evaluatedAt": "2026-05-05T23:45:04.033Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.662Z",
+          "evaluatedAt": "2026-05-05T23:45:04.033Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.662Z",
+        "evaluatedAt": "2026-05-05T23:45:04.034Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.662Z",
+          "evaluatedAt": "2026-05-05T23:45:04.034Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.662Z",
+          "evaluatedAt": "2026-05-05T23:45:04.034Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.663Z",
+        "evaluatedAt": "2026-05-05T23:45:04.035Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.663Z",
+          "evaluatedAt": "2026-05-05T23:45:04.035Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.663Z",
+          "evaluatedAt": "2026-05-05T23:45:04.035Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.665Z",
+        "evaluatedAt": "2026-05-05T23:45:04.036Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.665Z",
+          "evaluatedAt": "2026-05-05T23:45:04.036Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.665Z",
+          "evaluatedAt": "2026-05-05T23:45:04.036Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:50.666Z",
+        "evaluatedAt": "2026-05-05T23:45:04.038Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.666Z",
+          "evaluatedAt": "2026-05-05T23:45:04.038Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:50.666Z",
+          "evaluatedAt": "2026-05-05T23:45:04.038Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/antonbabenko_terraform-skill.json
+++ b/data/skill-index/antonbabenko_terraform-skill.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/antonbabenko/terraform-skill.git",
   "owner": "antonbabenko",
   "repo": "terraform-skill",
-  "updatedAt": "2026-04-30T23:05:44.906Z",
+  "updatedAt": "2026-05-05T23:45:58.244Z",
   "skillCount": 1,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.905Z",
+        "evaluatedAt": "2026-05-05T23:45:58.243Z",
         "evaluatedVersion": "1.8.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.905Z",
+          "evaluatedAt": "2026-05-05T23:45:58.243Z",
           "evaluatedVersion": "1.8.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.905Z",
+          "evaluatedAt": "2026-05-05T23:45:58.243Z",
           "evaluatedVersion": "1.8.0"
         }
       }

--- a/data/skill-index/bytedance_deer-flow.json
+++ b/data/skill-index/bytedance_deer-flow.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/bytedance/deer-flow.git",
   "owner": "bytedance",
   "repo": "deer-flow",
-  "updatedAt": "2026-04-30T23:05:21.560Z",
+  "updatedAt": "2026-05-05T23:45:34.246Z",
   "skillCount": 22,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.518Z",
+        "evaluatedAt": "2026-05-05T23:45:34.205Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.518Z",
+          "evaluatedAt": "2026-05-05T23:45:34.205Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.518Z",
+          "evaluatedAt": "2026-05-05T23:45:34.205Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.520Z",
+        "evaluatedAt": "2026-05-05T23:45:34.206Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.520Z",
+          "evaluatedAt": "2026-05-05T23:45:34.206Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.520Z",
+          "evaluatedAt": "2026-05-05T23:45:34.206Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.521Z",
+        "evaluatedAt": "2026-05-05T23:45:34.207Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.521Z",
+          "evaluatedAt": "2026-05-05T23:45:34.207Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.521Z",
+          "evaluatedAt": "2026-05-05T23:45:34.207Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.522Z",
+        "evaluatedAt": "2026-05-05T23:45:34.208Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.522Z",
+          "evaluatedAt": "2026-05-05T23:45:34.208Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.522Z",
+          "evaluatedAt": "2026-05-05T23:45:34.208Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.524Z",
+        "evaluatedAt": "2026-05-05T23:45:34.210Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.524Z",
+          "evaluatedAt": "2026-05-05T23:45:34.210Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.524Z",
+          "evaluatedAt": "2026-05-05T23:45:34.210Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.528Z",
+        "evaluatedAt": "2026-05-05T23:45:34.214Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.528Z",
+          "evaluatedAt": "2026-05-05T23:45:34.214Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.528Z",
+          "evaluatedAt": "2026-05-05T23:45:34.214Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.531Z",
+        "evaluatedAt": "2026-05-05T23:45:34.217Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.531Z",
+          "evaluatedAt": "2026-05-05T23:45:34.217Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.531Z",
+          "evaluatedAt": "2026-05-05T23:45:34.217Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.533Z",
+        "evaluatedAt": "2026-05-05T23:45:34.219Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.533Z",
+          "evaluatedAt": "2026-05-05T23:45:34.219Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.533Z",
+          "evaluatedAt": "2026-05-05T23:45:34.219Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.534Z",
+        "evaluatedAt": "2026-05-05T23:45:34.220Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.534Z",
+          "evaluatedAt": "2026-05-05T23:45:34.220Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.534Z",
+          "evaluatedAt": "2026-05-05T23:45:34.220Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.536Z",
+        "evaluatedAt": "2026-05-05T23:45:34.221Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.536Z",
+          "evaluatedAt": "2026-05-05T23:45:34.221Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.536Z",
+          "evaluatedAt": "2026-05-05T23:45:34.221Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.537Z",
+        "evaluatedAt": "2026-05-05T23:45:34.222Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.537Z",
+          "evaluatedAt": "2026-05-05T23:45:34.222Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.537Z",
+          "evaluatedAt": "2026-05-05T23:45:34.222Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.538Z",
+        "evaluatedAt": "2026-05-05T23:45:34.224Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.538Z",
+          "evaluatedAt": "2026-05-05T23:45:34.224Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.538Z",
+          "evaluatedAt": "2026-05-05T23:45:34.224Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.540Z",
+        "evaluatedAt": "2026-05-05T23:45:34.226Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.540Z",
+          "evaluatedAt": "2026-05-05T23:45:34.226Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.540Z",
+          "evaluatedAt": "2026-05-05T23:45:34.226Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.542Z",
+        "evaluatedAt": "2026-05-05T23:45:34.227Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.542Z",
+          "evaluatedAt": "2026-05-05T23:45:34.227Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.542Z",
+          "evaluatedAt": "2026-05-05T23:45:34.227Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.545Z",
+        "evaluatedAt": "2026-05-05T23:45:34.230Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.545Z",
+          "evaluatedAt": "2026-05-05T23:45:34.230Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.545Z",
+          "evaluatedAt": "2026-05-05T23:45:34.230Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.550Z",
+        "evaluatedAt": "2026-05-05T23:45:34.235Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.550Z",
+          "evaluatedAt": "2026-05-05T23:45:34.235Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.550Z",
+          "evaluatedAt": "2026-05-05T23:45:34.236Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.553Z",
+        "evaluatedAt": "2026-05-05T23:45:34.238Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.553Z",
+          "evaluatedAt": "2026-05-05T23:45:34.238Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 2
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.553Z",
+          "evaluatedAt": "2026-05-05T23:45:34.238Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.555Z",
+        "evaluatedAt": "2026-05-05T23:45:34.240Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.555Z",
+          "evaluatedAt": "2026-05-05T23:45:34.240Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.555Z",
+          "evaluatedAt": "2026-05-05T23:45:34.240Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.556Z",
+        "evaluatedAt": "2026-05-05T23:45:34.242Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.557Z",
+          "evaluatedAt": "2026-05-05T23:45:34.242Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.557Z",
+          "evaluatedAt": "2026-05-05T23:45:34.242Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.558Z",
+        "evaluatedAt": "2026-05-05T23:45:34.244Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.558Z",
+          "evaluatedAt": "2026-05-05T23:45:34.244Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.558Z",
+          "evaluatedAt": "2026-05-05T23:45:34.244Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.559Z",
+        "evaluatedAt": "2026-05-05T23:45:34.245Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.559Z",
+          "evaluatedAt": "2026-05-05T23:45:34.245Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.559Z",
+          "evaluatedAt": "2026-05-05T23:45:34.245Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:21.560Z",
+        "evaluatedAt": "2026-05-05T23:45:34.245Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.560Z",
+          "evaluatedAt": "2026-05-05T23:45:34.245Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:21.560Z",
+          "evaluatedAt": "2026-05-05T23:45:34.245Z",
           "evaluatedVersion": "1.0.0"
         }
       }

--- a/data/skill-index/coreyhaines31_marketingskills.json
+++ b/data/skill-index/coreyhaines31_marketingskills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/coreyhaines31/marketingskills.git",
   "owner": "coreyhaines31",
   "repo": "marketingskills",
-  "updatedAt": "2026-04-30T23:05:10.545Z",
+  "updatedAt": "2026-05-05T23:45:23.300Z",
   "skillCount": 40,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.458Z",
+        "evaluatedAt": "2026-05-05T23:45:23.216Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.458Z",
+          "evaluatedAt": "2026-05-05T23:45:23.216Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.458Z",
+          "evaluatedAt": "2026-05-05T23:45:23.216Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.461Z",
+        "evaluatedAt": "2026-05-05T23:45:23.219Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.461Z",
+          "evaluatedAt": "2026-05-05T23:45:23.219Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.461Z",
+          "evaluatedAt": "2026-05-05T23:45:23.219Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.463Z",
+        "evaluatedAt": "2026-05-05T23:45:23.222Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.463Z",
+          "evaluatedAt": "2026-05-05T23:45:23.222Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.464Z",
+          "evaluatedAt": "2026-05-05T23:45:23.222Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.466Z",
+        "evaluatedAt": "2026-05-05T23:45:23.224Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.466Z",
+          "evaluatedAt": "2026-05-05T23:45:23.224Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.466Z",
+          "evaluatedAt": "2026-05-05T23:45:23.224Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.468Z",
+        "evaluatedAt": "2026-05-05T23:45:23.227Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.468Z",
+          "evaluatedAt": "2026-05-05T23:45:23.227Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.468Z",
+          "evaluatedAt": "2026-05-05T23:45:23.227Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.471Z",
+        "evaluatedAt": "2026-05-05T23:45:23.229Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.471Z",
+          "evaluatedAt": "2026-05-05T23:45:23.230Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.471Z",
+          "evaluatedAt": "2026-05-05T23:45:23.230Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.473Z",
+        "evaluatedAt": "2026-05-05T23:45:23.232Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.473Z",
+          "evaluatedAt": "2026-05-05T23:45:23.232Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.473Z",
+          "evaluatedAt": "2026-05-05T23:45:23.232Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.475Z",
+        "evaluatedAt": "2026-05-05T23:45:23.233Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.475Z",
+          "evaluatedAt": "2026-05-05T23:45:23.233Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.475Z",
+          "evaluatedAt": "2026-05-05T23:45:23.233Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.477Z",
+        "evaluatedAt": "2026-05-05T23:45:23.235Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.477Z",
+          "evaluatedAt": "2026-05-05T23:45:23.235Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.477Z",
+          "evaluatedAt": "2026-05-05T23:45:23.235Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.479Z",
+        "evaluatedAt": "2026-05-05T23:45:23.237Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.479Z",
+          "evaluatedAt": "2026-05-05T23:45:23.237Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.479Z",
+          "evaluatedAt": "2026-05-05T23:45:23.237Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.482Z",
+        "evaluatedAt": "2026-05-05T23:45:23.240Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.482Z",
+          "evaluatedAt": "2026-05-05T23:45:23.240Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.482Z",
+          "evaluatedAt": "2026-05-05T23:45:23.240Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.484Z",
+        "evaluatedAt": "2026-05-05T23:45:23.242Z",
         "evaluatedVersion": "1.3.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.484Z",
+          "evaluatedAt": "2026-05-05T23:45:23.243Z",
           "evaluatedVersion": "1.3.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.484Z",
+          "evaluatedAt": "2026-05-05T23:45:23.243Z",
           "evaluatedVersion": "1.3.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.486Z",
+        "evaluatedAt": "2026-05-05T23:45:23.245Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.487Z",
+          "evaluatedAt": "2026-05-05T23:45:23.245Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.487Z",
+          "evaluatedAt": "2026-05-05T23:45:23.245Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.488Z",
+        "evaluatedAt": "2026-05-05T23:45:23.247Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.488Z",
+          "evaluatedAt": "2026-05-05T23:45:23.247Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.488Z",
+          "evaluatedAt": "2026-05-05T23:45:23.247Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.491Z",
+        "evaluatedAt": "2026-05-05T23:45:23.250Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.492Z",
+          "evaluatedAt": "2026-05-05T23:45:23.250Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.492Z",
+          "evaluatedAt": "2026-05-05T23:45:23.250Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.494Z",
+        "evaluatedAt": "2026-05-05T23:45:23.252Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.494Z",
+          "evaluatedAt": "2026-05-05T23:45:23.253Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.494Z",
+          "evaluatedAt": "2026-05-05T23:45:23.253Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.496Z",
+        "evaluatedAt": "2026-05-05T23:45:23.255Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.496Z",
+          "evaluatedAt": "2026-05-05T23:45:23.255Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.496Z",
+          "evaluatedAt": "2026-05-05T23:45:23.255Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.498Z",
+        "evaluatedAt": "2026-05-05T23:45:23.256Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.498Z",
+          "evaluatedAt": "2026-05-05T23:45:23.257Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.498Z",
+          "evaluatedAt": "2026-05-05T23:45:23.257Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.500Z",
+        "evaluatedAt": "2026-05-05T23:45:23.258Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.500Z",
+          "evaluatedAt": "2026-05-05T23:45:23.258Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.500Z",
+          "evaluatedAt": "2026-05-05T23:45:23.258Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.502Z",
+        "evaluatedAt": "2026-05-05T23:45:23.261Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.503Z",
+          "evaluatedAt": "2026-05-05T23:45:23.261Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.503Z",
+          "evaluatedAt": "2026-05-05T23:45:23.261Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.505Z",
+        "evaluatedAt": "2026-05-05T23:45:23.263Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.505Z",
+          "evaluatedAt": "2026-05-05T23:45:23.263Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.505Z",
+          "evaluatedAt": "2026-05-05T23:45:23.263Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.507Z",
+        "evaluatedAt": "2026-05-05T23:45:23.265Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.507Z",
+          "evaluatedAt": "2026-05-05T23:45:23.265Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.507Z",
+          "evaluatedAt": "2026-05-05T23:45:23.265Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3078,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.509Z",
+        "evaluatedAt": "2026-05-05T23:45:23.267Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3133,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.509Z",
+          "evaluatedAt": "2026-05-05T23:45:23.267Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3151,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.509Z",
+          "evaluatedAt": "2026-05-05T23:45:23.267Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3215,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.512Z",
+        "evaluatedAt": "2026-05-05T23:45:23.269Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3270,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.512Z",
+          "evaluatedAt": "2026-05-05T23:45:23.269Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3288,7 +3288,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.512Z",
+          "evaluatedAt": "2026-05-05T23:45:23.269Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3352,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.513Z",
+        "evaluatedAt": "2026-05-05T23:45:23.271Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3407,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.513Z",
+          "evaluatedAt": "2026-05-05T23:45:23.271Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3425,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.513Z",
+          "evaluatedAt": "2026-05-05T23:45:23.271Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3489,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.515Z",
+        "evaluatedAt": "2026-05-05T23:45:23.272Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -3544,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.515Z",
+          "evaluatedAt": "2026-05-05T23:45:23.272Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -3562,7 +3562,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.515Z",
+          "evaluatedAt": "2026-05-05T23:45:23.273Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -3626,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.517Z",
+        "evaluatedAt": "2026-05-05T23:45:23.274Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3681,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.517Z",
+          "evaluatedAt": "2026-05-05T23:45:23.274Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3699,7 +3699,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.517Z",
+          "evaluatedAt": "2026-05-05T23:45:23.274Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3763,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.519Z",
+        "evaluatedAt": "2026-05-05T23:45:23.276Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3818,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.519Z",
+          "evaluatedAt": "2026-05-05T23:45:23.276Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3836,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.519Z",
+          "evaluatedAt": "2026-05-05T23:45:23.276Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3900,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.520Z",
+        "evaluatedAt": "2026-05-05T23:45:23.278Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3955,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.521Z",
+          "evaluatedAt": "2026-05-05T23:45:23.278Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3973,7 +3973,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.521Z",
+          "evaluatedAt": "2026-05-05T23:45:23.278Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4037,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.522Z",
+        "evaluatedAt": "2026-05-05T23:45:23.279Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4092,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.522Z",
+          "evaluatedAt": "2026-05-05T23:45:23.279Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4110,7 +4110,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.522Z",
+          "evaluatedAt": "2026-05-05T23:45:23.279Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4174,7 +4174,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.524Z",
+        "evaluatedAt": "2026-05-05T23:45:23.281Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4229,7 +4229,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.524Z",
+          "evaluatedAt": "2026-05-05T23:45:23.281Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4247,7 +4247,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.524Z",
+          "evaluatedAt": "2026-05-05T23:45:23.281Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4311,7 +4311,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.525Z",
+        "evaluatedAt": "2026-05-05T23:45:23.282Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4366,7 +4366,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.525Z",
+          "evaluatedAt": "2026-05-05T23:45:23.282Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4384,7 +4384,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.525Z",
+          "evaluatedAt": "2026-05-05T23:45:23.282Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4448,7 +4448,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.528Z",
+        "evaluatedAt": "2026-05-05T23:45:23.284Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4503,7 +4503,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.528Z",
+          "evaluatedAt": "2026-05-05T23:45:23.284Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4521,7 +4521,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.528Z",
+          "evaluatedAt": "2026-05-05T23:45:23.284Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4585,7 +4585,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.530Z",
+        "evaluatedAt": "2026-05-05T23:45:23.287Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4640,7 +4640,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.530Z",
+          "evaluatedAt": "2026-05-05T23:45:23.287Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4658,7 +4658,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.530Z",
+          "evaluatedAt": "2026-05-05T23:45:23.287Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4722,7 +4722,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.532Z",
+        "evaluatedAt": "2026-05-05T23:45:23.288Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4777,7 +4777,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.532Z",
+          "evaluatedAt": "2026-05-05T23:45:23.288Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4795,7 +4795,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.532Z",
+          "evaluatedAt": "2026-05-05T23:45:23.288Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4859,7 +4859,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.534Z",
+        "evaluatedAt": "2026-05-05T23:45:23.290Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -4914,7 +4914,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.534Z",
+          "evaluatedAt": "2026-05-05T23:45:23.290Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -4932,7 +4932,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.534Z",
+          "evaluatedAt": "2026-05-05T23:45:23.290Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -4996,7 +4996,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.536Z",
+        "evaluatedAt": "2026-05-05T23:45:23.292Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -5051,7 +5051,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.536Z",
+          "evaluatedAt": "2026-05-05T23:45:23.292Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -5069,7 +5069,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.536Z",
+          "evaluatedAt": "2026-05-05T23:45:23.292Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -5133,7 +5133,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.539Z",
+        "evaluatedAt": "2026-05-05T23:45:23.294Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -5188,7 +5188,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.539Z",
+          "evaluatedAt": "2026-05-05T23:45:23.294Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -5206,7 +5206,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.539Z",
+          "evaluatedAt": "2026-05-05T23:45:23.294Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -5270,7 +5270,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.541Z",
+        "evaluatedAt": "2026-05-05T23:45:23.297Z",
         "evaluatedVersion": "1.3.0"
       },
       "evalSummaries": {
@@ -5325,7 +5325,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.541Z",
+          "evaluatedAt": "2026-05-05T23:45:23.297Z",
           "evaluatedVersion": "1.3.0"
         },
         "skill-best-practice": {
@@ -5343,7 +5343,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.541Z",
+          "evaluatedAt": "2026-05-05T23:45:23.297Z",
           "evaluatedVersion": "1.3.0"
         }
       }
@@ -5407,7 +5407,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:10.543Z",
+        "evaluatedAt": "2026-05-05T23:45:23.299Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -5462,7 +5462,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.544Z",
+          "evaluatedAt": "2026-05-05T23:45:23.299Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -5480,7 +5480,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:10.544Z",
+          "evaluatedAt": "2026-05-05T23:45:23.299Z",
           "evaluatedVersion": "1.0.0"
         }
       }

--- a/data/skill-index/entireio_skills.json
+++ b/data/skill-index/entireio_skills.json
@@ -1,0 +1,694 @@
+{
+  "repoUrl": "https://github.com/entireio/skills.git",
+  "owner": "entireio",
+  "repo": "skills",
+  "updatedAt": "2026-05-05T23:46:00.536Z",
+  "skillCount": 5,
+  "skills": [
+    {
+      "name": "explain",
+      "description": "Explains the intent behind source code by finding original session transcripts. Use explain with a function, file, or line of code to understand why it exists.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:entireio/skills:skills/explain",
+      "relPath": "skills/explain",
+      "verified": true,
+      "tokenCount": 724,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:46:00.529Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 66,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:46:00.529Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:46:00.529Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "search",
+      "description": "Use when the user wants to find prior work, checkpoints, or agent conversations by topic, repo, branch, author, or recent time window",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:entireio/skills:skills/search",
+      "relPath": "skills/search",
+      "verified": true,
+      "tokenCount": 815,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:46:00.530Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 66,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:46:00.530Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:46:00.530Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "session-handoff",
+      "description": "Use when the user wants to continue work from one agent in another agent, inspect recent sessions, or summarize a saved session or checkpoint for handoff",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:entireio/skills:skills/session-handoff",
+      "relPath": "skills/session-handoff",
+      "verified": true,
+      "tokenCount": 1927,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:46:00.531Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 70,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:46:00.531Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:46:00.531Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "session-to-skill",
+      "description": "Use when the user wants to turn one or more Entire-tracked sessions, checkpoints, or repeated agent workflows into a reusable agent skill.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:entireio/skills:skills/session-to-skill",
+      "relPath": "skills/session-to-skill",
+      "verified": true,
+      "tokenCount": 2425,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:46:00.532Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 81,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:46:00.532Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:46:00.532Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "What Happened",
+      "description": "Explain why code looks the way it does by tracing the latest change for a file range or pasted snippet through `git blame` and deduplicated `entire explain` lookups. Use when the user asks what happened, says \"tell me why\" about a code block, is confused about a section of code, asks \"wtf is going on\", \"why is this like this\", \"why was this changed\", or wants provenance for a specific file block.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:entireio/skills:skills/what-happened",
+      "relPath": "skills/what-happened",
+      "verified": true,
+      "tokenCount": 4471,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 5,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:46:00.534Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 61,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 5,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:46:00.534Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 54,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 7,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:46:00.535Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    }
+  ]
+}

--- a/data/skill-index/github_awesome-copilot.json
+++ b/data/skill-index/github_awesome-copilot.json
@@ -2,8 +2,8 @@
   "repoUrl": "https://github.com/github/awesome-copilot.git",
   "owner": "github",
   "repo": "awesome-copilot",
-  "updatedAt": "2026-04-30T23:05:30.066Z",
-  "skillCount": 459,
+  "updatedAt": "2026-05-05T23:45:43.014Z",
+  "skillCount": 478,
   "skills": [
     {
       "name": "acquire-codebase-knowledge",
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.375Z",
+        "evaluatedAt": "2026-05-05T23:45:42.276Z",
         "evaluatedVersion": "1.3"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.375Z",
+          "evaluatedAt": "2026-05-05T23:45:42.276Z",
           "evaluatedVersion": "1.3"
         },
         "skill-best-practice": {
@@ -137,8 +137,830 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.375Z",
+          "evaluatedAt": "2026-05-05T23:45:42.276Z",
           "evaluatedVersion": "1.3"
+        }
+      }
+    },
+    {
+      "name": "acreadiness-assess",
+      "description": "Run the AgentRC readiness assessment on the current repository and produce a static HTML dashboard at reports/index.html. Wraps `npx github:microsoft/agentrc readiness` and hands off rendering to the @ai-readiness-reporter custom agent. Supports policies (--policy) for org-specific scoring. Use when asked to assess, audit, or score the AI readiness of a repo.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:plugins/acreadiness-cockpit/skills/acreadiness-assess",
+      "relPath": "plugins/acreadiness-cockpit/skills/acreadiness-assess",
+      "verified": true,
+      "tokenCount": 970,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.278Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 73,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.278Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.278Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "acreadiness-assess",
+      "description": "Run the AgentRC readiness assessment on the current repository and produce a static HTML dashboard at reports/index.html. Wraps `npx github:microsoft/agentrc readiness` and hands off rendering to the @ai-readiness-reporter custom agent. Supports policies (--policy) for org-specific scoring. Use when asked to assess, audit, or score the AI readiness of a repo.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:skills/acreadiness-assess",
+      "relPath": "skills/acreadiness-assess",
+      "verified": true,
+      "tokenCount": 970,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.279Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 73,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.279Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.279Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "acreadiness-generate-instructions",
+      "description": "Generate tailored AI agent instruction files via AgentRC instructions command. Produces .github/copilot-instructions.md (default, recommended for Copilot in VS Code) plus optional per-area .instructions.md files with applyTo globs for monorepos. Use after running /acreadiness-assess to close gaps in the AI Tooling pillar.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:plugins/acreadiness-cockpit/skills/acreadiness-generate-instructions",
+      "relPath": "plugins/acreadiness-cockpit/skills/acreadiness-generate-instructions",
+      "verified": true,
+      "tokenCount": 2149,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.280Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 73,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.280Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.280Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "acreadiness-generate-instructions",
+      "description": "Generate tailored AI agent instruction files via AgentRC instructions command. Produces .github/copilot-instructions.md (default, recommended for Copilot in VS Code) plus optional per-area .instructions.md files with applyTo globs for monorepos. Use after running /acreadiness-assess to close gaps in the AI Tooling pillar.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:skills/acreadiness-generate-instructions",
+      "relPath": "skills/acreadiness-generate-instructions",
+      "verified": true,
+      "tokenCount": 2149,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.282Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 73,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.282Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.282Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "acreadiness-policy",
+      "description": "Help the user pick, write, or apply an AgentRC policy. Policies customise readiness scoring by disabling irrelevant checks, overriding impact/level, setting pass-rate thresholds, or chaining org baselines with team overrides. Use when the user asks about strict mode, AI-only scoring, custom weights, CI gating, or wants org-wide standardisation.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:plugins/acreadiness-cockpit/skills/acreadiness-policy",
+      "relPath": "plugins/acreadiness-cockpit/skills/acreadiness-policy",
+      "verified": true,
+      "tokenCount": 1046,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.283Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 64,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.283Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.283Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "acreadiness-policy",
+      "description": "Help the user pick, write, or apply an AgentRC policy. Policies customise readiness scoring by disabling irrelevant checks, overriding impact/level, setting pass-rate thresholds, or chaining org baselines with team overrides. Use when the user asks about strict mode, AI-only scoring, custom weights, CI gating, or wants org-wide standardisation.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:skills/acreadiness-policy",
+      "relPath": "skills/acreadiness-policy",
+      "verified": true,
+      "tokenCount": 1046,
+      "evalSummary": {
+        "overallScore": 64,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.284Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 64,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.284Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.284Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -201,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.376Z",
+        "evaluatedAt": "2026-05-05T23:45:42.286Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.376Z",
+          "evaluatedAt": "2026-05-05T23:45:42.286Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.376Z",
+          "evaluatedAt": "2026-05-05T23:45:42.286Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.379Z",
+        "evaluatedAt": "2026-05-05T23:45:42.288Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.379Z",
+          "evaluatedAt": "2026-05-05T23:45:42.288Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.379Z",
+          "evaluatedAt": "2026-05-05T23:45:42.288Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.382Z",
+        "evaluatedAt": "2026-05-05T23:45:42.292Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.382Z",
+          "evaluatedAt": "2026-05-05T23:45:42.292Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.382Z",
+          "evaluatedAt": "2026-05-05T23:45:42.292Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.385Z",
+        "evaluatedAt": "2026-05-05T23:45:42.295Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.385Z",
+          "evaluatedAt": "2026-05-05T23:45:42.295Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.385Z",
+          "evaluatedAt": "2026-05-05T23:45:42.295Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.387Z",
+        "evaluatedAt": "2026-05-05T23:45:42.297Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.387Z",
+          "evaluatedAt": "2026-05-05T23:45:42.297Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.387Z",
+          "evaluatedAt": "2026-05-05T23:45:42.297Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.389Z",
+        "evaluatedAt": "2026-05-05T23:45:42.298Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.389Z",
+          "evaluatedAt": "2026-05-05T23:45:42.298Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.389Z",
+          "evaluatedAt": "2026-05-05T23:45:42.298Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.391Z",
+        "evaluatedAt": "2026-05-05T23:45:42.300Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.391Z",
+          "evaluatedAt": "2026-05-05T23:45:42.300Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.391Z",
+          "evaluatedAt": "2026-05-05T23:45:42.300Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.393Z",
+        "evaluatedAt": "2026-05-05T23:45:42.302Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.393Z",
+          "evaluatedAt": "2026-05-05T23:45:42.302Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.393Z",
+          "evaluatedAt": "2026-05-05T23:45:42.302Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.394Z",
+        "evaluatedAt": "2026-05-05T23:45:42.304Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.394Z",
+          "evaluatedAt": "2026-05-05T23:45:42.304Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.394Z",
+          "evaluatedAt": "2026-05-05T23:45:42.304Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.396Z",
+        "evaluatedAt": "2026-05-05T23:45:42.305Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.396Z",
+          "evaluatedAt": "2026-05-05T23:45:42.305Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.396Z",
+          "evaluatedAt": "2026-05-05T23:45:42.305Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.396Z",
+        "evaluatedAt": "2026-05-05T23:45:42.306Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.396Z",
+          "evaluatedAt": "2026-05-05T23:45:42.306Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +2466,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.396Z",
+          "evaluatedAt": "2026-05-05T23:45:42.306Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1708,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.398Z",
+        "evaluatedAt": "2026-05-05T23:45:42.307Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.398Z",
+          "evaluatedAt": "2026-05-05T23:45:42.307Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +2603,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.398Z",
+          "evaluatedAt": "2026-05-05T23:45:42.307Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.398Z",
+        "evaluatedAt": "2026-05-05T23:45:42.308Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.399Z",
+          "evaluatedAt": "2026-05-05T23:45:42.308Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +2740,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.399Z",
+          "evaluatedAt": "2026-05-05T23:45:42.308Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1982,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.400Z",
+        "evaluatedAt": "2026-05-05T23:45:42.309Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.400Z",
+          "evaluatedAt": "2026-05-05T23:45:42.310Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2877,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.400Z",
+          "evaluatedAt": "2026-05-05T23:45:42.310Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2119,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.401Z",
+        "evaluatedAt": "2026-05-05T23:45:42.311Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.401Z",
+          "evaluatedAt": "2026-05-05T23:45:42.311Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +3014,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.401Z",
+          "evaluatedAt": "2026-05-05T23:45:42.311Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2256,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.402Z",
+        "evaluatedAt": "2026-05-05T23:45:42.312Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.402Z",
+          "evaluatedAt": "2026-05-05T23:45:42.312Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +3151,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.402Z",
+          "evaluatedAt": "2026-05-05T23:45:42.312Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2393,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.403Z",
+        "evaluatedAt": "2026-05-05T23:45:42.313Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.403Z",
+          "evaluatedAt": "2026-05-05T23:45:42.313Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +3288,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.403Z",
+          "evaluatedAt": "2026-05-05T23:45:42.313Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2482,7 +3304,7 @@
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-ai-provider-integration",
       "relPath": "plugins/arize-ax/skills/arize-ai-provider-integration",
       "verified": true,
-      "tokenCount": 2393,
+      "tokenCount": 2736,
       "evalSummary": {
         "overallScore": 73,
         "grade": "C",
@@ -2530,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.405Z",
+        "evaluatedAt": "2026-05-05T23:45:42.315Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.405Z",
+          "evaluatedAt": "2026-05-05T23:45:42.315Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +3425,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.405Z",
+          "evaluatedAt": "2026-05-05T23:45:42.315Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2619,7 +3441,7 @@
       "installUrl": "github:github/awesome-copilot:skills/arize-ai-provider-integration",
       "relPath": "skills/arize-ai-provider-integration",
       "verified": true,
-      "tokenCount": 2393,
+      "tokenCount": 2736,
       "evalSummary": {
         "overallScore": 73,
         "grade": "C",
@@ -2667,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.407Z",
+        "evaluatedAt": "2026-05-05T23:45:42.317Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.407Z",
+          "evaluatedAt": "2026-05-05T23:45:42.317Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2740,14 +3562,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.407Z",
+          "evaluatedAt": "2026-05-05T23:45:42.317Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-annotation",
-      "description": "INVOKE THIS SKILL when creating, managing, or using annotation configs on Arize (categorical, continuous, freeform), or applying human annotations to project spans via the Python SDK. Configs are the label schema for human feedback on spans and other surfaces in the Arize UI. Triggers: annotation config, label schema, human feedback schema, bulk annotate spans, update_annotations.",
+      "description": "INVOKE THIS SKILL when creating, managing, or using annotation configs or annotation queues on Arize (categorical, continuous, freeform), or applying human annotations to project spans via the Python SDK. Configs are the label schema for human feedback; queues are review workflows that route records to annotators. Triggers: annotation config, annotation queue, label schema, human feedback schema, bulk annotate spans, update_annotations, labeling queue, annotate record.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -2756,7 +3578,7 @@
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-annotation",
       "relPath": "plugins/arize-ax/skills/arize-annotation",
       "verified": true,
-      "tokenCount": 2124,
+      "tokenCount": 2887,
       "evalSummary": {
         "overallScore": 74,
         "grade": "C",
@@ -2770,13 +3592,13 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 5,
+            "score": 3,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
@@ -2804,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.409Z",
+        "evaluatedAt": "2026-05-05T23:45:42.319Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2825,13 +3647,13 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 5,
+              "score": 3,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 10,
               "max": 10
             },
             {
@@ -2859,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.409Z",
+          "evaluatedAt": "2026-05-05T23:45:42.319Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2877,14 +3699,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.409Z",
+          "evaluatedAt": "2026-05-05T23:45:42.319Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-annotation",
-      "description": "INVOKE THIS SKILL when creating, managing, or using annotation configs on Arize (categorical, continuous, freeform), or applying human annotations to project spans via the Python SDK. Configs are the label schema for human feedback on spans and other surfaces in the Arize UI. Triggers: annotation config, label schema, human feedback schema, bulk annotate spans, update_annotations.",
+      "description": "INVOKE THIS SKILL when creating, managing, or using annotation configs or annotation queues on Arize (categorical, continuous, freeform), or applying human annotations to project spans via the Python SDK. Configs are the label schema for human feedback; queues are review workflows that route records to annotators. Triggers: annotation config, annotation queue, label schema, human feedback schema, bulk annotate spans, update_annotations, labeling queue, annotate record.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -2893,7 +3715,7 @@
       "installUrl": "github:github/awesome-copilot:skills/arize-annotation",
       "relPath": "skills/arize-annotation",
       "verified": true,
-      "tokenCount": 2124,
+      "tokenCount": 2887,
       "evalSummary": {
         "overallScore": 74,
         "grade": "C",
@@ -2907,13 +3729,13 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 5,
+            "score": 3,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 8,
+            "score": 10,
             "max": 10
           },
           {
@@ -2941,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.410Z",
+        "evaluatedAt": "2026-05-05T23:45:42.321Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2962,13 +3784,13 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 5,
+              "score": 3,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 8,
+              "score": 10,
               "max": 10
             },
             {
@@ -2996,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.410Z",
+          "evaluatedAt": "2026-05-05T23:45:42.321Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3014,14 +3836,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.410Z",
+          "evaluatedAt": "2026-05-05T23:45:42.321Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-dataset",
-      "description": "INVOKE THIS SKILL when creating, managing, or querying Arize datasets and examples. Covers dataset CRUD, appending examples, exporting data, and file-based dataset creation using the ax CLI.",
+      "description": "INVOKE THIS SKILL when creating, managing, or querying Arize datasets and examples. Also use when the user needs test data or evaluation examples for their model. Covers dataset CRUD, appending examples, exporting data, and file-based dataset creation using the ax CLI.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -3030,9 +3852,9 @@
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-dataset",
       "relPath": "plugins/arize-ax/skills/arize-dataset",
       "verified": true,
-      "tokenCount": 4117,
+      "tokenCount": 4621,
       "evalSummary": {
-        "overallScore": 76,
+        "overallScore": 73,
         "grade": "C",
         "categories": [
           {
@@ -3044,7 +3866,7 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
@@ -3078,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.412Z",
+        "evaluatedAt": "2026-05-05T23:45:42.323Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3087,7 +3909,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 76,
+          "overallScore": 73,
           "grade": "C",
           "categories": [
             {
@@ -3099,7 +3921,7 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
@@ -3133,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.412Z",
+          "evaluatedAt": "2026-05-05T23:45:42.323Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3141,24 +3963,24 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 77,
+          "overallScore": 69,
           "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 10,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.412Z",
+          "evaluatedAt": "2026-05-05T23:45:42.323Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-dataset",
-      "description": "INVOKE THIS SKILL when creating, managing, or querying Arize datasets and examples. Covers dataset CRUD, appending examples, exporting data, and file-based dataset creation using the ax CLI.",
+      "description": "INVOKE THIS SKILL when creating, managing, or querying Arize datasets and examples. Also use when the user needs test data or evaluation examples for their model. Covers dataset CRUD, appending examples, exporting data, and file-based dataset creation using the ax CLI.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -3167,9 +3989,9 @@
       "installUrl": "github:github/awesome-copilot:skills/arize-dataset",
       "relPath": "skills/arize-dataset",
       "verified": true,
-      "tokenCount": 4117,
+      "tokenCount": 4621,
       "evalSummary": {
-        "overallScore": 76,
+        "overallScore": 73,
         "grade": "C",
         "categories": [
           {
@@ -3181,7 +4003,7 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
@@ -3215,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.414Z",
+        "evaluatedAt": "2026-05-05T23:45:42.326Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3224,7 +4046,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 76,
+          "overallScore": 73,
           "grade": "C",
           "categories": [
             {
@@ -3236,7 +4058,7 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
@@ -3270,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.414Z",
+          "evaluatedAt": "2026-05-05T23:45:42.326Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3278,17 +4100,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 77,
+          "overallScore": 69,
           "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 10,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.414Z",
+          "evaluatedAt": "2026-05-05T23:45:42.326Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3304,7 +4126,7 @@
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-evaluator",
       "relPath": "plugins/arize-ax/skills/arize-evaluator",
       "verified": true,
-      "tokenCount": 7045,
+      "tokenCount": 9146,
       "evalSummary": {
         "overallScore": 67,
         "grade": "C",
@@ -3352,7 +4174,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.417Z",
+        "evaluatedAt": "2026-05-05T23:45:42.330Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3407,7 +4229,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.417Z",
+          "evaluatedAt": "2026-05-05T23:45:42.330Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3425,7 +4247,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.417Z",
+          "evaluatedAt": "2026-05-05T23:45:42.330Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3441,7 +4263,7 @@
       "installUrl": "github:github/awesome-copilot:skills/arize-evaluator",
       "relPath": "skills/arize-evaluator",
       "verified": true,
-      "tokenCount": 7045,
+      "tokenCount": 9146,
       "evalSummary": {
         "overallScore": 67,
         "grade": "C",
@@ -3489,7 +4311,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.421Z",
+        "evaluatedAt": "2026-05-05T23:45:42.334Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3544,7 +4366,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.421Z",
+          "evaluatedAt": "2026-05-05T23:45:42.334Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3562,14 +4384,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.421Z",
+          "evaluatedAt": "2026-05-05T23:45:42.334Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-experiment",
-      "description": "INVOKE THIS SKILL when creating, running, or analyzing Arize experiments. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI.",
+      "description": "INVOKE THIS SKILL when creating, running, or analyzing Arize experiments. Also use when the user wants to evaluate or measure model performance, compare models (including GPT-4, Claude, or others), or assess how well their AI is doing. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -3578,10 +4400,10 @@
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-experiment",
       "relPath": "plugins/arize-ax/skills/arize-experiment",
       "verified": true,
-      "tokenCount": 3718,
+      "tokenCount": 5686,
       "evalSummary": {
-        "overallScore": 69,
-        "grade": "C",
+        "overallScore": 64,
+        "grade": "D",
         "categories": [
           {
             "id": "structure",
@@ -3592,19 +4414,19 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 7,
+            "score": 8,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
@@ -3626,7 +4448,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.423Z",
+        "evaluatedAt": "2026-05-05T23:45:42.338Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3635,8 +4457,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 69,
-          "grade": "C",
+          "overallScore": 64,
+          "grade": "D",
           "categories": [
             {
               "id": "structure",
@@ -3647,19 +4469,19 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 7,
+              "score": 8,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
@@ -3681,7 +4503,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.424Z",
+          "evaluatedAt": "2026-05-05T23:45:42.338Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3689,24 +4511,24 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 77,
+          "overallScore": 69,
           "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 10,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.424Z",
+          "evaluatedAt": "2026-05-05T23:45:42.338Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-experiment",
-      "description": "INVOKE THIS SKILL when creating, running, or analyzing Arize experiments. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI.",
+      "description": "INVOKE THIS SKILL when creating, running, or analyzing Arize experiments. Also use when the user wants to evaluate or measure model performance, compare models (including GPT-4, Claude, or others), or assess how well their AI is doing. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -3715,10 +4537,10 @@
       "installUrl": "github:github/awesome-copilot:skills/arize-experiment",
       "relPath": "skills/arize-experiment",
       "verified": true,
-      "tokenCount": 3718,
+      "tokenCount": 5686,
       "evalSummary": {
-        "overallScore": 69,
-        "grade": "C",
+        "overallScore": 64,
+        "grade": "D",
         "categories": [
           {
             "id": "structure",
@@ -3729,19 +4551,19 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 7,
+            "score": 8,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
@@ -3763,7 +4585,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.426Z",
+        "evaluatedAt": "2026-05-05T23:45:42.341Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3772,8 +4594,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 69,
-          "grade": "C",
+          "overallScore": 64,
+          "grade": "D",
           "categories": [
             {
               "id": "structure",
@@ -3784,19 +4606,19 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 7,
+              "score": 8,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
@@ -3818,7 +4640,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.426Z",
+          "evaluatedAt": "2026-05-05T23:45:42.341Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3826,24 +4648,24 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 77,
+          "overallScore": 69,
           "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 10,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.426Z",
+          "evaluatedAt": "2026-05-05T23:45:42.341Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-instrumentation",
-      "description": "INVOKE THIS SKILL when adding Arize AX tracing to an application. Follow the Agent-Assisted Tracing two-phase flow: analyze the codebase (read-only), then implement instrumentation after user confirmation. When the app uses LLM tool/function calling, add manual CHAIN + TOOL spans so traces show each tool's input and output. Leverages https://arize.com/docs/ax/alyx/tracing-assistant and https://arize.com/docs/PROMPT.md.",
+      "description": "INVOKE THIS SKILL when adding Arize AX tracing or observability to an app for the first time, or when the user wants to instrument their LLM app or get started with LLM observability. Follow the Agent-Assisted Tracing two-phase flow: analyze the codebase (read-only), then implement after user confirmation. When the app uses LLM tool/function calling, add manual CHAIN + TOOL spans. Leverages https://arize.com/docs/ax/alyx/tracing-assistant and https://arize.com/docs/PROMPT.md.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -3852,9 +4674,9 @@
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-instrumentation",
       "relPath": "plugins/arize-ax/skills/arize-instrumentation",
       "verified": true,
-      "tokenCount": 4466,
+      "tokenCount": 4694,
       "evalSummary": {
-        "overallScore": 77,
+        "overallScore": 74,
         "grade": "C",
         "categories": [
           {
@@ -3866,7 +4688,7 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 5,
+            "score": 3,
             "max": 10
           },
           {
@@ -3900,7 +4722,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.428Z",
+        "evaluatedAt": "2026-05-05T23:45:42.344Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3909,7 +4731,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 77,
+          "overallScore": 74,
           "grade": "C",
           "categories": [
             {
@@ -3921,7 +4743,7 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 5,
+              "score": 3,
               "max": 10
             },
             {
@@ -3955,7 +4777,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.428Z",
+          "evaluatedAt": "2026-05-05T23:45:42.344Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3973,14 +4795,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.428Z",
+          "evaluatedAt": "2026-05-05T23:45:42.344Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-instrumentation",
-      "description": "INVOKE THIS SKILL when adding Arize AX tracing to an application. Follow the Agent-Assisted Tracing two-phase flow: analyze the codebase (read-only), then implement instrumentation after user confirmation. When the app uses LLM tool/function calling, add manual CHAIN + TOOL spans so traces show each tool's input and output. Leverages https://arize.com/docs/ax/alyx/tracing-assistant and https://arize.com/docs/PROMPT.md.",
+      "description": "INVOKE THIS SKILL when adding Arize AX tracing or observability to an app for the first time, or when the user wants to instrument their LLM app or get started with LLM observability. Follow the Agent-Assisted Tracing two-phase flow: analyze the codebase (read-only), then implement after user confirmation. When the app uses LLM tool/function calling, add manual CHAIN + TOOL spans. Leverages https://arize.com/docs/ax/alyx/tracing-assistant and https://arize.com/docs/PROMPT.md.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -3989,9 +4811,9 @@
       "installUrl": "github:github/awesome-copilot:skills/arize-instrumentation",
       "relPath": "skills/arize-instrumentation",
       "verified": true,
-      "tokenCount": 4466,
+      "tokenCount": 4694,
       "evalSummary": {
-        "overallScore": 77,
+        "overallScore": 74,
         "grade": "C",
         "categories": [
           {
@@ -4003,7 +4825,7 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 5,
+            "score": 3,
             "max": 10
           },
           {
@@ -4037,7 +4859,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.431Z",
+        "evaluatedAt": "2026-05-05T23:45:42.347Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4046,7 +4868,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 77,
+          "overallScore": 74,
           "grade": "C",
           "categories": [
             {
@@ -4058,7 +4880,7 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 5,
+              "score": 3,
               "max": 10
             },
             {
@@ -4092,7 +4914,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.431Z",
+          "evaluatedAt": "2026-05-05T23:45:42.347Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4110,14 +4932,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.431Z",
+          "evaluatedAt": "2026-05-05T23:45:42.347Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-link",
-      "description": "Generate deep links to the Arize UI. Use when the user wants a clickable URL to open a specific trace, span, session, dataset, labeling queue, evaluator, or annotation config.",
+      "description": "Generate deep links to the Arize UI. Use when the user wants a clickable URL to open or share a specific trace, span, session, dataset, labeling queue, evaluator, or annotation config, or when sharing Arize resources with team members.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -4126,7 +4948,7 @@
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-link",
       "relPath": "plugins/arize-ax/skills/arize-link",
       "verified": true,
-      "tokenCount": 964,
+      "tokenCount": 984,
       "evalSummary": {
         "overallScore": 74,
         "grade": "C",
@@ -4174,7 +4996,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.433Z",
+        "evaluatedAt": "2026-05-05T23:45:42.349Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4229,7 +5051,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.433Z",
+          "evaluatedAt": "2026-05-05T23:45:42.349Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4247,14 +5069,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.433Z",
+          "evaluatedAt": "2026-05-05T23:45:42.349Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-link",
-      "description": "Generate deep links to the Arize UI. Use when the user wants a clickable URL to open a specific trace, span, session, dataset, labeling queue, evaluator, or annotation config.",
+      "description": "Generate deep links to the Arize UI. Use when the user wants a clickable URL to open or share a specific trace, span, session, dataset, labeling queue, evaluator, or annotation config, or when sharing Arize resources with team members.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -4263,7 +5085,7 @@
       "installUrl": "github:github/awesome-copilot:skills/arize-link",
       "relPath": "skills/arize-link",
       "verified": true,
-      "tokenCount": 964,
+      "tokenCount": 984,
       "evalSummary": {
         "overallScore": 74,
         "grade": "C",
@@ -4311,7 +5133,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.434Z",
+        "evaluatedAt": "2026-05-05T23:45:42.350Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4366,7 +5188,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.434Z",
+          "evaluatedAt": "2026-05-05T23:45:42.351Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4384,14 +5206,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.434Z",
+          "evaluatedAt": "2026-05-05T23:45:42.351Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-prompt-optimization",
-      "description": "INVOKE THIS SKILL when optimizing, improving, or debugging LLM prompts using production trace data, evaluations, and annotations. Covers extracting prompts from spans, gathering performance signal, and running a data-driven optimization loop using the ax CLI.",
+      "description": "INVOKE THIS SKILL when optimizing, improving, or debugging LLM prompts using production trace data, evaluations, and annotations. Also use when the user wants to make their AI respond better or improve AI output quality. Covers extracting prompts from spans, gathering performance signal, and running a data-driven optimization loop using the ax CLI.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -4400,9 +5222,9 @@
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-prompt-optimization",
       "relPath": "plugins/arize-ax/skills/arize-prompt-optimization",
       "verified": true,
-      "tokenCount": 5080,
+      "tokenCount": 5288,
       "evalSummary": {
-        "overallScore": 73,
+        "overallScore": 70,
         "grade": "C",
         "categories": [
           {
@@ -4414,7 +5236,7 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
@@ -4448,7 +5270,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.436Z",
+        "evaluatedAt": "2026-05-05T23:45:42.353Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4457,7 +5279,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 73,
+          "overallScore": 70,
           "grade": "C",
           "categories": [
             {
@@ -4469,7 +5291,7 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
@@ -4503,7 +5325,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.436Z",
+          "evaluatedAt": "2026-05-05T23:45:42.353Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4521,14 +5343,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.436Z",
+          "evaluatedAt": "2026-05-05T23:45:42.353Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-prompt-optimization",
-      "description": "INVOKE THIS SKILL when optimizing, improving, or debugging LLM prompts using production trace data, evaluations, and annotations. Covers extracting prompts from spans, gathering performance signal, and running a data-driven optimization loop using the ax CLI.",
+      "description": "INVOKE THIS SKILL when optimizing, improving, or debugging LLM prompts using production trace data, evaluations, and annotations. Also use when the user wants to make their AI respond better or improve AI output quality. Covers extracting prompts from spans, gathering performance signal, and running a data-driven optimization loop using the ax CLI.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -4537,9 +5359,9 @@
       "installUrl": "github:github/awesome-copilot:skills/arize-prompt-optimization",
       "relPath": "skills/arize-prompt-optimization",
       "verified": true,
-      "tokenCount": 5080,
+      "tokenCount": 5288,
       "evalSummary": {
-        "overallScore": 73,
+        "overallScore": 70,
         "grade": "C",
         "categories": [
           {
@@ -4551,7 +5373,7 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 5,
             "max": 10
           },
           {
@@ -4585,7 +5407,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.439Z",
+        "evaluatedAt": "2026-05-05T23:45:42.356Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4594,7 +5416,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 73,
+          "overallScore": 70,
           "grade": "C",
           "categories": [
             {
@@ -4606,7 +5428,7 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 5,
               "max": 10
             },
             {
@@ -4640,7 +5462,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.439Z",
+          "evaluatedAt": "2026-05-05T23:45:42.356Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4658,14 +5480,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.439Z",
+          "evaluatedAt": "2026-05-05T23:45:42.356Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-trace",
-      "description": "INVOKE THIS SKILL when downloading or exporting Arize traces and spans. Covers exporting traces by ID, sessions by ID, and debugging LLM application issues using the ax CLI.",
+      "description": "INVOKE THIS SKILL when downloading, exporting, or inspecting Arize traces and spans, or when a user wants to look at what their LLM app is doing using existing trace data, or when an already-instrumented app has a bug or error to investigate. Use for debugging unknown runtime issues, failures, and behavior regressions. Covers exporting traces by ID, spans by ID, sessions by ID, and root-cause investigation with the ax CLI.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -4674,9 +5496,9 @@
       "installUrl": "github:github/awesome-copilot:plugins/arize-ax/skills/arize-trace",
       "relPath": "plugins/arize-ax/skills/arize-trace",
       "verified": true,
-      "tokenCount": 5766,
+      "tokenCount": 6623,
       "evalSummary": {
-        "overallScore": 77,
+        "overallScore": 67,
         "grade": "C",
         "categories": [
           {
@@ -4688,19 +5510,19 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 3,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 10,
+            "score": 9,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 8,
+            "score": 6,
             "max": 10
           },
           {
@@ -4722,7 +5544,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.442Z",
+        "evaluatedAt": "2026-05-05T23:45:42.360Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4731,7 +5553,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 77,
+          "overallScore": 67,
           "grade": "C",
           "categories": [
             {
@@ -4743,19 +5565,19 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 3,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 10,
+              "score": 9,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 8,
+              "score": 6,
               "max": 10
             },
             {
@@ -4777,7 +5599,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.442Z",
+          "evaluatedAt": "2026-05-05T23:45:42.360Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4785,24 +5607,24 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 77,
+          "overallScore": 69,
           "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 10,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.442Z",
+          "evaluatedAt": "2026-05-05T23:45:42.360Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "arize-trace",
-      "description": "INVOKE THIS SKILL when downloading or exporting Arize traces and spans. Covers exporting traces by ID, sessions by ID, and debugging LLM application issues using the ax CLI.",
+      "description": "INVOKE THIS SKILL when downloading, exporting, or inspecting Arize traces and spans, or when a user wants to look at what their LLM app is doing using existing trace data, or when an already-instrumented app has a bug or error to investigate. Use for debugging unknown runtime issues, failures, and behavior regressions. Covers exporting traces by ID, spans by ID, sessions by ID, and root-cause investigation with the ax CLI.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -4811,9 +5633,9 @@
       "installUrl": "github:github/awesome-copilot:skills/arize-trace",
       "relPath": "skills/arize-trace",
       "verified": true,
-      "tokenCount": 5766,
+      "tokenCount": 6623,
       "evalSummary": {
-        "overallScore": 77,
+        "overallScore": 67,
         "grade": "C",
         "categories": [
           {
@@ -4825,19 +5647,19 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 7,
+            "score": 3,
             "max": 10
           },
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 10,
+            "score": 9,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 8,
+            "score": 6,
             "max": 10
           },
           {
@@ -4859,7 +5681,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.445Z",
+        "evaluatedAt": "2026-05-05T23:45:42.363Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -4868,7 +5690,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 77,
+          "overallScore": 67,
           "grade": "C",
           "categories": [
             {
@@ -4880,19 +5702,19 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 7,
+              "score": 3,
               "max": 10
             },
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 10,
+              "score": 9,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 8,
+              "score": 6,
               "max": 10
             },
             {
@@ -4914,7 +5736,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.445Z",
+          "evaluatedAt": "2026-05-05T23:45:42.363Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -4922,17 +5744,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 77,
+          "overallScore": 69,
           "grade": "C",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 10,
+              "score": 9,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.445Z",
+          "evaluatedAt": "2026-05-05T23:45:42.363Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -4996,7 +5818,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.447Z",
+        "evaluatedAt": "2026-05-05T23:45:42.366Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5051,7 +5873,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.447Z",
+          "evaluatedAt": "2026-05-05T23:45:42.366Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5069,7 +5891,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.447Z",
+          "evaluatedAt": "2026-05-05T23:45:42.366Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5133,7 +5955,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.448Z",
+        "evaluatedAt": "2026-05-05T23:45:42.367Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5188,7 +6010,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.448Z",
+          "evaluatedAt": "2026-05-05T23:45:42.368Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5206,7 +6028,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.448Z",
+          "evaluatedAt": "2026-05-05T23:45:42.367Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5270,7 +6092,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.449Z",
+        "evaluatedAt": "2026-05-05T23:45:42.368Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5325,7 +6147,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.449Z",
+          "evaluatedAt": "2026-05-05T23:45:42.368Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5343,7 +6165,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.449Z",
+          "evaluatedAt": "2026-05-05T23:45:42.368Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5407,7 +6229,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.450Z",
+        "evaluatedAt": "2026-05-05T23:45:42.369Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -5462,7 +6284,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.450Z",
+          "evaluatedAt": "2026-05-05T23:45:42.369Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -5480,7 +6302,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.450Z",
+          "evaluatedAt": "2026-05-05T23:45:42.369Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -5544,7 +6366,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.451Z",
+        "evaluatedAt": "2026-05-05T23:45:42.371Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5599,7 +6421,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.451Z",
+          "evaluatedAt": "2026-05-05T23:45:42.371Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5617,7 +6439,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.451Z",
+          "evaluatedAt": "2026-05-05T23:45:42.371Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5681,7 +6503,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.453Z",
+        "evaluatedAt": "2026-05-05T23:45:42.373Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5736,7 +6558,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.453Z",
+          "evaluatedAt": "2026-05-05T23:45:42.373Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5754,7 +6576,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.453Z",
+          "evaluatedAt": "2026-05-05T23:45:42.373Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5818,7 +6640,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.455Z",
+        "evaluatedAt": "2026-05-05T23:45:42.375Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -5873,7 +6695,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.455Z",
+          "evaluatedAt": "2026-05-05T23:45:42.376Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -5891,7 +6713,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.455Z",
+          "evaluatedAt": "2026-05-05T23:45:42.376Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -5955,7 +6777,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.456Z",
+        "evaluatedAt": "2026-05-05T23:45:42.377Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6010,7 +6832,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.456Z",
+          "evaluatedAt": "2026-05-05T23:45:42.377Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6028,7 +6850,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.456Z",
+          "evaluatedAt": "2026-05-05T23:45:42.377Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6092,7 +6914,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.457Z",
+        "evaluatedAt": "2026-05-05T23:45:42.378Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6147,7 +6969,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.457Z",
+          "evaluatedAt": "2026-05-05T23:45:42.378Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6165,7 +6987,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.457Z",
+          "evaluatedAt": "2026-05-05T23:45:42.378Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6229,7 +7051,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.459Z",
+        "evaluatedAt": "2026-05-05T23:45:42.380Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6284,7 +7106,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.459Z",
+          "evaluatedAt": "2026-05-05T23:45:42.380Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6302,7 +7124,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.459Z",
+          "evaluatedAt": "2026-05-05T23:45:42.380Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6366,7 +7188,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.461Z",
+        "evaluatedAt": "2026-05-05T23:45:42.382Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6421,7 +7243,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.461Z",
+          "evaluatedAt": "2026-05-05T23:45:42.382Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6439,7 +7261,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.461Z",
+          "evaluatedAt": "2026-05-05T23:45:42.382Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6503,7 +7325,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.463Z",
+        "evaluatedAt": "2026-05-05T23:45:42.384Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6558,7 +7380,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.463Z",
+          "evaluatedAt": "2026-05-05T23:45:42.384Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6576,7 +7398,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.463Z",
+          "evaluatedAt": "2026-05-05T23:45:42.384Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6640,7 +7462,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.464Z",
+        "evaluatedAt": "2026-05-05T23:45:42.385Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -6695,7 +7517,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.464Z",
+          "evaluatedAt": "2026-05-05T23:45:42.385Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -6713,7 +7535,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.464Z",
+          "evaluatedAt": "2026-05-05T23:45:42.385Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -6777,7 +7599,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.465Z",
+        "evaluatedAt": "2026-05-05T23:45:42.387Z",
         "evaluatedVersion": "1.2"
       },
       "evalSummaries": {
@@ -6832,7 +7654,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.465Z",
+          "evaluatedAt": "2026-05-05T23:45:42.387Z",
           "evaluatedVersion": "1.2"
         },
         "skill-best-practice": {
@@ -6850,7 +7672,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.465Z",
+          "evaluatedAt": "2026-05-05T23:45:42.387Z",
           "evaluatedVersion": "1.2"
         }
       }
@@ -6914,7 +7736,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.467Z",
+        "evaluatedAt": "2026-05-05T23:45:42.388Z",
         "evaluatedVersion": "1.2"
       },
       "evalSummaries": {
@@ -6969,7 +7791,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.467Z",
+          "evaluatedAt": "2026-05-05T23:45:42.388Z",
           "evaluatedVersion": "1.2"
         },
         "skill-best-practice": {
@@ -6987,7 +7809,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.467Z",
+          "evaluatedAt": "2026-05-05T23:45:42.388Z",
           "evaluatedVersion": "1.2"
         }
       }
@@ -7051,7 +7873,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.468Z",
+        "evaluatedAt": "2026-05-05T23:45:42.390Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7106,7 +7928,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.468Z",
+          "evaluatedAt": "2026-05-05T23:45:42.390Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7124,7 +7946,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.468Z",
+          "evaluatedAt": "2026-05-05T23:45:42.390Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7188,7 +8010,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.470Z",
+        "evaluatedAt": "2026-05-05T23:45:42.392Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7243,7 +8065,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.470Z",
+          "evaluatedAt": "2026-05-05T23:45:42.392Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7261,7 +8083,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.470Z",
+          "evaluatedAt": "2026-05-05T23:45:42.392Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7325,7 +8147,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.472Z",
+        "evaluatedAt": "2026-05-05T23:45:42.394Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7380,7 +8202,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.472Z",
+          "evaluatedAt": "2026-05-05T23:45:42.394Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7398,7 +8220,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.472Z",
+          "evaluatedAt": "2026-05-05T23:45:42.394Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7462,7 +8284,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.474Z",
+        "evaluatedAt": "2026-05-05T23:45:42.396Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7517,7 +8339,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.474Z",
+          "evaluatedAt": "2026-05-05T23:45:42.396Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7535,7 +8357,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.474Z",
+          "evaluatedAt": "2026-05-05T23:45:42.396Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7608,7 +8430,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.475Z",
+        "evaluatedAt": "2026-05-05T23:45:42.397Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7663,7 +8485,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.475Z",
+          "evaluatedAt": "2026-05-05T23:45:42.397Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7681,7 +8503,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.475Z",
+          "evaluatedAt": "2026-05-05T23:45:42.397Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7745,7 +8567,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.476Z",
+        "evaluatedAt": "2026-05-05T23:45:42.398Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7800,7 +8622,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.476Z",
+          "evaluatedAt": "2026-05-05T23:45:42.398Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7818,7 +8640,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.476Z",
+          "evaluatedAt": "2026-05-05T23:45:42.398Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -7882,7 +8704,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.478Z",
+        "evaluatedAt": "2026-05-05T23:45:42.399Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -7937,7 +8759,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.478Z",
+          "evaluatedAt": "2026-05-05T23:45:42.399Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -7955,7 +8777,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.478Z",
+          "evaluatedAt": "2026-05-05T23:45:42.399Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8019,7 +8841,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.480Z",
+        "evaluatedAt": "2026-05-05T23:45:42.402Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8074,7 +8896,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.480Z",
+          "evaluatedAt": "2026-05-05T23:45:42.402Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8092,7 +8914,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.480Z",
+          "evaluatedAt": "2026-05-05T23:45:42.402Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8156,7 +8978,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.482Z",
+        "evaluatedAt": "2026-05-05T23:45:42.404Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8211,7 +9033,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.482Z",
+          "evaluatedAt": "2026-05-05T23:45:42.404Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8229,7 +9051,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.482Z",
+          "evaluatedAt": "2026-05-05T23:45:42.404Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8293,7 +9115,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.482Z",
+        "evaluatedAt": "2026-05-05T23:45:42.405Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8348,7 +9170,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.482Z",
+          "evaluatedAt": "2026-05-05T23:45:42.405Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8366,7 +9188,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.482Z",
+          "evaluatedAt": "2026-05-05T23:45:42.405Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8430,7 +9252,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.484Z",
+        "evaluatedAt": "2026-05-05T23:45:42.406Z",
         "evaluatedVersion": "1.1"
       },
       "evalSummaries": {
@@ -8485,7 +9307,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.484Z",
+          "evaluatedAt": "2026-05-05T23:45:42.406Z",
           "evaluatedVersion": "1.1"
         },
         "skill-best-practice": {
@@ -8503,7 +9325,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.484Z",
+          "evaluatedAt": "2026-05-05T23:45:42.406Z",
           "evaluatedVersion": "1.1"
         }
       }
@@ -8567,7 +9389,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.485Z",
+        "evaluatedAt": "2026-05-05T23:45:42.408Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8622,7 +9444,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.485Z",
+          "evaluatedAt": "2026-05-05T23:45:42.408Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8640,7 +9462,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.485Z",
+          "evaluatedAt": "2026-05-05T23:45:42.408Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8704,7 +9526,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.486Z",
+        "evaluatedAt": "2026-05-05T23:45:42.408Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8759,7 +9581,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.486Z",
+          "evaluatedAt": "2026-05-05T23:45:42.408Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8777,7 +9599,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.486Z",
+          "evaluatedAt": "2026-05-05T23:45:42.408Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8841,7 +9663,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.486Z",
+        "evaluatedAt": "2026-05-05T23:45:42.409Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -8896,7 +9718,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.486Z",
+          "evaluatedAt": "2026-05-05T23:45:42.409Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -8914,7 +9736,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.486Z",
+          "evaluatedAt": "2026-05-05T23:45:42.409Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -8978,7 +9800,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.487Z",
+        "evaluatedAt": "2026-05-05T23:45:42.410Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9033,7 +9855,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.487Z",
+          "evaluatedAt": "2026-05-05T23:45:42.410Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9051,7 +9873,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.487Z",
+          "evaluatedAt": "2026-05-05T23:45:42.410Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9115,7 +9937,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.488Z",
+        "evaluatedAt": "2026-05-05T23:45:42.412Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9170,7 +9992,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.488Z",
+          "evaluatedAt": "2026-05-05T23:45:42.412Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9188,7 +10010,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.488Z",
+          "evaluatedAt": "2026-05-05T23:45:42.412Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9252,7 +10074,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.489Z",
+        "evaluatedAt": "2026-05-05T23:45:42.414Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9307,7 +10129,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.489Z",
+          "evaluatedAt": "2026-05-05T23:45:42.414Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9325,7 +10147,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.489Z",
+          "evaluatedAt": "2026-05-05T23:45:42.414Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9389,7 +10211,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.489Z",
+        "evaluatedAt": "2026-05-05T23:45:42.415Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9444,7 +10266,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.489Z",
+          "evaluatedAt": "2026-05-05T23:45:42.415Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9462,7 +10284,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.489Z",
+          "evaluatedAt": "2026-05-05T23:45:42.415Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9526,7 +10348,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.490Z",
+        "evaluatedAt": "2026-05-05T23:45:42.416Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9581,7 +10403,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.490Z",
+          "evaluatedAt": "2026-05-05T23:45:42.416Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9599,7 +10421,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.490Z",
+          "evaluatedAt": "2026-05-05T23:45:42.416Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9663,7 +10485,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.491Z",
+        "evaluatedAt": "2026-05-05T23:45:42.418Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9718,7 +10540,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.491Z",
+          "evaluatedAt": "2026-05-05T23:45:42.418Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9736,7 +10558,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.491Z",
+          "evaluatedAt": "2026-05-05T23:45:42.418Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9800,7 +10622,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.494Z",
+        "evaluatedAt": "2026-05-05T23:45:42.420Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9855,7 +10677,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.494Z",
+          "evaluatedAt": "2026-05-05T23:45:42.420Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -9873,7 +10695,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.494Z",
+          "evaluatedAt": "2026-05-05T23:45:42.420Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -9937,7 +10759,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.495Z",
+        "evaluatedAt": "2026-05-05T23:45:42.422Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -9992,7 +10814,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.495Z",
+          "evaluatedAt": "2026-05-05T23:45:42.422Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10010,7 +10832,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.495Z",
+          "evaluatedAt": "2026-05-05T23:45:42.422Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10074,7 +10896,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.499Z",
+        "evaluatedAt": "2026-05-05T23:45:42.422Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10129,7 +10951,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.499Z",
+          "evaluatedAt": "2026-05-05T23:45:42.422Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10147,7 +10969,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.499Z",
+          "evaluatedAt": "2026-05-05T23:45:42.422Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10211,7 +11033,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.500Z",
+        "evaluatedAt": "2026-05-05T23:45:42.423Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -10266,7 +11088,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.500Z",
+          "evaluatedAt": "2026-05-05T23:45:42.423Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -10284,7 +11106,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.500Z",
+          "evaluatedAt": "2026-05-05T23:45:42.423Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -10348,7 +11170,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.502Z",
+        "evaluatedAt": "2026-05-05T23:45:42.424Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10403,7 +11225,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.502Z",
+          "evaluatedAt": "2026-05-05T23:45:42.424Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10421,7 +11243,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.502Z",
+          "evaluatedAt": "2026-05-05T23:45:42.424Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10485,7 +11307,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.503Z",
+        "evaluatedAt": "2026-05-05T23:45:42.425Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10540,7 +11362,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.503Z",
+          "evaluatedAt": "2026-05-05T23:45:42.425Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10558,7 +11380,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.503Z",
+          "evaluatedAt": "2026-05-05T23:45:42.425Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10622,7 +11444,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.505Z",
+        "evaluatedAt": "2026-05-05T23:45:42.428Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10677,7 +11499,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.505Z",
+          "evaluatedAt": "2026-05-05T23:45:42.428Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10695,7 +11517,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.505Z",
+          "evaluatedAt": "2026-05-05T23:45:42.428Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10759,7 +11581,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.508Z",
+        "evaluatedAt": "2026-05-05T23:45:42.431Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10814,7 +11636,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.508Z",
+          "evaluatedAt": "2026-05-05T23:45:42.431Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10832,7 +11654,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.508Z",
+          "evaluatedAt": "2026-05-05T23:45:42.431Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -10896,7 +11718,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.510Z",
+        "evaluatedAt": "2026-05-05T23:45:42.432Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -10951,7 +11773,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.510Z",
+          "evaluatedAt": "2026-05-05T23:45:42.432Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -10969,7 +11791,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.510Z",
+          "evaluatedAt": "2026-05-05T23:45:42.432Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "commit-message-storyteller",
+      "description": "Analyzes git diffs or staged changes and generates narrative commit messages that explain WHY a change was made, not just what changed — following Conventional Commits format. Use when asked to \"write a commit message\", \"generate a commit\", \"describe my changes\", \"what should I commit this as\", \"commit this\", \"summarize my diff\", or \"help me commit\". Works with git diff output, staged files, or plain descriptions of changes.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:skills/commit-message-storyteller",
+      "relPath": "skills/commit-message-storyteller",
+      "verified": true,
+      "tokenCount": 1576,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.433Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.433Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.433Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11033,7 +11992,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.512Z",
+        "evaluatedAt": "2026-05-05T23:45:42.435Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11088,7 +12047,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.512Z",
+          "evaluatedAt": "2026-05-05T23:45:42.436Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11106,7 +12065,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.512Z",
+          "evaluatedAt": "2026-05-05T23:45:42.436Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11170,7 +12129,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.515Z",
+        "evaluatedAt": "2026-05-05T23:45:42.439Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11225,7 +12184,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.515Z",
+          "evaluatedAt": "2026-05-05T23:45:42.439Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11243,7 +12202,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.515Z",
+          "evaluatedAt": "2026-05-05T23:45:42.439Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "content-management-systems",
+      "description": "Workflow for building and modifying content management systems across WordPress, Shopify, Wix, Squarespace, Drupal, WooCommerce, Joomla, HubSpot CMS Hub, Webflow, Adobe Experience Manager, and similar platforms. Use when working on CMS themes, plugins, apps, modules, admin panels, media uploads, content models, editors, markdown pipelines, or static export workflows.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:plugins/cms-development/skills/content-management-systems",
+      "relPath": "plugins/cms-development/skills/content-management-systems",
+      "verified": true,
+      "tokenCount": 1501,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.441Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 70,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.441Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.441Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "content-management-systems",
+      "description": "Workflow for building and modifying content management systems across WordPress, Shopify, Wix, Squarespace, Drupal, WooCommerce, Joomla, HubSpot CMS Hub, Webflow, Adobe Experience Manager, and similar platforms. Use when working on CMS themes, plugins, apps, modules, admin panels, media uploads, content models, editors, markdown pipelines, or static export workflows.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:skills/content-management-systems",
+      "relPath": "skills/content-management-systems",
+      "verified": true,
+      "tokenCount": 1501,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.442Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 70,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.442Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.442Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11307,7 +12540,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.517Z",
+        "evaluatedAt": "2026-05-05T23:45:42.442Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11362,7 +12595,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.517Z",
+          "evaluatedAt": "2026-05-05T23:45:42.442Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11380,7 +12613,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.517Z",
+          "evaluatedAt": "2026-05-05T23:45:42.442Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11444,7 +12677,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.517Z",
+        "evaluatedAt": "2026-05-05T23:45:42.443Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11499,7 +12732,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.517Z",
+          "evaluatedAt": "2026-05-05T23:45:42.443Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11517,7 +12750,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.517Z",
+          "evaluatedAt": "2026-05-05T23:45:42.443Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11581,7 +12814,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.518Z",
+        "evaluatedAt": "2026-05-05T23:45:42.444Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11636,7 +12869,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.518Z",
+          "evaluatedAt": "2026-05-05T23:45:42.444Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11654,7 +12887,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.518Z",
+          "evaluatedAt": "2026-05-05T23:45:42.444Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11718,7 +12951,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.519Z",
+        "evaluatedAt": "2026-05-05T23:45:42.445Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11773,7 +13006,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.519Z",
+          "evaluatedAt": "2026-05-05T23:45:42.445Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11791,7 +13024,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.519Z",
+          "evaluatedAt": "2026-05-05T23:45:42.445Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11855,7 +13088,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.523Z",
+        "evaluatedAt": "2026-05-05T23:45:42.448Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -11910,7 +13143,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.523Z",
+          "evaluatedAt": "2026-05-05T23:45:42.448Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -11928,7 +13161,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.523Z",
+          "evaluatedAt": "2026-05-05T23:45:42.448Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -11992,7 +13225,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.526Z",
+        "evaluatedAt": "2026-05-05T23:45:42.452Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12047,7 +13280,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.526Z",
+          "evaluatedAt": "2026-05-05T23:45:42.452Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12065,7 +13298,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.526Z",
+          "evaluatedAt": "2026-05-05T23:45:42.452Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12129,7 +13362,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.529Z",
+        "evaluatedAt": "2026-05-05T23:45:42.455Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12184,7 +13417,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.529Z",
+          "evaluatedAt": "2026-05-05T23:45:42.455Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12202,7 +13435,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.529Z",
+          "evaluatedAt": "2026-05-05T23:45:42.455Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12266,7 +13499,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.533Z",
+        "evaluatedAt": "2026-05-05T23:45:42.458Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12321,7 +13554,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.533Z",
+          "evaluatedAt": "2026-05-05T23:45:42.458Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12339,7 +13572,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.533Z",
+          "evaluatedAt": "2026-05-05T23:45:42.458Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12403,7 +13636,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.535Z",
+        "evaluatedAt": "2026-05-05T23:45:42.461Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12458,7 +13691,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.535Z",
+          "evaluatedAt": "2026-05-05T23:45:42.461Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12476,7 +13709,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.535Z",
+          "evaluatedAt": "2026-05-05T23:45:42.461Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12540,7 +13773,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.537Z",
+        "evaluatedAt": "2026-05-05T23:45:42.462Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12595,7 +13828,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.537Z",
+          "evaluatedAt": "2026-05-05T23:45:42.462Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12613,7 +13846,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.537Z",
+          "evaluatedAt": "2026-05-05T23:45:42.462Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12677,7 +13910,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.540Z",
+        "evaluatedAt": "2026-05-05T23:45:42.465Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12732,7 +13965,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.541Z",
+          "evaluatedAt": "2026-05-05T23:45:42.466Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12750,7 +13983,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.541Z",
+          "evaluatedAt": "2026-05-05T23:45:42.466Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12814,7 +14047,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.544Z",
+        "evaluatedAt": "2026-05-05T23:45:42.470Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -12869,7 +14102,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.544Z",
+          "evaluatedAt": "2026-05-05T23:45:42.470Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -12887,7 +14120,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.544Z",
+          "evaluatedAt": "2026-05-05T23:45:42.470Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -12951,7 +14184,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.546Z",
+        "evaluatedAt": "2026-05-05T23:45:42.471Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13006,7 +14239,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.546Z",
+          "evaluatedAt": "2026-05-05T23:45:42.471Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13024,7 +14257,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.546Z",
+          "evaluatedAt": "2026-05-05T23:45:42.471Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13088,7 +14321,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.547Z",
+        "evaluatedAt": "2026-05-05T23:45:42.472Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13143,7 +14376,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.547Z",
+          "evaluatedAt": "2026-05-05T23:45:42.472Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13161,7 +14394,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.547Z",
+          "evaluatedAt": "2026-05-05T23:45:42.472Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13225,7 +14458,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.548Z",
+        "evaluatedAt": "2026-05-05T23:45:42.473Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13280,7 +14513,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.548Z",
+          "evaluatedAt": "2026-05-05T23:45:42.473Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13298,7 +14531,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.548Z",
+          "evaluatedAt": "2026-05-05T23:45:42.473Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13362,7 +14595,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.548Z",
+        "evaluatedAt": "2026-05-05T23:45:42.473Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13417,7 +14650,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.548Z",
+          "evaluatedAt": "2026-05-05T23:45:42.473Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13435,7 +14668,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.548Z",
+          "evaluatedAt": "2026-05-05T23:45:42.473Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13499,7 +14732,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.549Z",
+        "evaluatedAt": "2026-05-05T23:45:42.473Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13554,7 +14787,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.549Z",
+          "evaluatedAt": "2026-05-05T23:45:42.473Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13572,7 +14805,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.549Z",
+          "evaluatedAt": "2026-05-05T23:45:42.473Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13636,7 +14869,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.549Z",
+        "evaluatedAt": "2026-05-05T23:45:42.474Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13691,7 +14924,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.549Z",
+          "evaluatedAt": "2026-05-05T23:45:42.474Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13709,7 +14942,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.549Z",
+          "evaluatedAt": "2026-05-05T23:45:42.474Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13773,7 +15006,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.550Z",
+        "evaluatedAt": "2026-05-05T23:45:42.475Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13828,7 +15061,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.550Z",
+          "evaluatedAt": "2026-05-05T23:45:42.475Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13846,7 +15079,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.550Z",
+          "evaluatedAt": "2026-05-05T23:45:42.475Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -13910,7 +15143,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.551Z",
+        "evaluatedAt": "2026-05-05T23:45:42.476Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -13965,7 +15198,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.551Z",
+          "evaluatedAt": "2026-05-05T23:45:42.476Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -13983,7 +15216,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.551Z",
+          "evaluatedAt": "2026-05-05T23:45:42.476Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14047,7 +15280,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.552Z",
+        "evaluatedAt": "2026-05-05T23:45:42.477Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14102,7 +15335,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.552Z",
+          "evaluatedAt": "2026-05-05T23:45:42.477Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14120,7 +15353,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.552Z",
+          "evaluatedAt": "2026-05-05T23:45:42.477Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14184,7 +15417,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.554Z",
+        "evaluatedAt": "2026-05-05T23:45:42.478Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14239,7 +15472,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.554Z",
+          "evaluatedAt": "2026-05-05T23:45:42.478Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14257,7 +15490,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.554Z",
+          "evaluatedAt": "2026-05-05T23:45:42.478Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14321,7 +15554,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.554Z",
+        "evaluatedAt": "2026-05-05T23:45:42.479Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14376,7 +15609,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.554Z",
+          "evaluatedAt": "2026-05-05T23:45:42.479Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14394,7 +15627,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.555Z",
+          "evaluatedAt": "2026-05-05T23:45:42.479Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14458,7 +15691,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.555Z",
+        "evaluatedAt": "2026-05-05T23:45:42.480Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14513,7 +15746,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.555Z",
+          "evaluatedAt": "2026-05-05T23:45:42.480Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14531,7 +15764,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.555Z",
+          "evaluatedAt": "2026-05-05T23:45:42.480Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14595,7 +15828,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.556Z",
+        "evaluatedAt": "2026-05-05T23:45:42.481Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14650,7 +15883,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.556Z",
+          "evaluatedAt": "2026-05-05T23:45:42.481Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14668,7 +15901,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.556Z",
+          "evaluatedAt": "2026-05-05T23:45:42.481Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14732,7 +15965,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.558Z",
+        "evaluatedAt": "2026-05-05T23:45:42.482Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14787,7 +16020,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.558Z",
+          "evaluatedAt": "2026-05-05T23:45:42.482Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14805,7 +16038,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.558Z",
+          "evaluatedAt": "2026-05-05T23:45:42.482Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -14869,7 +16102,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.559Z",
+        "evaluatedAt": "2026-05-05T23:45:42.483Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -14924,7 +16157,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.559Z",
+          "evaluatedAt": "2026-05-05T23:45:42.483Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -14942,7 +16175,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.559Z",
+          "evaluatedAt": "2026-05-05T23:45:42.483Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15006,7 +16239,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.560Z",
+        "evaluatedAt": "2026-05-05T23:45:42.484Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15061,7 +16294,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.560Z",
+          "evaluatedAt": "2026-05-05T23:45:42.484Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15079,7 +16312,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.560Z",
+          "evaluatedAt": "2026-05-05T23:45:42.484Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15143,7 +16376,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.561Z",
+        "evaluatedAt": "2026-05-05T23:45:42.485Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15198,7 +16431,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.561Z",
+          "evaluatedAt": "2026-05-05T23:45:42.485Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15216,7 +16449,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.561Z",
+          "evaluatedAt": "2026-05-05T23:45:42.485Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15280,7 +16513,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.563Z",
+        "evaluatedAt": "2026-05-05T23:45:42.486Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15335,7 +16568,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.563Z",
+          "evaluatedAt": "2026-05-05T23:45:42.486Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15353,7 +16586,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.563Z",
+          "evaluatedAt": "2026-05-05T23:45:42.486Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15417,7 +16650,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.564Z",
+        "evaluatedAt": "2026-05-05T23:45:42.487Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15472,7 +16705,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.564Z",
+          "evaluatedAt": "2026-05-05T23:45:42.487Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15490,7 +16723,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.564Z",
+          "evaluatedAt": "2026-05-05T23:45:42.487Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15554,7 +16787,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.565Z",
+        "evaluatedAt": "2026-05-05T23:45:42.488Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15609,7 +16842,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.565Z",
+          "evaluatedAt": "2026-05-05T23:45:42.488Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15627,7 +16860,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.565Z",
+          "evaluatedAt": "2026-05-05T23:45:42.488Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15691,7 +16924,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.566Z",
+        "evaluatedAt": "2026-05-05T23:45:42.489Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15746,7 +16979,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.566Z",
+          "evaluatedAt": "2026-05-05T23:45:42.489Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15764,7 +16997,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.566Z",
+          "evaluatedAt": "2026-05-05T23:45:42.489Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15828,7 +17061,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.566Z",
+        "evaluatedAt": "2026-05-05T23:45:42.490Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -15883,7 +17116,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.566Z",
+          "evaluatedAt": "2026-05-05T23:45:42.490Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -15901,7 +17134,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.566Z",
+          "evaluatedAt": "2026-05-05T23:45:42.490Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -15965,7 +17198,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.567Z",
+        "evaluatedAt": "2026-05-05T23:45:42.491Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16020,7 +17253,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.567Z",
+          "evaluatedAt": "2026-05-05T23:45:42.491Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16038,7 +17271,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.567Z",
+          "evaluatedAt": "2026-05-05T23:45:42.491Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16102,7 +17335,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.568Z",
+        "evaluatedAt": "2026-05-05T23:45:42.491Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16157,7 +17390,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.568Z",
+          "evaluatedAt": "2026-05-05T23:45:42.491Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16175,7 +17408,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.568Z",
+          "evaluatedAt": "2026-05-05T23:45:42.491Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16239,7 +17472,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.569Z",
+        "evaluatedAt": "2026-05-05T23:45:42.492Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16294,7 +17527,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.569Z",
+          "evaluatedAt": "2026-05-05T23:45:42.492Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16312,7 +17545,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.569Z",
+          "evaluatedAt": "2026-05-05T23:45:42.492Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16376,7 +17609,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.570Z",
+        "evaluatedAt": "2026-05-05T23:45:42.493Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16431,7 +17664,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.570Z",
+          "evaluatedAt": "2026-05-05T23:45:42.493Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16449,7 +17682,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.570Z",
+          "evaluatedAt": "2026-05-05T23:45:42.493Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16513,7 +17746,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.570Z",
+        "evaluatedAt": "2026-05-05T23:45:42.494Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16568,7 +17801,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.570Z",
+          "evaluatedAt": "2026-05-05T23:45:42.494Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16586,7 +17819,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.570Z",
+          "evaluatedAt": "2026-05-05T23:45:42.494Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16650,7 +17883,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.571Z",
+        "evaluatedAt": "2026-05-05T23:45:42.495Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16705,7 +17938,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.571Z",
+          "evaluatedAt": "2026-05-05T23:45:42.495Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16723,7 +17956,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.571Z",
+          "evaluatedAt": "2026-05-05T23:45:42.495Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16787,7 +18020,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.572Z",
+        "evaluatedAt": "2026-05-05T23:45:42.496Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16842,7 +18075,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.572Z",
+          "evaluatedAt": "2026-05-05T23:45:42.496Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16860,7 +18093,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.572Z",
+          "evaluatedAt": "2026-05-05T23:45:42.496Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -16924,7 +18157,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.573Z",
+        "evaluatedAt": "2026-05-05T23:45:42.496Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -16979,7 +18212,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.573Z",
+          "evaluatedAt": "2026-05-05T23:45:42.496Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -16997,7 +18230,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.573Z",
+          "evaluatedAt": "2026-05-05T23:45:42.496Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17061,7 +18294,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.574Z",
+        "evaluatedAt": "2026-05-05T23:45:42.498Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17116,7 +18349,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.574Z",
+          "evaluatedAt": "2026-05-05T23:45:42.498Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17134,7 +18367,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.574Z",
+          "evaluatedAt": "2026-05-05T23:45:42.498Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17198,7 +18431,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.577Z",
+        "evaluatedAt": "2026-05-05T23:45:42.500Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17253,7 +18486,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.577Z",
+          "evaluatedAt": "2026-05-05T23:45:42.500Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17271,7 +18504,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.577Z",
+          "evaluatedAt": "2026-05-05T23:45:42.500Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17335,7 +18568,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.578Z",
+        "evaluatedAt": "2026-05-05T23:45:42.502Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17390,7 +18623,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.578Z",
+          "evaluatedAt": "2026-05-05T23:45:42.502Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17408,7 +18641,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.578Z",
+          "evaluatedAt": "2026-05-05T23:45:42.502Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17472,7 +18705,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.579Z",
+        "evaluatedAt": "2026-05-05T23:45:42.503Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17527,7 +18760,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.579Z",
+          "evaluatedAt": "2026-05-05T23:45:42.503Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17545,7 +18778,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.579Z",
+          "evaluatedAt": "2026-05-05T23:45:42.503Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17609,7 +18842,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.580Z",
+        "evaluatedAt": "2026-05-05T23:45:42.503Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17664,7 +18897,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.580Z",
+          "evaluatedAt": "2026-05-05T23:45:42.503Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17682,7 +18915,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.580Z",
+          "evaluatedAt": "2026-05-05T23:45:42.503Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17746,7 +18979,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.581Z",
+        "evaluatedAt": "2026-05-05T23:45:42.504Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17801,7 +19034,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.581Z",
+          "evaluatedAt": "2026-05-05T23:45:42.504Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17819,7 +19052,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.581Z",
+          "evaluatedAt": "2026-05-05T23:45:42.505Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -17883,7 +19116,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.582Z",
+        "evaluatedAt": "2026-05-05T23:45:42.505Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -17938,7 +19171,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.582Z",
+          "evaluatedAt": "2026-05-05T23:45:42.505Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -17956,7 +19189,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.582Z",
+          "evaluatedAt": "2026-05-05T23:45:42.505Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18020,7 +19253,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.583Z",
+        "evaluatedAt": "2026-05-05T23:45:42.506Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18075,7 +19308,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.583Z",
+          "evaluatedAt": "2026-05-05T23:45:42.506Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18093,7 +19326,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.583Z",
+          "evaluatedAt": "2026-05-05T23:45:42.506Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18157,7 +19390,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.583Z",
+        "evaluatedAt": "2026-05-05T23:45:42.507Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18212,7 +19445,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.583Z",
+          "evaluatedAt": "2026-05-05T23:45:42.507Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18230,7 +19463,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.583Z",
+          "evaluatedAt": "2026-05-05T23:45:42.507Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18294,7 +19527,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.584Z",
+        "evaluatedAt": "2026-05-05T23:45:42.508Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18349,7 +19582,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.584Z",
+          "evaluatedAt": "2026-05-05T23:45:42.508Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18367,7 +19600,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.584Z",
+          "evaluatedAt": "2026-05-05T23:45:42.508Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18431,7 +19664,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.586Z",
+        "evaluatedAt": "2026-05-05T23:45:42.510Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18486,7 +19719,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.586Z",
+          "evaluatedAt": "2026-05-05T23:45:42.510Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18504,7 +19737,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.586Z",
+          "evaluatedAt": "2026-05-05T23:45:42.510Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18568,7 +19801,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.588Z",
+        "evaluatedAt": "2026-05-05T23:45:42.512Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18623,7 +19856,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.588Z",
+          "evaluatedAt": "2026-05-05T23:45:42.512Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18641,7 +19874,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.588Z",
+          "evaluatedAt": "2026-05-05T23:45:42.512Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18705,7 +19938,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.589Z",
+        "evaluatedAt": "2026-05-05T23:45:42.513Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18760,7 +19993,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.589Z",
+          "evaluatedAt": "2026-05-05T23:45:42.513Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18778,7 +20011,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.589Z",
+          "evaluatedAt": "2026-05-05T23:45:42.513Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18842,7 +20075,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.590Z",
+        "evaluatedAt": "2026-05-05T23:45:42.514Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -18897,7 +20130,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.590Z",
+          "evaluatedAt": "2026-05-05T23:45:42.514Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -18915,7 +20148,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.590Z",
+          "evaluatedAt": "2026-05-05T23:45:42.514Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -18979,7 +20212,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.590Z",
+        "evaluatedAt": "2026-05-05T23:45:42.515Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19034,7 +20267,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.590Z",
+          "evaluatedAt": "2026-05-05T23:45:42.515Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19052,7 +20285,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.590Z",
+          "evaluatedAt": "2026-05-05T23:45:42.515Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19116,7 +20349,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.591Z",
+        "evaluatedAt": "2026-05-05T23:45:42.516Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19171,7 +20404,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.591Z",
+          "evaluatedAt": "2026-05-05T23:45:42.516Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19189,7 +20422,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.591Z",
+          "evaluatedAt": "2026-05-05T23:45:42.516Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19253,7 +20486,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.592Z",
+        "evaluatedAt": "2026-05-05T23:45:42.516Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19308,7 +20541,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.592Z",
+          "evaluatedAt": "2026-05-05T23:45:42.516Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19326,7 +20559,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.592Z",
+          "evaluatedAt": "2026-05-05T23:45:42.516Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19390,7 +20623,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.592Z",
+        "evaluatedAt": "2026-05-05T23:45:42.517Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19445,7 +20678,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.592Z",
+          "evaluatedAt": "2026-05-05T23:45:42.517Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19463,7 +20696,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.592Z",
+          "evaluatedAt": "2026-05-05T23:45:42.517Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19527,7 +20760,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.593Z",
+        "evaluatedAt": "2026-05-05T23:45:42.518Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19582,7 +20815,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.593Z",
+          "evaluatedAt": "2026-05-05T23:45:42.518Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19600,7 +20833,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.593Z",
+          "evaluatedAt": "2026-05-05T23:45:42.518Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19664,7 +20897,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.595Z",
+        "evaluatedAt": "2026-05-05T23:45:42.519Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19719,7 +20952,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.595Z",
+          "evaluatedAt": "2026-05-05T23:45:42.519Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19737,7 +20970,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.595Z",
+          "evaluatedAt": "2026-05-05T23:45:42.519Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19801,7 +21034,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.595Z",
+        "evaluatedAt": "2026-05-05T23:45:42.520Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19856,7 +21089,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.595Z",
+          "evaluatedAt": "2026-05-05T23:45:42.520Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -19874,7 +21107,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.596Z",
+          "evaluatedAt": "2026-05-05T23:45:42.520Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -19938,7 +21171,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.596Z",
+        "evaluatedAt": "2026-05-05T23:45:42.521Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -19993,7 +21226,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.596Z",
+          "evaluatedAt": "2026-05-05T23:45:42.521Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20011,7 +21244,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.596Z",
+          "evaluatedAt": "2026-05-05T23:45:42.521Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20075,7 +21308,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.598Z",
+        "evaluatedAt": "2026-05-05T23:45:42.522Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20130,7 +21363,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.598Z",
+          "evaluatedAt": "2026-05-05T23:45:42.522Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20148,7 +21381,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.598Z",
+          "evaluatedAt": "2026-05-05T23:45:42.522Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20212,7 +21445,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.599Z",
+        "evaluatedAt": "2026-05-05T23:45:42.524Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20267,7 +21500,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.599Z",
+          "evaluatedAt": "2026-05-05T23:45:42.524Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20285,7 +21518,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.599Z",
+          "evaluatedAt": "2026-05-05T23:45:42.524Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20349,7 +21582,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.600Z",
+        "evaluatedAt": "2026-05-05T23:45:42.524Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20404,7 +21637,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.600Z",
+          "evaluatedAt": "2026-05-05T23:45:42.524Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20422,7 +21655,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.600Z",
+          "evaluatedAt": "2026-05-05T23:45:42.524Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20486,7 +21719,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.601Z",
+        "evaluatedAt": "2026-05-05T23:45:42.525Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20541,7 +21774,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.601Z",
+          "evaluatedAt": "2026-05-05T23:45:42.525Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20559,7 +21792,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.601Z",
+          "evaluatedAt": "2026-05-05T23:45:42.525Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20623,7 +21856,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.602Z",
+        "evaluatedAt": "2026-05-05T23:45:42.526Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20678,7 +21911,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.602Z",
+          "evaluatedAt": "2026-05-05T23:45:42.526Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20696,7 +21929,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.602Z",
+          "evaluatedAt": "2026-05-05T23:45:42.526Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20760,7 +21993,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.602Z",
+        "evaluatedAt": "2026-05-05T23:45:42.527Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20815,7 +22048,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.602Z",
+          "evaluatedAt": "2026-05-05T23:45:42.527Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20833,7 +22066,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.602Z",
+          "evaluatedAt": "2026-05-05T23:45:42.527Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -20897,7 +22130,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.603Z",
+        "evaluatedAt": "2026-05-05T23:45:42.528Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -20952,7 +22185,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.603Z",
+          "evaluatedAt": "2026-05-05T23:45:42.528Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -20970,7 +22203,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.603Z",
+          "evaluatedAt": "2026-05-05T23:45:42.528Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21034,7 +22267,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.604Z",
+        "evaluatedAt": "2026-05-05T23:45:42.529Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21089,7 +22322,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.604Z",
+          "evaluatedAt": "2026-05-05T23:45:42.530Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21107,7 +22340,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.604Z",
+          "evaluatedAt": "2026-05-05T23:45:42.530Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21171,7 +22404,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.606Z",
+        "evaluatedAt": "2026-05-05T23:45:42.531Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21226,7 +22459,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.606Z",
+          "evaluatedAt": "2026-05-05T23:45:42.531Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21244,7 +22477,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.606Z",
+          "evaluatedAt": "2026-05-05T23:45:42.531Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21308,7 +22541,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.608Z",
+        "evaluatedAt": "2026-05-05T23:45:42.533Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21363,7 +22596,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.608Z",
+          "evaluatedAt": "2026-05-05T23:45:42.533Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21381,7 +22614,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.608Z",
+          "evaluatedAt": "2026-05-05T23:45:42.533Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21445,7 +22678,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.610Z",
+        "evaluatedAt": "2026-05-05T23:45:42.535Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21500,7 +22733,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.610Z",
+          "evaluatedAt": "2026-05-05T23:45:42.535Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21518,7 +22751,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.610Z",
+          "evaluatedAt": "2026-05-05T23:45:42.535Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21582,7 +22815,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.612Z",
+        "evaluatedAt": "2026-05-05T23:45:42.538Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21637,7 +22870,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.613Z",
+          "evaluatedAt": "2026-05-05T23:45:42.538Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21655,7 +22888,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.613Z",
+          "evaluatedAt": "2026-05-05T23:45:42.538Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "drawio",
+      "description": "Generate draw.io diagrams as .drawio files and export to PNG/SVG/PDF with embedded XML",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:plugins/project-documenter/skills/drawio",
+      "relPath": "plugins/project-documenter/skills/drawio",
+      "verified": true,
+      "tokenCount": 679,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.540Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.540Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.540Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "drawio",
+      "description": "Generate draw.io diagrams as .drawio files and export to PNG/SVG/PDF with embedded XML",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:skills/drawio",
+      "relPath": "skills/drawio",
+      "verified": true,
+      "tokenCount": 679,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.541Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.541Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.541Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21719,7 +23226,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.615Z",
+        "evaluatedAt": "2026-05-05T23:45:42.542Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21774,7 +23281,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.615Z",
+          "evaluatedAt": "2026-05-05T23:45:42.542Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21792,7 +23299,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.615Z",
+          "evaluatedAt": "2026-05-05T23:45:42.542Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21856,7 +23363,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.615Z",
+        "evaluatedAt": "2026-05-05T23:45:42.543Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -21911,7 +23418,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.615Z",
+          "evaluatedAt": "2026-05-05T23:45:42.543Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -21929,7 +23436,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.615Z",
+          "evaluatedAt": "2026-05-05T23:45:42.543Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -21993,7 +23500,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.616Z",
+        "evaluatedAt": "2026-05-05T23:45:42.544Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22048,7 +23555,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.616Z",
+          "evaluatedAt": "2026-05-05T23:45:42.544Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22066,7 +23573,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.616Z",
+          "evaluatedAt": "2026-05-05T23:45:42.544Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22130,7 +23637,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.618Z",
+        "evaluatedAt": "2026-05-05T23:45:42.545Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22185,7 +23692,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.618Z",
+          "evaluatedAt": "2026-05-05T23:45:42.545Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22203,7 +23710,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.618Z",
+          "evaluatedAt": "2026-05-05T23:45:42.545Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22267,7 +23774,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.620Z",
+        "evaluatedAt": "2026-05-05T23:45:42.547Z",
         "evaluatedVersion": "0.8.4"
       },
       "evalSummaries": {
@@ -22322,7 +23829,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.620Z",
+          "evaluatedAt": "2026-05-05T23:45:42.547Z",
           "evaluatedVersion": "0.8.4"
         },
         "skill-best-practice": {
@@ -22340,7 +23847,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.620Z",
+          "evaluatedAt": "2026-05-05T23:45:42.547Z",
           "evaluatedVersion": "0.8.4"
         }
       }
@@ -22404,7 +23911,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.622Z",
+        "evaluatedAt": "2026-05-05T23:45:42.549Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22459,7 +23966,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.622Z",
+          "evaluatedAt": "2026-05-05T23:45:42.549Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22477,7 +23984,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.622Z",
+          "evaluatedAt": "2026-05-05T23:45:42.549Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22541,7 +24048,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.624Z",
+        "evaluatedAt": "2026-05-05T23:45:42.551Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22596,7 +24103,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.624Z",
+          "evaluatedAt": "2026-05-05T23:45:42.551Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22614,7 +24121,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.624Z",
+          "evaluatedAt": "2026-05-05T23:45:42.551Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "eyeball",
+      "description": "Document analysis with inline source screenshots. When you ask Copilot to analyze a document, Eyeball generates a Word doc where every factual claim includes a highlighted screenshot from the source material so you can verify it with your own eyes.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:plugins/eyeball/skills/eyeball",
+      "relPath": "plugins/eyeball/skills/eyeball",
+      "verified": true,
+      "tokenCount": 1901,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.554Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 76,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.554Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.554Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "eyeball",
+      "description": "Document analysis with inline source screenshots. When you ask Copilot to analyze a document, Eyeball generates a Word doc where every factual claim includes a highlighted screenshot from the source material so you can verify it with your own eyes.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:skills/eyeball",
+      "relPath": "skills/eyeball",
+      "verified": true,
+      "tokenCount": 1901,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.555Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 76,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.555Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.555Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22678,7 +24459,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.626Z",
+        "evaluatedAt": "2026-05-05T23:45:42.556Z",
         "evaluatedVersion": "1.0"
       },
       "evalSummaries": {
@@ -22733,7 +24514,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.626Z",
+          "evaluatedAt": "2026-05-05T23:45:42.556Z",
           "evaluatedVersion": "1.0"
         },
         "skill-best-practice": {
@@ -22751,7 +24532,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.626Z",
+          "evaluatedAt": "2026-05-05T23:45:42.556Z",
           "evaluatedVersion": "1.0"
         }
       }
@@ -22815,7 +24596,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.627Z",
+        "evaluatedAt": "2026-05-05T23:45:42.557Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -22870,7 +24651,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.627Z",
+          "evaluatedAt": "2026-05-05T23:45:42.557Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -22888,7 +24669,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.627Z",
+          "evaluatedAt": "2026-05-05T23:45:42.557Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -22952,7 +24733,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.628Z",
+        "evaluatedAt": "2026-05-05T23:45:42.558Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23007,7 +24788,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.628Z",
+          "evaluatedAt": "2026-05-05T23:45:42.558Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23025,7 +24806,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.628Z",
+          "evaluatedAt": "2026-05-05T23:45:42.558Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23089,7 +24870,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.628Z",
+        "evaluatedAt": "2026-05-05T23:45:42.559Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23144,7 +24925,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.628Z",
+          "evaluatedAt": "2026-05-05T23:45:42.559Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23162,7 +24943,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.628Z",
+          "evaluatedAt": "2026-05-05T23:45:42.559Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23226,7 +25007,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.629Z",
+        "evaluatedAt": "2026-05-05T23:45:42.560Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23281,7 +25062,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.629Z",
+          "evaluatedAt": "2026-05-05T23:45:42.560Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23299,7 +25080,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.629Z",
+          "evaluatedAt": "2026-05-05T23:45:42.560Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23363,7 +25144,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.631Z",
+        "evaluatedAt": "2026-05-05T23:45:42.561Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23418,7 +25199,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.631Z",
+          "evaluatedAt": "2026-05-05T23:45:42.561Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23436,7 +25217,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.631Z",
+          "evaluatedAt": "2026-05-05T23:45:42.561Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23500,7 +25281,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.634Z",
+        "evaluatedAt": "2026-05-05T23:45:42.564Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23555,7 +25336,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.634Z",
+          "evaluatedAt": "2026-05-05T23:45:42.564Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23573,7 +25354,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.634Z",
+          "evaluatedAt": "2026-05-05T23:45:42.564Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23637,7 +25418,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.637Z",
+        "evaluatedAt": "2026-05-05T23:45:42.567Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23692,7 +25473,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.637Z",
+          "evaluatedAt": "2026-05-05T23:45:42.567Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23710,7 +25491,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.637Z",
+          "evaluatedAt": "2026-05-05T23:45:42.567Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23774,7 +25555,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.640Z",
+        "evaluatedAt": "2026-05-05T23:45:42.570Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23829,7 +25610,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.640Z",
+          "evaluatedAt": "2026-05-05T23:45:42.570Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23847,7 +25628,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.640Z",
+          "evaluatedAt": "2026-05-05T23:45:42.570Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -23911,7 +25692,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.643Z",
+        "evaluatedAt": "2026-05-05T23:45:42.573Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -23966,7 +25747,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.643Z",
+          "evaluatedAt": "2026-05-05T23:45:42.573Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -23984,7 +25765,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.643Z",
+          "evaluatedAt": "2026-05-05T23:45:42.573Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24048,7 +25829,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.647Z",
+        "evaluatedAt": "2026-05-05T23:45:42.577Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24103,7 +25884,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.647Z",
+          "evaluatedAt": "2026-05-05T23:45:42.577Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24121,7 +25902,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.647Z",
+          "evaluatedAt": "2026-05-05T23:45:42.577Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24185,7 +25966,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.650Z",
+        "evaluatedAt": "2026-05-05T23:45:42.580Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24240,7 +26021,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.650Z",
+          "evaluatedAt": "2026-05-05T23:45:42.580Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24258,7 +26039,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.650Z",
+          "evaluatedAt": "2026-05-05T23:45:42.580Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24322,7 +26103,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.652Z",
+        "evaluatedAt": "2026-05-05T23:45:42.582Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24377,7 +26158,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.652Z",
+          "evaluatedAt": "2026-05-05T23:45:42.582Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24395,7 +26176,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.652Z",
+          "evaluatedAt": "2026-05-05T23:45:42.582Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24459,7 +26240,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.654Z",
+        "evaluatedAt": "2026-05-05T23:45:42.584Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24514,7 +26295,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.654Z",
+          "evaluatedAt": "2026-05-05T23:45:42.584Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24532,7 +26313,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.654Z",
+          "evaluatedAt": "2026-05-05T23:45:42.584Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24596,7 +26377,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.657Z",
+        "evaluatedAt": "2026-05-05T23:45:42.586Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24651,7 +26432,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.657Z",
+          "evaluatedAt": "2026-05-05T23:45:42.586Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24669,7 +26450,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.657Z",
+          "evaluatedAt": "2026-05-05T23:45:42.586Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24733,7 +26514,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.659Z",
+        "evaluatedAt": "2026-05-05T23:45:42.588Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24788,7 +26569,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.659Z",
+          "evaluatedAt": "2026-05-05T23:45:42.588Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24806,7 +26587,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.659Z",
+          "evaluatedAt": "2026-05-05T23:45:42.588Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -24870,7 +26651,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.660Z",
+        "evaluatedAt": "2026-05-05T23:45:42.590Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -24925,7 +26706,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.661Z",
+          "evaluatedAt": "2026-05-05T23:45:42.590Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -24943,7 +26724,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.661Z",
+          "evaluatedAt": "2026-05-05T23:45:42.590Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25007,7 +26788,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.662Z",
+        "evaluatedAt": "2026-05-05T23:45:42.591Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25062,7 +26843,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.662Z",
+          "evaluatedAt": "2026-05-05T23:45:42.592Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25080,7 +26861,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.662Z",
+          "evaluatedAt": "2026-05-05T23:45:42.592Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25144,7 +26925,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.665Z",
+        "evaluatedAt": "2026-05-05T23:45:42.594Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25199,7 +26980,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.665Z",
+          "evaluatedAt": "2026-05-05T23:45:42.594Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25217,7 +26998,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.665Z",
+          "evaluatedAt": "2026-05-05T23:45:42.594Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25281,7 +27062,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.667Z",
+        "evaluatedAt": "2026-05-05T23:45:42.596Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25336,7 +27117,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.667Z",
+          "evaluatedAt": "2026-05-05T23:45:42.596Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25354,7 +27135,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.667Z",
+          "evaluatedAt": "2026-05-05T23:45:42.596Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25418,7 +27199,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.668Z",
+        "evaluatedAt": "2026-05-05T23:45:42.597Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25473,7 +27254,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.668Z",
+          "evaluatedAt": "2026-05-05T23:45:42.597Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25491,7 +27272,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.668Z",
+          "evaluatedAt": "2026-05-05T23:45:42.597Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25555,7 +27336,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.669Z",
+        "evaluatedAt": "2026-05-05T23:45:42.598Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25610,7 +27391,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.669Z",
+          "evaluatedAt": "2026-05-05T23:45:42.598Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25628,7 +27409,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.669Z",
+          "evaluatedAt": "2026-05-05T23:45:42.598Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25692,7 +27473,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.670Z",
+        "evaluatedAt": "2026-05-05T23:45:42.600Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25747,7 +27528,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.670Z",
+          "evaluatedAt": "2026-05-05T23:45:42.600Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25765,7 +27546,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.670Z",
+          "evaluatedAt": "2026-05-05T23:45:42.600Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25829,7 +27610,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.672Z",
+        "evaluatedAt": "2026-05-05T23:45:42.601Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -25884,7 +27665,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.672Z",
+          "evaluatedAt": "2026-05-05T23:45:42.601Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -25902,7 +27683,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.672Z",
+          "evaluatedAt": "2026-05-05T23:45:42.601Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -25966,7 +27747,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.673Z",
+        "evaluatedAt": "2026-05-05T23:45:42.603Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26021,7 +27802,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.673Z",
+          "evaluatedAt": "2026-05-05T23:45:42.603Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26039,7 +27820,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.673Z",
+          "evaluatedAt": "2026-05-05T23:45:42.603Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26103,7 +27884,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.678Z",
+        "evaluatedAt": "2026-05-05T23:45:42.606Z",
         "evaluatedVersion": "0.0.9"
       },
       "evalSummaries": {
@@ -26158,7 +27939,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.678Z",
+          "evaluatedAt": "2026-05-05T23:45:42.606Z",
           "evaluatedVersion": "0.0.9"
         },
         "skill-best-practice": {
@@ -26176,7 +27957,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.678Z",
+          "evaluatedAt": "2026-05-05T23:45:42.606Z",
           "evaluatedVersion": "0.0.9"
         }
       }
@@ -26240,7 +28021,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.684Z",
+        "evaluatedAt": "2026-05-05T23:45:42.612Z",
         "evaluatedVersion": "0.0.9"
       },
       "evalSummaries": {
@@ -26295,7 +28076,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.684Z",
+          "evaluatedAt": "2026-05-05T23:45:42.612Z",
           "evaluatedVersion": "0.0.9"
         },
         "skill-best-practice": {
@@ -26313,7 +28094,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.684Z",
+          "evaluatedAt": "2026-05-05T23:45:42.612Z",
           "evaluatedVersion": "0.0.9"
         }
       }
@@ -26377,7 +28158,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.690Z",
+        "evaluatedAt": "2026-05-05T23:45:42.618Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26432,7 +28213,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.691Z",
+          "evaluatedAt": "2026-05-05T23:45:42.618Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26450,7 +28231,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.691Z",
+          "evaluatedAt": "2026-05-05T23:45:42.618Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26514,7 +28295,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.694Z",
+        "evaluatedAt": "2026-05-05T23:45:42.622Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26569,7 +28350,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.694Z",
+          "evaluatedAt": "2026-05-05T23:45:42.622Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26587,7 +28368,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.694Z",
+          "evaluatedAt": "2026-05-05T23:45:42.622Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26651,7 +28432,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.695Z",
+        "evaluatedAt": "2026-05-05T23:45:42.623Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26706,7 +28487,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.696Z",
+          "evaluatedAt": "2026-05-05T23:45:42.623Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26724,7 +28505,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.696Z",
+          "evaluatedAt": "2026-05-05T23:45:42.623Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26788,7 +28569,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.697Z",
+        "evaluatedAt": "2026-05-05T23:45:42.626Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26843,7 +28624,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.697Z",
+          "evaluatedAt": "2026-05-05T23:45:42.626Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26861,7 +28642,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.698Z",
+          "evaluatedAt": "2026-05-05T23:45:42.626Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -26925,7 +28706,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.699Z",
+        "evaluatedAt": "2026-05-05T23:45:42.628Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -26980,7 +28761,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.699Z",
+          "evaluatedAt": "2026-05-05T23:45:42.628Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -26998,7 +28779,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.699Z",
+          "evaluatedAt": "2026-05-05T23:45:42.628Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27062,7 +28843,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.701Z",
+        "evaluatedAt": "2026-05-05T23:45:42.630Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27117,7 +28898,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.701Z",
+          "evaluatedAt": "2026-05-05T23:45:42.630Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27135,7 +28916,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.701Z",
+          "evaluatedAt": "2026-05-05T23:45:42.630Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27199,7 +28980,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.703Z",
+        "evaluatedAt": "2026-05-05T23:45:42.632Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27254,7 +29035,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.703Z",
+          "evaluatedAt": "2026-05-05T23:45:42.632Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27272,7 +29053,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.703Z",
+          "evaluatedAt": "2026-05-05T23:45:42.632Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27336,7 +29117,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.704Z",
+        "evaluatedAt": "2026-05-05T23:45:42.634Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27391,7 +29172,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.704Z",
+          "evaluatedAt": "2026-05-05T23:45:42.634Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27409,7 +29190,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.704Z",
+          "evaluatedAt": "2026-05-05T23:45:42.634Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27473,7 +29254,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.706Z",
+        "evaluatedAt": "2026-05-05T23:45:42.635Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27528,7 +29309,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.706Z",
+          "evaluatedAt": "2026-05-05T23:45:42.635Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27546,7 +29327,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.706Z",
+          "evaluatedAt": "2026-05-05T23:45:42.635Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27610,7 +29391,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.708Z",
+        "evaluatedAt": "2026-05-05T23:45:42.637Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27665,7 +29446,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.708Z",
+          "evaluatedAt": "2026-05-05T23:45:42.637Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27683,7 +29464,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.708Z",
+          "evaluatedAt": "2026-05-05T23:45:42.637Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27747,7 +29528,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.711Z",
+        "evaluatedAt": "2026-05-05T23:45:42.640Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27802,7 +29583,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.711Z",
+          "evaluatedAt": "2026-05-05T23:45:42.640Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27820,7 +29601,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.711Z",
+          "evaluatedAt": "2026-05-05T23:45:42.640Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -27884,7 +29665,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.715Z",
+        "evaluatedAt": "2026-05-05T23:45:42.644Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -27939,7 +29720,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.715Z",
+          "evaluatedAt": "2026-05-05T23:45:42.644Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -27957,7 +29738,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.715Z",
+          "evaluatedAt": "2026-05-05T23:45:42.644Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28021,7 +29802,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.717Z",
+        "evaluatedAt": "2026-05-05T23:45:42.646Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28076,7 +29857,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.717Z",
+          "evaluatedAt": "2026-05-05T23:45:42.646Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28094,7 +29875,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.717Z",
+          "evaluatedAt": "2026-05-05T23:45:42.646Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28158,7 +29939,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.719Z",
+        "evaluatedAt": "2026-05-05T23:45:42.649Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28213,7 +29994,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.719Z",
+          "evaluatedAt": "2026-05-05T23:45:42.649Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28231,7 +30012,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.719Z",
+          "evaluatedAt": "2026-05-05T23:45:42.649Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28295,7 +30076,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.722Z",
+        "evaluatedAt": "2026-05-05T23:45:42.651Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28350,7 +30131,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.722Z",
+          "evaluatedAt": "2026-05-05T23:45:42.651Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28368,7 +30149,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.722Z",
+          "evaluatedAt": "2026-05-05T23:45:42.651Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28432,7 +30213,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.725Z",
+        "evaluatedAt": "2026-05-05T23:45:42.654Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28487,7 +30268,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.725Z",
+          "evaluatedAt": "2026-05-05T23:45:42.654Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28505,7 +30286,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.725Z",
+          "evaluatedAt": "2026-05-05T23:45:42.654Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28569,7 +30350,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.728Z",
+        "evaluatedAt": "2026-05-05T23:45:42.657Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28624,7 +30405,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.728Z",
+          "evaluatedAt": "2026-05-05T23:45:42.657Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28642,7 +30423,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.728Z",
+          "evaluatedAt": "2026-05-05T23:45:42.657Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28706,7 +30487,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.731Z",
+        "evaluatedAt": "2026-05-05T23:45:42.660Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28761,7 +30542,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.731Z",
+          "evaluatedAt": "2026-05-05T23:45:42.660Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28779,7 +30560,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.731Z",
+          "evaluatedAt": "2026-05-05T23:45:42.660Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28843,7 +30624,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.733Z",
+        "evaluatedAt": "2026-05-05T23:45:42.662Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -28898,7 +30679,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.733Z",
+          "evaluatedAt": "2026-05-05T23:45:42.662Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -28916,7 +30697,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.733Z",
+          "evaluatedAt": "2026-05-05T23:45:42.662Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -28980,7 +30761,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.736Z",
+        "evaluatedAt": "2026-05-05T23:45:42.664Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29035,7 +30816,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.736Z",
+          "evaluatedAt": "2026-05-05T23:45:42.665Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29053,7 +30834,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.736Z",
+          "evaluatedAt": "2026-05-05T23:45:42.665Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29117,7 +30898,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.738Z",
+        "evaluatedAt": "2026-05-05T23:45:42.666Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29172,7 +30953,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.738Z",
+          "evaluatedAt": "2026-05-05T23:45:42.666Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29190,7 +30971,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.738Z",
+          "evaluatedAt": "2026-05-05T23:45:42.666Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29254,7 +31035,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.739Z",
+        "evaluatedAt": "2026-05-05T23:45:42.668Z",
         "evaluatedVersion": "2.0.0"
       },
       "evalSummaries": {
@@ -29309,7 +31090,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.739Z",
+          "evaluatedAt": "2026-05-05T23:45:42.668Z",
           "evaluatedVersion": "2.0.0"
         },
         "skill-best-practice": {
@@ -29327,7 +31108,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.739Z",
+          "evaluatedAt": "2026-05-05T23:45:42.668Z",
           "evaluatedVersion": "2.0.0"
         }
       }
@@ -29391,7 +31172,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.742Z",
+        "evaluatedAt": "2026-05-05T23:45:42.670Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29446,7 +31227,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.742Z",
+          "evaluatedAt": "2026-05-05T23:45:42.670Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29464,7 +31245,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.742Z",
+          "evaluatedAt": "2026-05-05T23:45:42.670Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29528,7 +31309,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.745Z",
+        "evaluatedAt": "2026-05-05T23:45:42.673Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29583,7 +31364,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.745Z",
+          "evaluatedAt": "2026-05-05T23:45:42.674Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29601,7 +31382,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.745Z",
+          "evaluatedAt": "2026-05-05T23:45:42.674Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29665,7 +31446,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.747Z",
+        "evaluatedAt": "2026-05-05T23:45:42.676Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29720,7 +31501,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.747Z",
+          "evaluatedAt": "2026-05-05T23:45:42.676Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29738,7 +31519,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.747Z",
+          "evaluatedAt": "2026-05-05T23:45:42.676Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29802,7 +31583,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.748Z",
+        "evaluatedAt": "2026-05-05T23:45:42.677Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29857,7 +31638,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.748Z",
+          "evaluatedAt": "2026-05-05T23:45:42.677Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -29875,7 +31656,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.748Z",
+          "evaluatedAt": "2026-05-05T23:45:42.677Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -29939,7 +31720,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.750Z",
+        "evaluatedAt": "2026-05-05T23:45:42.679Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -29994,7 +31775,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.750Z",
+          "evaluatedAt": "2026-05-05T23:45:42.679Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30012,7 +31793,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.750Z",
+          "evaluatedAt": "2026-05-05T23:45:42.679Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30076,7 +31857,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.753Z",
+        "evaluatedAt": "2026-05-05T23:45:42.682Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30131,7 +31912,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.753Z",
+          "evaluatedAt": "2026-05-05T23:45:42.682Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30149,7 +31930,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.753Z",
+          "evaluatedAt": "2026-05-05T23:45:42.682Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30213,7 +31994,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.754Z",
+        "evaluatedAt": "2026-05-05T23:45:42.684Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30268,7 +32049,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.754Z",
+          "evaluatedAt": "2026-05-05T23:45:42.684Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30286,7 +32067,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.754Z",
+          "evaluatedAt": "2026-05-05T23:45:42.684Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30350,7 +32131,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.755Z",
+        "evaluatedAt": "2026-05-05T23:45:42.684Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30405,7 +32186,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.755Z",
+          "evaluatedAt": "2026-05-05T23:45:42.684Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30423,7 +32204,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.755Z",
+          "evaluatedAt": "2026-05-05T23:45:42.684Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30487,7 +32268,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.755Z",
+        "evaluatedAt": "2026-05-05T23:45:42.685Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30542,7 +32323,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.755Z",
+          "evaluatedAt": "2026-05-05T23:45:42.685Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30560,7 +32341,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.755Z",
+          "evaluatedAt": "2026-05-05T23:45:42.685Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30624,7 +32405,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.756Z",
+        "evaluatedAt": "2026-05-05T23:45:42.686Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30679,7 +32460,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.756Z",
+          "evaluatedAt": "2026-05-05T23:45:42.686Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30697,7 +32478,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.756Z",
+          "evaluatedAt": "2026-05-05T23:45:42.686Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30761,7 +32542,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.757Z",
+        "evaluatedAt": "2026-05-05T23:45:42.686Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30816,7 +32597,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.757Z",
+          "evaluatedAt": "2026-05-05T23:45:42.686Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30834,7 +32615,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.757Z",
+          "evaluatedAt": "2026-05-05T23:45:42.686Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -30898,7 +32679,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.759Z",
+        "evaluatedAt": "2026-05-05T23:45:42.688Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -30953,7 +32734,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.759Z",
+          "evaluatedAt": "2026-05-05T23:45:42.688Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -30971,7 +32752,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.759Z",
+          "evaluatedAt": "2026-05-05T23:45:42.688Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31035,7 +32816,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.763Z",
+        "evaluatedAt": "2026-05-05T23:45:42.692Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31090,7 +32871,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.763Z",
+          "evaluatedAt": "2026-05-05T23:45:42.692Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31108,7 +32889,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.763Z",
+          "evaluatedAt": "2026-05-05T23:45:42.692Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31172,7 +32953,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.765Z",
+        "evaluatedAt": "2026-05-05T23:45:42.694Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31227,7 +33008,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.765Z",
+          "evaluatedAt": "2026-05-05T23:45:42.694Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31245,7 +33026,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.765Z",
+          "evaluatedAt": "2026-05-05T23:45:42.694Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31309,7 +33090,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.765Z",
+        "evaluatedAt": "2026-05-05T23:45:42.695Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31364,7 +33145,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.765Z",
+          "evaluatedAt": "2026-05-05T23:45:42.695Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31382,7 +33163,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.766Z",
+          "evaluatedAt": "2026-05-05T23:45:42.695Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31446,7 +33227,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.766Z",
+        "evaluatedAt": "2026-05-05T23:45:42.696Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31501,7 +33282,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.766Z",
+          "evaluatedAt": "2026-05-05T23:45:42.696Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31519,7 +33300,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.766Z",
+          "evaluatedAt": "2026-05-05T23:45:42.696Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31583,7 +33364,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.767Z",
+        "evaluatedAt": "2026-05-05T23:45:42.696Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31638,7 +33419,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.767Z",
+          "evaluatedAt": "2026-05-05T23:45:42.696Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31656,7 +33437,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.767Z",
+          "evaluatedAt": "2026-05-05T23:45:42.696Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31720,7 +33501,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.768Z",
+        "evaluatedAt": "2026-05-05T23:45:42.697Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31775,7 +33556,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.768Z",
+          "evaluatedAt": "2026-05-05T23:45:42.697Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31793,7 +33574,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.768Z",
+          "evaluatedAt": "2026-05-05T23:45:42.697Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31857,7 +33638,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.768Z",
+        "evaluatedAt": "2026-05-05T23:45:42.698Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -31912,7 +33693,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.768Z",
+          "evaluatedAt": "2026-05-05T23:45:42.698Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -31930,7 +33711,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.768Z",
+          "evaluatedAt": "2026-05-05T23:45:42.698Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -31994,7 +33775,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.770Z",
+        "evaluatedAt": "2026-05-05T23:45:42.699Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32049,7 +33830,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.770Z",
+          "evaluatedAt": "2026-05-05T23:45:42.699Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32067,7 +33848,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.770Z",
+          "evaluatedAt": "2026-05-05T23:45:42.699Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32131,7 +33912,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.772Z",
+        "evaluatedAt": "2026-05-05T23:45:42.701Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32186,7 +33967,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.772Z",
+          "evaluatedAt": "2026-05-05T23:45:42.701Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32204,7 +33985,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.772Z",
+          "evaluatedAt": "2026-05-05T23:45:42.701Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32268,7 +34049,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.773Z",
+        "evaluatedAt": "2026-05-05T23:45:42.703Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32323,7 +34104,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.773Z",
+          "evaluatedAt": "2026-05-05T23:45:42.703Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32341,7 +34122,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.773Z",
+          "evaluatedAt": "2026-05-05T23:45:42.703Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32405,7 +34186,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.774Z",
+        "evaluatedAt": "2026-05-05T23:45:42.704Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32460,7 +34241,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.774Z",
+          "evaluatedAt": "2026-05-05T23:45:42.704Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32478,7 +34259,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.774Z",
+          "evaluatedAt": "2026-05-05T23:45:42.704Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32542,7 +34323,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.776Z",
+        "evaluatedAt": "2026-05-05T23:45:42.706Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32597,7 +34378,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.776Z",
+          "evaluatedAt": "2026-05-05T23:45:42.706Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32615,7 +34396,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.776Z",
+          "evaluatedAt": "2026-05-05T23:45:42.706Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32679,7 +34460,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.777Z",
+        "evaluatedAt": "2026-05-05T23:45:42.707Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32734,7 +34515,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.777Z",
+          "evaluatedAt": "2026-05-05T23:45:42.707Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32752,7 +34533,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.777Z",
+          "evaluatedAt": "2026-05-05T23:45:42.707Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32824,7 +34605,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.778Z",
+        "evaluatedAt": "2026-05-05T23:45:42.708Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -32879,7 +34660,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.778Z",
+          "evaluatedAt": "2026-05-05T23:45:42.708Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -32897,7 +34678,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.778Z",
+          "evaluatedAt": "2026-05-05T23:45:42.708Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -32961,7 +34742,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.779Z",
+        "evaluatedAt": "2026-05-05T23:45:42.709Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33016,7 +34797,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.779Z",
+          "evaluatedAt": "2026-05-05T23:45:42.709Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33034,7 +34815,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.779Z",
+          "evaluatedAt": "2026-05-05T23:45:42.709Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "markdown-to-html",
+      "description": "Convert Markdown files to HTML similar to `marked.js`, `pandoc`, `gomarkdown/markdown`, or similar tools; or writing custom script to convert markdown to html and/or working on web template systems like `jekyll/jekyll`, `gohugoio/hugo`, or similar web templating systems that utilize markdown documents, converting them to html. Use when asked to \"convert markdown to html\", \"transform md to html\", \"render markdown\", \"generate html from markdown\", or when working with .md files and/or web a templating system that converts markdown to HTML output. Supports CLI and Node.js workflows with GFM, CommonMark, and standard Markdown flavors.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:plugins/cms-development/skills/markdown-to-html",
+      "relPath": "plugins/cms-development/skills/markdown-to-html",
+      "verified": true,
+      "tokenCount": 6525,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.711Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 71,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.711Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.711Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33098,7 +35016,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.781Z",
+        "evaluatedAt": "2026-05-05T23:45:42.715Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33153,7 +35071,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.781Z",
+          "evaluatedAt": "2026-05-05T23:45:42.715Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33171,7 +35089,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.781Z",
+          "evaluatedAt": "2026-05-05T23:45:42.715Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33235,7 +35153,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.783Z",
+        "evaluatedAt": "2026-05-05T23:45:42.717Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33290,7 +35208,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.783Z",
+          "evaluatedAt": "2026-05-05T23:45:42.717Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33308,7 +35226,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.783Z",
+          "evaluatedAt": "2026-05-05T23:45:42.717Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33372,7 +35290,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.784Z",
+        "evaluatedAt": "2026-05-05T23:45:42.718Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33427,7 +35345,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.784Z",
+          "evaluatedAt": "2026-05-05T23:45:42.718Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33445,7 +35363,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.784Z",
+          "evaluatedAt": "2026-05-05T23:45:42.718Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33509,7 +35427,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.785Z",
+        "evaluatedAt": "2026-05-05T23:45:42.719Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33564,7 +35482,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.785Z",
+          "evaluatedAt": "2026-05-05T23:45:42.719Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33582,7 +35500,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.785Z",
+          "evaluatedAt": "2026-05-05T23:45:42.719Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33646,7 +35564,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.786Z",
+        "evaluatedAt": "2026-05-05T23:45:42.721Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33701,7 +35619,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.786Z",
+          "evaluatedAt": "2026-05-05T23:45:42.721Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33719,7 +35637,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.786Z",
+          "evaluatedAt": "2026-05-05T23:45:42.721Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33783,7 +35701,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.788Z",
+        "evaluatedAt": "2026-05-05T23:45:42.722Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33838,7 +35756,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.788Z",
+          "evaluatedAt": "2026-05-05T23:45:42.723Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33856,7 +35774,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.788Z",
+          "evaluatedAt": "2026-05-05T23:45:42.723Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -33920,7 +35838,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.790Z",
+        "evaluatedAt": "2026-05-05T23:45:42.724Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -33975,7 +35893,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.790Z",
+          "evaluatedAt": "2026-05-05T23:45:42.724Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -33993,7 +35911,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.790Z",
+          "evaluatedAt": "2026-05-05T23:45:42.724Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34057,7 +35975,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.791Z",
+        "evaluatedAt": "2026-05-05T23:45:42.725Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34112,7 +36030,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.791Z",
+          "evaluatedAt": "2026-05-05T23:45:42.725Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34130,7 +36048,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.791Z",
+          "evaluatedAt": "2026-05-05T23:45:42.725Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34194,7 +36112,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.793Z",
+        "evaluatedAt": "2026-05-05T23:45:42.727Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34249,7 +36167,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.793Z",
+          "evaluatedAt": "2026-05-05T23:45:42.727Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34267,7 +36185,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.793Z",
+          "evaluatedAt": "2026-05-05T23:45:42.727Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34331,7 +36249,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.794Z",
+        "evaluatedAt": "2026-05-05T23:45:42.729Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34386,7 +36304,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.795Z",
+          "evaluatedAt": "2026-05-05T23:45:42.729Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34404,7 +36322,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.795Z",
+          "evaluatedAt": "2026-05-05T23:45:42.729Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34468,7 +36386,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.796Z",
+        "evaluatedAt": "2026-05-05T23:45:42.730Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34523,7 +36441,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.796Z",
+          "evaluatedAt": "2026-05-05T23:45:42.731Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34541,7 +36459,281 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.796Z",
+          "evaluatedAt": "2026-05-05T23:45:42.731Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "md-to-docx",
+      "description": "Convert Markdown files to professionally formatted Word (.docx) documents with embedded PNG images — pure JavaScript, no external tools required",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:plugins/project-documenter/skills/md-to-docx",
+      "relPath": "plugins/project-documenter/skills/md-to-docx",
+      "verified": true,
+      "tokenCount": 740,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.732Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 63,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.732Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.732Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "md-to-docx",
+      "description": "Convert Markdown files to professionally formatted Word (.docx) documents with embedded PNG images — pure JavaScript, no external tools required",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:skills/md-to-docx",
+      "relPath": "skills/md-to-docx",
+      "verified": true,
+      "tokenCount": 740,
+      "evalSummary": {
+        "overallScore": 63,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.733Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 63,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.733Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.733Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34605,7 +36797,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.798Z",
+        "evaluatedAt": "2026-05-05T23:45:42.734Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34660,7 +36852,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.798Z",
+          "evaluatedAt": "2026-05-05T23:45:42.734Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34678,7 +36870,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.798Z",
+          "evaluatedAt": "2026-05-05T23:45:42.734Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34742,7 +36934,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.799Z",
+        "evaluatedAt": "2026-05-05T23:45:42.735Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34797,7 +36989,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.799Z",
+          "evaluatedAt": "2026-05-05T23:45:42.735Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34815,7 +37007,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.799Z",
+          "evaluatedAt": "2026-05-05T23:45:42.735Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -34879,7 +37071,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.800Z",
+        "evaluatedAt": "2026-05-05T23:45:42.737Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -34934,7 +37126,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.800Z",
+          "evaluatedAt": "2026-05-05T23:45:42.737Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -34952,7 +37144,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.800Z",
+          "evaluatedAt": "2026-05-05T23:45:42.737Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35016,7 +37208,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.802Z",
+        "evaluatedAt": "2026-05-05T23:45:42.739Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35071,7 +37263,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.802Z",
+          "evaluatedAt": "2026-05-05T23:45:42.739Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35089,7 +37281,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.802Z",
+          "evaluatedAt": "2026-05-05T23:45:42.739Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35153,7 +37345,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.803Z",
+        "evaluatedAt": "2026-05-05T23:45:42.740Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35208,7 +37400,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.803Z",
+          "evaluatedAt": "2026-05-05T23:45:42.740Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35226,7 +37418,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.803Z",
+          "evaluatedAt": "2026-05-05T23:45:42.740Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35290,7 +37482,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.804Z",
+        "evaluatedAt": "2026-05-05T23:45:42.741Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35345,7 +37537,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.804Z",
+          "evaluatedAt": "2026-05-05T23:45:42.741Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35363,7 +37555,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.804Z",
+          "evaluatedAt": "2026-05-05T23:45:42.741Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35427,7 +37619,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.805Z",
+        "evaluatedAt": "2026-05-05T23:45:42.742Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35482,7 +37674,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.805Z",
+          "evaluatedAt": "2026-05-05T23:45:42.742Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35500,7 +37692,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.805Z",
+          "evaluatedAt": "2026-05-05T23:45:42.742Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35564,7 +37756,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.806Z",
+        "evaluatedAt": "2026-05-05T23:45:42.743Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35619,7 +37811,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.806Z",
+          "evaluatedAt": "2026-05-05T23:45:42.743Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35637,7 +37829,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.806Z",
+          "evaluatedAt": "2026-05-05T23:45:42.743Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35701,7 +37893,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.807Z",
+        "evaluatedAt": "2026-05-05T23:45:42.744Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35756,7 +37948,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.807Z",
+          "evaluatedAt": "2026-05-05T23:45:42.744Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35774,7 +37966,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.807Z",
+          "evaluatedAt": "2026-05-05T23:45:42.744Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35838,7 +38030,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.809Z",
+        "evaluatedAt": "2026-05-05T23:45:42.745Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -35893,7 +38085,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.809Z",
+          "evaluatedAt": "2026-05-05T23:45:42.745Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -35911,7 +38103,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.809Z",
+          "evaluatedAt": "2026-05-05T23:45:42.745Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "mini-context-graph",
+      "description": "A persistent, compounding knowledge base combining Karpathy's LLM Wiki pattern with a structured knowledge graph. Ingest documents once — the LLM writes wiki pages, extracts entities/relations into the graph, and stores raw content for evidence retrieval. Knowledge accumulates and cross-references; it is never re-derived from scratch.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:skills/mini-context-graph",
+      "relPath": "skills/mini-context-graph",
+      "verified": true,
+      "tokenCount": 2132,
+      "evalSummary": {
+        "overallScore": 59,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.747Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 59,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.747Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 62,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 8,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.747Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -35975,7 +38304,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.810Z",
+        "evaluatedAt": "2026-05-05T23:45:42.748Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36030,7 +38359,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.810Z",
+          "evaluatedAt": "2026-05-05T23:45:42.748Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36048,7 +38377,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.810Z",
+          "evaluatedAt": "2026-05-05T23:45:42.748Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36112,7 +38441,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.813Z",
+        "evaluatedAt": "2026-05-05T23:45:42.750Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36167,7 +38496,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.813Z",
+          "evaluatedAt": "2026-05-05T23:45:42.750Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36185,7 +38514,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.813Z",
+          "evaluatedAt": "2026-05-05T23:45:42.750Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36249,7 +38578,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.816Z",
+        "evaluatedAt": "2026-05-05T23:45:42.753Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36304,7 +38633,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.816Z",
+          "evaluatedAt": "2026-05-05T23:45:42.753Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36322,7 +38651,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.816Z",
+          "evaluatedAt": "2026-05-05T23:45:42.753Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36386,7 +38715,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.817Z",
+        "evaluatedAt": "2026-05-05T23:45:42.755Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36441,7 +38770,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.817Z",
+          "evaluatedAt": "2026-05-05T23:45:42.755Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36459,7 +38788,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.817Z",
+          "evaluatedAt": "2026-05-05T23:45:42.755Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36523,7 +38852,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.818Z",
+        "evaluatedAt": "2026-05-05T23:45:42.755Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36578,7 +38907,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.818Z",
+          "evaluatedAt": "2026-05-05T23:45:42.755Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36596,7 +38925,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.818Z",
+          "evaluatedAt": "2026-05-05T23:45:42.755Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36660,7 +38989,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.819Z",
+        "evaluatedAt": "2026-05-05T23:45:42.756Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36715,7 +39044,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.819Z",
+          "evaluatedAt": "2026-05-05T23:45:42.756Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36733,7 +39062,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.819Z",
+          "evaluatedAt": "2026-05-05T23:45:42.756Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36797,7 +39126,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.819Z",
+        "evaluatedAt": "2026-05-05T23:45:42.756Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36852,7 +39181,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.819Z",
+          "evaluatedAt": "2026-05-05T23:45:42.756Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -36870,7 +39199,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.819Z",
+          "evaluatedAt": "2026-05-05T23:45:42.756Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -36934,7 +39263,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.820Z",
+        "evaluatedAt": "2026-05-05T23:45:42.757Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -36989,7 +39318,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.820Z",
+          "evaluatedAt": "2026-05-05T23:45:42.757Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37007,7 +39336,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.820Z",
+          "evaluatedAt": "2026-05-05T23:45:42.757Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37071,7 +39400,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.821Z",
+        "evaluatedAt": "2026-05-05T23:45:42.758Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37126,7 +39455,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.821Z",
+          "evaluatedAt": "2026-05-05T23:45:42.758Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37144,7 +39473,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.821Z",
+          "evaluatedAt": "2026-05-05T23:45:42.758Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37208,7 +39537,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.822Z",
+        "evaluatedAt": "2026-05-05T23:45:42.759Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37263,7 +39592,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.822Z",
+          "evaluatedAt": "2026-05-05T23:45:42.759Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37281,7 +39610,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.822Z",
+          "evaluatedAt": "2026-05-05T23:45:42.759Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37345,7 +39674,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.823Z",
+        "evaluatedAt": "2026-05-05T23:45:42.760Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37400,7 +39729,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.823Z",
+          "evaluatedAt": "2026-05-05T23:45:42.760Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37418,7 +39747,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.823Z",
+          "evaluatedAt": "2026-05-05T23:45:42.760Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37482,7 +39811,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.824Z",
+        "evaluatedAt": "2026-05-05T23:45:42.762Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37537,7 +39866,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.824Z",
+          "evaluatedAt": "2026-05-05T23:45:42.762Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37555,7 +39884,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.824Z",
+          "evaluatedAt": "2026-05-05T23:45:42.762Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37619,7 +39948,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.826Z",
+        "evaluatedAt": "2026-05-05T23:45:42.764Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37674,7 +40003,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.826Z",
+          "evaluatedAt": "2026-05-05T23:45:42.764Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37692,7 +40021,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.826Z",
+          "evaluatedAt": "2026-05-05T23:45:42.764Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37756,7 +40085,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.828Z",
+        "evaluatedAt": "2026-05-05T23:45:42.765Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37811,7 +40140,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.828Z",
+          "evaluatedAt": "2026-05-05T23:45:42.765Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37829,7 +40158,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.828Z",
+          "evaluatedAt": "2026-05-05T23:45:42.765Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -37893,7 +40222,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.829Z",
+        "evaluatedAt": "2026-05-05T23:45:42.766Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -37948,7 +40277,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.829Z",
+          "evaluatedAt": "2026-05-05T23:45:42.766Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -37966,7 +40295,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.829Z",
+          "evaluatedAt": "2026-05-05T23:45:42.766Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38030,7 +40359,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.831Z",
+        "evaluatedAt": "2026-05-05T23:45:42.769Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38085,7 +40414,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.831Z",
+          "evaluatedAt": "2026-05-05T23:45:42.769Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38103,7 +40432,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.831Z",
+          "evaluatedAt": "2026-05-05T23:45:42.769Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38167,7 +40496,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.833Z",
+        "evaluatedAt": "2026-05-05T23:45:42.770Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38222,7 +40551,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.833Z",
+          "evaluatedAt": "2026-05-05T23:45:42.770Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38240,7 +40569,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.833Z",
+          "evaluatedAt": "2026-05-05T23:45:42.770Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38304,7 +40633,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.834Z",
+        "evaluatedAt": "2026-05-05T23:45:42.771Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38359,7 +40688,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.834Z",
+          "evaluatedAt": "2026-05-05T23:45:42.771Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38377,7 +40706,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.834Z",
+          "evaluatedAt": "2026-05-05T23:45:42.771Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38441,7 +40770,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.835Z",
+        "evaluatedAt": "2026-05-05T23:45:42.772Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38496,7 +40825,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.835Z",
+          "evaluatedAt": "2026-05-05T23:45:42.772Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38514,7 +40843,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.835Z",
+          "evaluatedAt": "2026-05-05T23:45:42.772Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38578,7 +40907,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.837Z",
+        "evaluatedAt": "2026-05-05T23:45:42.773Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38633,7 +40962,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.837Z",
+          "evaluatedAt": "2026-05-05T23:45:42.773Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38651,7 +40980,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.837Z",
+          "evaluatedAt": "2026-05-05T23:45:42.773Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38715,7 +41044,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.838Z",
+        "evaluatedAt": "2026-05-05T23:45:42.774Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38770,7 +41099,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.838Z",
+          "evaluatedAt": "2026-05-05T23:45:42.774Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38788,7 +41117,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.838Z",
+          "evaluatedAt": "2026-05-05T23:45:42.774Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38852,7 +41181,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.839Z",
+        "evaluatedAt": "2026-05-05T23:45:42.775Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -38907,7 +41236,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.840Z",
+          "evaluatedAt": "2026-05-05T23:45:42.775Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -38925,7 +41254,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.840Z",
+          "evaluatedAt": "2026-05-05T23:45:42.775Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -38989,7 +41318,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.841Z",
+        "evaluatedAt": "2026-05-05T23:45:42.776Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39044,7 +41373,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.841Z",
+          "evaluatedAt": "2026-05-05T23:45:42.776Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39062,7 +41391,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.841Z",
+          "evaluatedAt": "2026-05-05T23:45:42.776Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39126,7 +41455,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.842Z",
+        "evaluatedAt": "2026-05-05T23:45:42.777Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39181,7 +41510,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.842Z",
+          "evaluatedAt": "2026-05-05T23:45:42.777Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39199,7 +41528,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.842Z",
+          "evaluatedAt": "2026-05-05T23:45:42.777Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -39263,7 +41592,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.843Z",
+        "evaluatedAt": "2026-05-05T23:45:42.778Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -39318,7 +41647,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.843Z",
+          "evaluatedAt": "2026-05-05T23:45:42.778Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -39336,15 +41665,15 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.843Z",
+          "evaluatedAt": "2026-05-05T23:45:42.778Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "phoenix-cli",
-      "description": "Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, review experiments, inspect datasets, and query the GraphQL API. Use when debugging AI/LLM applications, analyzing trace data, working with Phoenix observability, or investigating LLM performance issues.",
-      "version": "2.0.0",
+      "description": "Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, structure trace review with open coding and axial coding, inspect datasets, review experiments, query annotation configs, and use the GraphQL API. Use whenever the user is analyzing traces or spans, investigating LLM/agent failures, deciding what to do after instrumenting an app, building failure taxonomies, choosing what evals to write, or asking \"what's going wrong\", \"what kinds of mistakes\", or \"where do I focus\" — even without naming a technique.",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "creator": "",
       "compatibility": "Requires Node.js (for npx) or global install of @arizeai/phoenix-cli. Optionally requires jq for JSON processing.",
@@ -39352,9 +41681,9 @@
       "installUrl": "github:github/awesome-copilot:plugins/phoenix/skills/phoenix-cli",
       "relPath": "plugins/phoenix/skills/phoenix-cli",
       "verified": true,
-      "tokenCount": 1839,
+      "tokenCount": 3308,
       "evalSummary": {
-        "overallScore": 67,
+        "overallScore": 71,
         "grade": "C",
         "categories": [
           {
@@ -39366,7 +41695,7 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 10,
+            "score": 6,
             "max": 10
           },
           {
@@ -39378,19 +41707,19 @@
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 6,
+            "score": 9,
             "max": 10
           },
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 7,
+            "score": 10,
             "max": 10
           },
           {
             "id": "testability",
             "name": "Testability",
-            "score": 0,
+            "score": 1,
             "max": 10
           },
           {
@@ -39400,8 +41729,8 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.845Z",
-        "evaluatedVersion": "2.0.0"
+        "evaluatedAt": "2026-05-05T23:45:42.780Z",
+        "evaluatedVersion": "3.3.0"
       },
       "evalSummaries": {
         "quality": {
@@ -39409,7 +41738,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 67,
+          "overallScore": 71,
           "grade": "C",
           "categories": [
             {
@@ -39421,7 +41750,7 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 10,
+              "score": 6,
               "max": 10
             },
             {
@@ -39433,19 +41762,19 @@
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 6,
+              "score": 9,
               "max": 10
             },
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 7,
+              "score": 10,
               "max": 10
             },
             {
               "id": "testability",
               "name": "Testability",
-              "score": 0,
+              "score": 1,
               "max": 10
             },
             {
@@ -39455,8 +41784,8 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.845Z",
-          "evaluatedVersion": "2.0.0"
+          "evaluatedAt": "2026-05-05T23:45:42.780Z",
+          "evaluatedVersion": "3.3.0"
         },
         "skill-best-practice": {
           "providerId": "skill-best-practice",
@@ -39473,15 +41802,15 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.845Z",
-          "evaluatedVersion": "2.0.0"
+          "evaluatedAt": "2026-05-05T23:45:42.780Z",
+          "evaluatedVersion": "3.3.0"
         }
       }
     },
     {
       "name": "phoenix-cli",
-      "description": "Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, review experiments, inspect datasets, and query the GraphQL API. Use when debugging AI/LLM applications, analyzing trace data, working with Phoenix observability, or investigating LLM performance issues.",
-      "version": "2.0.0",
+      "description": "Debug LLM applications using the Phoenix CLI. Fetch traces, analyze errors, structure trace review with open coding and axial coding, inspect datasets, review experiments, query annotation configs, and use the GraphQL API. Use whenever the user is analyzing traces or spans, investigating LLM/agent failures, deciding what to do after instrumenting an app, building failure taxonomies, choosing what evals to write, or asking \"what's going wrong\", \"what kinds of mistakes\", or \"where do I focus\" — even without naming a technique.",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "creator": "",
       "compatibility": "Requires Node.js (for npx) or global install of @arizeai/phoenix-cli. Optionally requires jq for JSON processing.",
@@ -39489,9 +41818,9 @@
       "installUrl": "github:github/awesome-copilot:skills/phoenix-cli",
       "relPath": "skills/phoenix-cli",
       "verified": true,
-      "tokenCount": 1839,
+      "tokenCount": 3308,
       "evalSummary": {
-        "overallScore": 67,
+        "overallScore": 71,
         "grade": "C",
         "categories": [
           {
@@ -39503,7 +41832,7 @@
           {
             "id": "description",
             "name": "Description quality",
-            "score": 10,
+            "score": 6,
             "max": 10
           },
           {
@@ -39515,19 +41844,19 @@
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 6,
+            "score": 9,
             "max": 10
           },
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 7,
+            "score": 10,
             "max": 10
           },
           {
             "id": "testability",
             "name": "Testability",
-            "score": 0,
+            "score": 1,
             "max": 10
           },
           {
@@ -39537,8 +41866,8 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.846Z",
-        "evaluatedVersion": "2.0.0"
+        "evaluatedAt": "2026-05-05T23:45:42.782Z",
+        "evaluatedVersion": "3.3.0"
       },
       "evalSummaries": {
         "quality": {
@@ -39546,7 +41875,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 67,
+          "overallScore": 71,
           "grade": "C",
           "categories": [
             {
@@ -39558,7 +41887,7 @@
             {
               "id": "description",
               "name": "Description quality",
-              "score": 10,
+              "score": 6,
               "max": 10
             },
             {
@@ -39570,19 +41899,19 @@
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 6,
+              "score": 9,
               "max": 10
             },
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 7,
+              "score": 10,
               "max": 10
             },
             {
               "id": "testability",
               "name": "Testability",
-              "score": 0,
+              "score": 1,
               "max": 10
             },
             {
@@ -39592,8 +41921,8 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.846Z",
-          "evaluatedVersion": "2.0.0"
+          "evaluatedAt": "2026-05-05T23:45:42.782Z",
+          "evaluatedVersion": "3.3.0"
         },
         "skill-best-practice": {
           "providerId": "skill-best-practice",
@@ -39610,8 +41939,8 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.846Z",
-          "evaluatedVersion": "2.0.0"
+          "evaluatedAt": "2026-05-05T23:45:42.782Z",
+          "evaluatedVersion": "3.3.0"
         }
       }
     },
@@ -39674,7 +42003,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.848Z",
+        "evaluatedAt": "2026-05-05T23:45:42.784Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -39729,7 +42058,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.848Z",
+          "evaluatedAt": "2026-05-05T23:45:42.784Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -39747,7 +42076,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.848Z",
+          "evaluatedAt": "2026-05-05T23:45:42.784Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -39811,7 +42140,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.849Z",
+        "evaluatedAt": "2026-05-05T23:45:42.785Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -39866,7 +42195,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.849Z",
+          "evaluatedAt": "2026-05-05T23:45:42.785Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -39884,7 +42213,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.849Z",
+          "evaluatedAt": "2026-05-05T23:45:42.785Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -39948,7 +42277,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.850Z",
+        "evaluatedAt": "2026-05-05T23:45:42.786Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -40003,7 +42332,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.850Z",
+          "evaluatedAt": "2026-05-05T23:45:42.786Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -40021,7 +42350,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.850Z",
+          "evaluatedAt": "2026-05-05T23:45:42.786Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -40085,7 +42414,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.851Z",
+        "evaluatedAt": "2026-05-05T23:45:42.787Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -40140,7 +42469,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.851Z",
+          "evaluatedAt": "2026-05-05T23:45:42.787Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -40158,7 +42487,7 @@
               "max": 15
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.851Z",
+          "evaluatedAt": "2026-05-05T23:45:42.787Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -40222,7 +42551,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.853Z",
+        "evaluatedAt": "2026-05-05T23:45:42.789Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40277,7 +42606,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.853Z",
+          "evaluatedAt": "2026-05-05T23:45:42.789Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40295,7 +42624,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.853Z",
+          "evaluatedAt": "2026-05-05T23:45:42.789Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40359,7 +42688,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.855Z",
+        "evaluatedAt": "2026-05-05T23:45:42.790Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40414,7 +42743,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.855Z",
+          "evaluatedAt": "2026-05-05T23:45:42.790Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40432,7 +42761,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.855Z",
+          "evaluatedAt": "2026-05-05T23:45:42.790Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40496,7 +42825,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.856Z",
+        "evaluatedAt": "2026-05-05T23:45:42.792Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40551,7 +42880,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.856Z",
+          "evaluatedAt": "2026-05-05T23:45:42.792Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40569,7 +42898,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.856Z",
+          "evaluatedAt": "2026-05-05T23:45:42.792Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40633,7 +42962,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.857Z",
+        "evaluatedAt": "2026-05-05T23:45:42.792Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40688,7 +43017,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.857Z",
+          "evaluatedAt": "2026-05-05T23:45:42.792Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40706,7 +43035,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.857Z",
+          "evaluatedAt": "2026-05-05T23:45:42.792Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40770,7 +43099,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.858Z",
+        "evaluatedAt": "2026-05-05T23:45:42.793Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40825,7 +43154,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.858Z",
+          "evaluatedAt": "2026-05-05T23:45:42.793Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40843,7 +43172,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.858Z",
+          "evaluatedAt": "2026-05-05T23:45:42.793Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -40907,7 +43236,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.859Z",
+        "evaluatedAt": "2026-05-05T23:45:42.794Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -40962,7 +43291,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.859Z",
+          "evaluatedAt": "2026-05-05T23:45:42.794Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -40980,7 +43309,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.859Z",
+          "evaluatedAt": "2026-05-05T23:45:42.794Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41044,7 +43373,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.859Z",
+        "evaluatedAt": "2026-05-05T23:45:42.794Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41099,7 +43428,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.859Z",
+          "evaluatedAt": "2026-05-05T23:45:42.794Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41117,7 +43446,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.859Z",
+          "evaluatedAt": "2026-05-05T23:45:42.795Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41181,7 +43510,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.859Z",
+        "evaluatedAt": "2026-05-05T23:45:42.795Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41236,7 +43565,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.859Z",
+          "evaluatedAt": "2026-05-05T23:45:42.795Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41254,7 +43583,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.859Z",
+          "evaluatedAt": "2026-05-05T23:45:42.795Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41318,7 +43647,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.860Z",
+        "evaluatedAt": "2026-05-05T23:45:42.795Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41373,7 +43702,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.860Z",
+          "evaluatedAt": "2026-05-05T23:45:42.795Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41391,7 +43720,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.860Z",
+          "evaluatedAt": "2026-05-05T23:45:42.795Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41455,7 +43784,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.860Z",
+        "evaluatedAt": "2026-05-05T23:45:42.796Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41510,7 +43839,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.861Z",
+          "evaluatedAt": "2026-05-05T23:45:42.796Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41528,7 +43857,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.861Z",
+          "evaluatedAt": "2026-05-05T23:45:42.796Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41592,7 +43921,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.861Z",
+        "evaluatedAt": "2026-05-05T23:45:42.796Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41647,7 +43976,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.861Z",
+          "evaluatedAt": "2026-05-05T23:45:42.796Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41665,7 +43994,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.861Z",
+          "evaluatedAt": "2026-05-05T23:45:42.796Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41729,7 +44058,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.862Z",
+        "evaluatedAt": "2026-05-05T23:45:42.797Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41784,7 +44113,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.862Z",
+          "evaluatedAt": "2026-05-05T23:45:42.797Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41802,7 +44131,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.862Z",
+          "evaluatedAt": "2026-05-05T23:45:42.797Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -41866,7 +44195,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.862Z",
+        "evaluatedAt": "2026-05-05T23:45:42.797Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -41921,7 +44250,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.863Z",
+          "evaluatedAt": "2026-05-05T23:45:42.797Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -41939,7 +44268,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.863Z",
+          "evaluatedAt": "2026-05-05T23:45:42.797Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42003,7 +44332,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.864Z",
+        "evaluatedAt": "2026-05-05T23:45:42.799Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42058,7 +44387,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.864Z",
+          "evaluatedAt": "2026-05-05T23:45:42.799Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42076,7 +44405,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.864Z",
+          "evaluatedAt": "2026-05-05T23:45:42.799Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42140,7 +44469,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.865Z",
+        "evaluatedAt": "2026-05-05T23:45:42.800Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42195,7 +44524,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.865Z",
+          "evaluatedAt": "2026-05-05T23:45:42.800Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42213,7 +44542,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.865Z",
+          "evaluatedAt": "2026-05-05T23:45:42.800Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42277,7 +44606,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.867Z",
+        "evaluatedAt": "2026-05-05T23:45:42.802Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42332,7 +44661,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.867Z",
+          "evaluatedAt": "2026-05-05T23:45:42.802Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42350,7 +44679,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.867Z",
+          "evaluatedAt": "2026-05-05T23:45:42.802Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42414,7 +44743,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.869Z",
+        "evaluatedAt": "2026-05-05T23:45:42.804Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42469,7 +44798,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.869Z",
+          "evaluatedAt": "2026-05-05T23:45:42.804Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42487,7 +44816,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.869Z",
+          "evaluatedAt": "2026-05-05T23:45:42.804Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42551,7 +44880,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.871Z",
+        "evaluatedAt": "2026-05-05T23:45:42.806Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42606,7 +44935,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.871Z",
+          "evaluatedAt": "2026-05-05T23:45:42.806Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42624,7 +44953,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.871Z",
+          "evaluatedAt": "2026-05-05T23:45:42.806Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42688,7 +45017,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.873Z",
+        "evaluatedAt": "2026-05-05T23:45:42.808Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42743,7 +45072,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.873Z",
+          "evaluatedAt": "2026-05-05T23:45:42.808Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42761,7 +45090,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.873Z",
+          "evaluatedAt": "2026-05-05T23:45:42.808Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42825,7 +45154,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.874Z",
+        "evaluatedAt": "2026-05-05T23:45:42.809Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -42880,7 +45209,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.874Z",
+          "evaluatedAt": "2026-05-05T23:45:42.809Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -42898,7 +45227,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.874Z",
+          "evaluatedAt": "2026-05-05T23:45:42.809Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -42962,7 +45291,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.875Z",
+        "evaluatedAt": "2026-05-05T23:45:42.811Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43017,7 +45346,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.875Z",
+          "evaluatedAt": "2026-05-05T23:45:42.811Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43035,7 +45364,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.875Z",
+          "evaluatedAt": "2026-05-05T23:45:42.811Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43099,7 +45428,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.876Z",
+        "evaluatedAt": "2026-05-05T23:45:42.812Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43154,7 +45483,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.876Z",
+          "evaluatedAt": "2026-05-05T23:45:42.812Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43172,7 +45501,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.876Z",
+          "evaluatedAt": "2026-05-05T23:45:42.812Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43236,7 +45565,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.878Z",
+        "evaluatedAt": "2026-05-05T23:45:42.813Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43291,7 +45620,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.878Z",
+          "evaluatedAt": "2026-05-05T23:45:42.813Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43309,7 +45638,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.878Z",
+          "evaluatedAt": "2026-05-05T23:45:42.813Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43373,7 +45702,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.880Z",
+        "evaluatedAt": "2026-05-05T23:45:42.815Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43428,7 +45757,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.880Z",
+          "evaluatedAt": "2026-05-05T23:45:42.815Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43446,7 +45775,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.880Z",
+          "evaluatedAt": "2026-05-05T23:45:42.815Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43510,7 +45839,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.882Z",
+        "evaluatedAt": "2026-05-05T23:45:42.817Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43565,7 +45894,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.882Z",
+          "evaluatedAt": "2026-05-05T23:45:42.817Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43583,7 +45912,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.882Z",
+          "evaluatedAt": "2026-05-05T23:45:42.817Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43647,7 +45976,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.884Z",
+        "evaluatedAt": "2026-05-05T23:45:42.819Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43702,7 +46031,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.884Z",
+          "evaluatedAt": "2026-05-05T23:45:42.819Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43720,7 +46049,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.884Z",
+          "evaluatedAt": "2026-05-05T23:45:42.819Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43784,7 +46113,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.886Z",
+        "evaluatedAt": "2026-05-05T23:45:42.821Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43839,7 +46168,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.886Z",
+          "evaluatedAt": "2026-05-05T23:45:42.821Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43857,7 +46186,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.886Z",
+          "evaluatedAt": "2026-05-05T23:45:42.821Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -43921,7 +46250,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.888Z",
+        "evaluatedAt": "2026-05-05T23:45:42.823Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -43976,7 +46305,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.888Z",
+          "evaluatedAt": "2026-05-05T23:45:42.823Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -43994,7 +46323,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.888Z",
+          "evaluatedAt": "2026-05-05T23:45:42.823Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44058,7 +46387,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.891Z",
+        "evaluatedAt": "2026-05-05T23:45:42.826Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44113,7 +46442,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.891Z",
+          "evaluatedAt": "2026-05-05T23:45:42.826Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44131,7 +46460,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.891Z",
+          "evaluatedAt": "2026-05-05T23:45:42.826Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44195,7 +46524,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.893Z",
+        "evaluatedAt": "2026-05-05T23:45:42.828Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44250,7 +46579,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.893Z",
+          "evaluatedAt": "2026-05-05T23:45:42.828Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44268,7 +46597,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.893Z",
+          "evaluatedAt": "2026-05-05T23:45:42.828Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44332,7 +46661,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.895Z",
+        "evaluatedAt": "2026-05-05T23:45:42.830Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44387,7 +46716,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.895Z",
+          "evaluatedAt": "2026-05-05T23:45:42.830Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44405,7 +46734,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.895Z",
+          "evaluatedAt": "2026-05-05T23:45:42.830Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44469,7 +46798,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.896Z",
+        "evaluatedAt": "2026-05-05T23:45:42.832Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44524,7 +46853,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.896Z",
+          "evaluatedAt": "2026-05-05T23:45:42.832Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44542,7 +46871,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.896Z",
+          "evaluatedAt": "2026-05-05T23:45:42.832Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44606,7 +46935,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.897Z",
+        "evaluatedAt": "2026-05-05T23:45:42.833Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44661,7 +46990,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.897Z",
+          "evaluatedAt": "2026-05-05T23:45:42.833Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44679,7 +47008,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.897Z",
+          "evaluatedAt": "2026-05-05T23:45:42.833Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44743,7 +47072,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.898Z",
+        "evaluatedAt": "2026-05-05T23:45:42.834Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44798,7 +47127,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.898Z",
+          "evaluatedAt": "2026-05-05T23:45:42.834Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44816,7 +47145,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.898Z",
+          "evaluatedAt": "2026-05-05T23:45:42.834Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -44880,7 +47209,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.899Z",
+        "evaluatedAt": "2026-05-05T23:45:42.834Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -44935,7 +47264,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.899Z",
+          "evaluatedAt": "2026-05-05T23:45:42.834Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -44953,7 +47282,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.899Z",
+          "evaluatedAt": "2026-05-05T23:45:42.834Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45017,7 +47346,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.900Z",
+        "evaluatedAt": "2026-05-05T23:45:42.836Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45072,7 +47401,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.900Z",
+          "evaluatedAt": "2026-05-05T23:45:42.836Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45090,7 +47419,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.900Z",
+          "evaluatedAt": "2026-05-05T23:45:42.836Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45154,7 +47483,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.902Z",
+        "evaluatedAt": "2026-05-05T23:45:42.838Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45209,7 +47538,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.902Z",
+          "evaluatedAt": "2026-05-05T23:45:42.838Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45227,7 +47556,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.902Z",
+          "evaluatedAt": "2026-05-05T23:45:42.838Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45291,7 +47620,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.903Z",
+        "evaluatedAt": "2026-05-05T23:45:42.839Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45346,7 +47675,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.903Z",
+          "evaluatedAt": "2026-05-05T23:45:42.839Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45364,7 +47693,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.903Z",
+          "evaluatedAt": "2026-05-05T23:45:42.839Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45428,7 +47757,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.904Z",
+        "evaluatedAt": "2026-05-05T23:45:42.841Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45483,7 +47812,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.904Z",
+          "evaluatedAt": "2026-05-05T23:45:42.841Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45501,7 +47830,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.904Z",
+          "evaluatedAt": "2026-05-05T23:45:42.841Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45565,7 +47894,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.905Z",
+        "evaluatedAt": "2026-05-05T23:45:42.841Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45620,7 +47949,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.905Z",
+          "evaluatedAt": "2026-05-05T23:45:42.841Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45638,7 +47967,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.905Z",
+          "evaluatedAt": "2026-05-05T23:45:42.841Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45702,7 +48031,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.906Z",
+        "evaluatedAt": "2026-05-05T23:45:42.842Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45757,7 +48086,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.906Z",
+          "evaluatedAt": "2026-05-05T23:45:42.842Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45775,7 +48104,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.906Z",
+          "evaluatedAt": "2026-05-05T23:45:42.842Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45839,7 +48168,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.907Z",
+        "evaluatedAt": "2026-05-05T23:45:42.843Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -45894,7 +48223,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.907Z",
+          "evaluatedAt": "2026-05-05T23:45:42.843Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -45912,7 +48241,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.907Z",
+          "evaluatedAt": "2026-05-05T23:45:42.843Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -45976,7 +48305,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.907Z",
+        "evaluatedAt": "2026-05-05T23:45:42.844Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46031,7 +48360,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.907Z",
+          "evaluatedAt": "2026-05-05T23:45:42.844Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46049,7 +48378,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.907Z",
+          "evaluatedAt": "2026-05-05T23:45:42.844Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46113,7 +48442,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.909Z",
+        "evaluatedAt": "2026-05-05T23:45:42.845Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46168,7 +48497,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.909Z",
+          "evaluatedAt": "2026-05-05T23:45:42.846Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46186,7 +48515,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.909Z",
+          "evaluatedAt": "2026-05-05T23:45:42.846Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46250,7 +48579,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.911Z",
+        "evaluatedAt": "2026-05-05T23:45:42.847Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46305,7 +48634,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.911Z",
+          "evaluatedAt": "2026-05-05T23:45:42.847Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46323,7 +48652,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.911Z",
+          "evaluatedAt": "2026-05-05T23:45:42.847Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46387,7 +48716,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.912Z",
+        "evaluatedAt": "2026-05-05T23:45:42.848Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46442,7 +48771,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.912Z",
+          "evaluatedAt": "2026-05-05T23:45:42.848Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46460,7 +48789,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.912Z",
+          "evaluatedAt": "2026-05-05T23:45:42.848Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46524,7 +48853,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.913Z",
+        "evaluatedAt": "2026-05-05T23:45:42.849Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46579,7 +48908,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.913Z",
+          "evaluatedAt": "2026-05-05T23:45:42.849Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46597,7 +48926,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.913Z",
+          "evaluatedAt": "2026-05-05T23:45:42.849Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46661,7 +48990,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.913Z",
+        "evaluatedAt": "2026-05-05T23:45:42.850Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46716,7 +49045,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.913Z",
+          "evaluatedAt": "2026-05-05T23:45:42.850Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46734,7 +49063,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.913Z",
+          "evaluatedAt": "2026-05-05T23:45:42.850Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46798,7 +49127,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.914Z",
+        "evaluatedAt": "2026-05-05T23:45:42.851Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46853,7 +49182,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.914Z",
+          "evaluatedAt": "2026-05-05T23:45:42.851Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -46871,7 +49200,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.914Z",
+          "evaluatedAt": "2026-05-05T23:45:42.851Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -46935,7 +49264,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.914Z",
+        "evaluatedAt": "2026-05-05T23:45:42.851Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -46990,7 +49319,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.914Z",
+          "evaluatedAt": "2026-05-05T23:45:42.851Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47008,7 +49337,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.914Z",
+          "evaluatedAt": "2026-05-05T23:45:42.851Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47072,7 +49401,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.915Z",
+        "evaluatedAt": "2026-05-05T23:45:42.852Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47127,7 +49456,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.915Z",
+          "evaluatedAt": "2026-05-05T23:45:42.852Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47145,7 +49474,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.915Z",
+          "evaluatedAt": "2026-05-05T23:45:42.852Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47209,7 +49538,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.916Z",
+        "evaluatedAt": "2026-05-05T23:45:42.852Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47264,7 +49593,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.916Z",
+          "evaluatedAt": "2026-05-05T23:45:42.852Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47282,7 +49611,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.916Z",
+          "evaluatedAt": "2026-05-05T23:45:42.852Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47346,7 +49675,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.919Z",
+        "evaluatedAt": "2026-05-05T23:45:42.855Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -47401,7 +49730,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.919Z",
+          "evaluatedAt": "2026-05-05T23:45:42.855Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -47419,8 +49748,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.919Z",
+          "evaluatedAt": "2026-05-05T23:45:42.855Z",
           "evaluatedVersion": "1.2.0"
+        }
+      }
+    },
+    {
+      "name": "quasi-coder",
+      "description": "Expert 10x engineer skill for interpreting and implementing code from shorthand, quasi-code, and natural language descriptions. Use when collaborators provide incomplete code snippets, pseudo-code, or descriptions with potential typos or incorrect terminology. Excels at translating non-technical or semi-technical descriptions into production-quality code.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:plugins/cms-development/skills/quasi-coder",
+      "relPath": "plugins/cms-development/skills/quasi-coder",
+      "verified": true,
+      "tokenCount": 3998,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.859Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 76,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.859Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.859Z",
+          "evaluatedVersion": "0.0.0"
         }
       }
     },
@@ -47483,7 +49949,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.923Z",
+        "evaluatedAt": "2026-05-05T23:45:42.861Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47538,7 +50004,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.923Z",
+          "evaluatedAt": "2026-05-05T23:45:42.861Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47556,7 +50022,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.923Z",
+          "evaluatedAt": "2026-05-05T23:45:42.861Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47620,7 +50086,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.925Z",
+        "evaluatedAt": "2026-05-05T23:45:42.863Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47675,7 +50141,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.925Z",
+          "evaluatedAt": "2026-05-05T23:45:42.863Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47693,7 +50159,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.925Z",
+          "evaluatedAt": "2026-05-05T23:45:42.863Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47757,7 +50223,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.925Z",
+        "evaluatedAt": "2026-05-05T23:45:42.863Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47812,7 +50278,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.925Z",
+          "evaluatedAt": "2026-05-05T23:45:42.864Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47830,7 +50296,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.926Z",
+          "evaluatedAt": "2026-05-05T23:45:42.864Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -47894,7 +50360,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.926Z",
+        "evaluatedAt": "2026-05-05T23:45:42.864Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -47949,7 +50415,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.926Z",
+          "evaluatedAt": "2026-05-05T23:45:42.864Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -47967,7 +50433,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.926Z",
+          "evaluatedAt": "2026-05-05T23:45:42.864Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48031,7 +50497,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.927Z",
+        "evaluatedAt": "2026-05-05T23:45:42.865Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48086,7 +50552,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.927Z",
+          "evaluatedAt": "2026-05-05T23:45:42.865Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48104,7 +50570,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.927Z",
+          "evaluatedAt": "2026-05-05T23:45:42.865Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48168,7 +50634,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.928Z",
+        "evaluatedAt": "2026-05-05T23:45:42.866Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48223,7 +50689,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.928Z",
+          "evaluatedAt": "2026-05-05T23:45:42.866Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48241,7 +50707,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.928Z",
+          "evaluatedAt": "2026-05-05T23:45:42.866Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48305,7 +50771,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.929Z",
+        "evaluatedAt": "2026-05-05T23:45:42.867Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48360,7 +50826,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.929Z",
+          "evaluatedAt": "2026-05-05T23:45:42.867Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48378,7 +50844,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.929Z",
+          "evaluatedAt": "2026-05-05T23:45:42.867Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48442,7 +50908,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.930Z",
+        "evaluatedAt": "2026-05-05T23:45:42.868Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48497,7 +50963,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.930Z",
+          "evaluatedAt": "2026-05-05T23:45:42.868Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48515,7 +50981,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.930Z",
+          "evaluatedAt": "2026-05-05T23:45:42.868Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48579,7 +51045,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.931Z",
+        "evaluatedAt": "2026-05-05T23:45:42.869Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48634,7 +51100,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.931Z",
+          "evaluatedAt": "2026-05-05T23:45:42.869Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48652,7 +51118,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.931Z",
+          "evaluatedAt": "2026-05-05T23:45:42.869Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48716,7 +51182,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.931Z",
+        "evaluatedAt": "2026-05-05T23:45:42.870Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48771,7 +51237,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.931Z",
+          "evaluatedAt": "2026-05-05T23:45:42.870Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48789,7 +51255,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.931Z",
+          "evaluatedAt": "2026-05-05T23:45:42.870Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48853,7 +51319,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.932Z",
+        "evaluatedAt": "2026-05-05T23:45:42.870Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -48908,7 +51374,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.932Z",
+          "evaluatedAt": "2026-05-05T23:45:42.870Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -48926,7 +51392,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.932Z",
+          "evaluatedAt": "2026-05-05T23:45:42.870Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -48990,7 +51456,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.933Z",
+        "evaluatedAt": "2026-05-05T23:45:42.871Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49045,7 +51511,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.933Z",
+          "evaluatedAt": "2026-05-05T23:45:42.871Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49063,7 +51529,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.933Z",
+          "evaluatedAt": "2026-05-05T23:45:42.871Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49127,7 +51593,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.934Z",
+        "evaluatedAt": "2026-05-05T23:45:42.872Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49182,7 +51648,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.934Z",
+          "evaluatedAt": "2026-05-05T23:45:42.872Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49200,7 +51666,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.934Z",
+          "evaluatedAt": "2026-05-05T23:45:42.872Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49264,7 +51730,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.934Z",
+        "evaluatedAt": "2026-05-05T23:45:42.873Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49319,7 +51785,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.934Z",
+          "evaluatedAt": "2026-05-05T23:45:42.873Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49337,7 +51803,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.934Z",
+          "evaluatedAt": "2026-05-05T23:45:42.873Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49401,7 +51867,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.935Z",
+        "evaluatedAt": "2026-05-05T23:45:42.873Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49456,7 +51922,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.935Z",
+          "evaluatedAt": "2026-05-05T23:45:42.873Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49474,7 +51940,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.935Z",
+          "evaluatedAt": "2026-05-05T23:45:42.873Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49538,7 +52004,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.936Z",
+        "evaluatedAt": "2026-05-05T23:45:42.874Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49593,7 +52059,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.936Z",
+          "evaluatedAt": "2026-05-05T23:45:42.874Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49611,7 +52077,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.936Z",
+          "evaluatedAt": "2026-05-05T23:45:42.874Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49675,7 +52141,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.937Z",
+        "evaluatedAt": "2026-05-05T23:45:42.875Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49730,7 +52196,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.937Z",
+          "evaluatedAt": "2026-05-05T23:45:42.875Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49748,7 +52214,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.937Z",
+          "evaluatedAt": "2026-05-05T23:45:42.875Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49812,7 +52278,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.937Z",
+        "evaluatedAt": "2026-05-05T23:45:42.875Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -49867,7 +52333,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.937Z",
+          "evaluatedAt": "2026-05-05T23:45:42.875Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -49885,7 +52351,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.937Z",
+          "evaluatedAt": "2026-05-05T23:45:42.875Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -49949,7 +52415,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.938Z",
+        "evaluatedAt": "2026-05-05T23:45:42.876Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50004,7 +52470,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.938Z",
+          "evaluatedAt": "2026-05-05T23:45:42.876Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50022,7 +52488,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.938Z",
+          "evaluatedAt": "2026-05-05T23:45:42.876Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50086,7 +52552,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.939Z",
+        "evaluatedAt": "2026-05-05T23:45:42.877Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50141,7 +52607,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.939Z",
+          "evaluatedAt": "2026-05-05T23:45:42.877Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50159,7 +52625,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.939Z",
+          "evaluatedAt": "2026-05-05T23:45:42.877Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50223,7 +52689,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.939Z",
+        "evaluatedAt": "2026-05-05T23:45:42.878Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50278,7 +52744,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.939Z",
+          "evaluatedAt": "2026-05-05T23:45:42.878Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50296,7 +52762,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.939Z",
+          "evaluatedAt": "2026-05-05T23:45:42.878Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50360,7 +52826,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.940Z",
+        "evaluatedAt": "2026-05-05T23:45:42.878Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50415,7 +52881,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.940Z",
+          "evaluatedAt": "2026-05-05T23:45:42.878Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50433,7 +52899,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.940Z",
+          "evaluatedAt": "2026-05-05T23:45:42.878Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50497,7 +52963,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.942Z",
+        "evaluatedAt": "2026-05-05T23:45:42.880Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50552,7 +53018,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.942Z",
+          "evaluatedAt": "2026-05-05T23:45:42.880Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50570,7 +53036,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.942Z",
+          "evaluatedAt": "2026-05-05T23:45:42.880Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50634,7 +53100,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.944Z",
+        "evaluatedAt": "2026-05-05T23:45:42.881Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50689,7 +53155,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.944Z",
+          "evaluatedAt": "2026-05-05T23:45:42.881Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50707,7 +53173,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.944Z",
+          "evaluatedAt": "2026-05-05T23:45:42.881Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50771,7 +53237,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.944Z",
+        "evaluatedAt": "2026-05-05T23:45:42.882Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50826,7 +53292,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.944Z",
+          "evaluatedAt": "2026-05-05T23:45:42.882Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50844,7 +53310,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.944Z",
+          "evaluatedAt": "2026-05-05T23:45:42.882Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -50908,7 +53374,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.945Z",
+        "evaluatedAt": "2026-05-05T23:45:42.882Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -50963,7 +53429,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.945Z",
+          "evaluatedAt": "2026-05-05T23:45:42.883Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -50981,7 +53447,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.945Z",
+          "evaluatedAt": "2026-05-05T23:45:42.883Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51045,7 +53511,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.946Z",
+        "evaluatedAt": "2026-05-05T23:45:42.883Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51100,7 +53566,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.946Z",
+          "evaluatedAt": "2026-05-05T23:45:42.883Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51118,7 +53584,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.946Z",
+          "evaluatedAt": "2026-05-05T23:45:42.883Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51182,7 +53648,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.947Z",
+        "evaluatedAt": "2026-05-05T23:45:42.884Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51237,7 +53703,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.947Z",
+          "evaluatedAt": "2026-05-05T23:45:42.884Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51255,7 +53721,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.947Z",
+          "evaluatedAt": "2026-05-05T23:45:42.884Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51319,7 +53785,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.947Z",
+        "evaluatedAt": "2026-05-05T23:45:42.885Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51374,7 +53840,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.947Z",
+          "evaluatedAt": "2026-05-05T23:45:42.885Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51392,7 +53858,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.947Z",
+          "evaluatedAt": "2026-05-05T23:45:42.885Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51456,7 +53922,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.948Z",
+        "evaluatedAt": "2026-05-05T23:45:42.886Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51511,7 +53977,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.948Z",
+          "evaluatedAt": "2026-05-05T23:45:42.886Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51529,7 +53995,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.948Z",
+          "evaluatedAt": "2026-05-05T23:45:42.886Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51593,7 +54059,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.950Z",
+        "evaluatedAt": "2026-05-05T23:45:42.887Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51648,7 +54114,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.950Z",
+          "evaluatedAt": "2026-05-05T23:45:42.887Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51666,7 +54132,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.950Z",
+          "evaluatedAt": "2026-05-05T23:45:42.887Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51730,7 +54196,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.951Z",
+        "evaluatedAt": "2026-05-05T23:45:42.889Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51785,7 +54251,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.951Z",
+          "evaluatedAt": "2026-05-05T23:45:42.889Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51803,7 +54269,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.951Z",
+          "evaluatedAt": "2026-05-05T23:45:42.889Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -51867,7 +54333,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.952Z",
+        "evaluatedAt": "2026-05-05T23:45:42.889Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -51922,7 +54388,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.952Z",
+          "evaluatedAt": "2026-05-05T23:45:42.889Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -51940,7 +54406,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.952Z",
+          "evaluatedAt": "2026-05-05T23:45:42.889Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52004,7 +54470,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.953Z",
+        "evaluatedAt": "2026-05-05T23:45:42.890Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52059,7 +54525,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.953Z",
+          "evaluatedAt": "2026-05-05T23:45:42.890Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52077,7 +54543,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.953Z",
+          "evaluatedAt": "2026-05-05T23:45:42.890Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52141,7 +54607,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.954Z",
+        "evaluatedAt": "2026-05-05T23:45:42.891Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52196,7 +54662,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.954Z",
+          "evaluatedAt": "2026-05-05T23:45:42.891Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52214,7 +54680,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.954Z",
+          "evaluatedAt": "2026-05-05T23:45:42.891Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52278,7 +54744,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.956Z",
+        "evaluatedAt": "2026-05-05T23:45:42.893Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52333,7 +54799,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.956Z",
+          "evaluatedAt": "2026-05-05T23:45:42.893Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52351,7 +54817,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.956Z",
+          "evaluatedAt": "2026-05-05T23:45:42.893Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52415,7 +54881,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.958Z",
+        "evaluatedAt": "2026-05-05T23:45:42.895Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52470,7 +54936,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.958Z",
+          "evaluatedAt": "2026-05-05T23:45:42.895Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52488,7 +54954,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.958Z",
+          "evaluatedAt": "2026-05-05T23:45:42.895Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52552,7 +55018,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.960Z",
+        "evaluatedAt": "2026-05-05T23:45:42.897Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52607,7 +55073,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.960Z",
+          "evaluatedAt": "2026-05-05T23:45:42.897Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52625,7 +55091,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.960Z",
+          "evaluatedAt": "2026-05-05T23:45:42.897Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52689,7 +55155,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.962Z",
+        "evaluatedAt": "2026-05-05T23:45:42.900Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52744,7 +55210,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.962Z",
+          "evaluatedAt": "2026-05-05T23:45:42.900Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52762,7 +55228,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.962Z",
+          "evaluatedAt": "2026-05-05T23:45:42.900Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52826,7 +55292,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.965Z",
+        "evaluatedAt": "2026-05-05T23:45:42.904Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -52881,7 +55347,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.965Z",
+          "evaluatedAt": "2026-05-05T23:45:42.904Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -52899,7 +55365,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.965Z",
+          "evaluatedAt": "2026-05-05T23:45:42.904Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -52963,7 +55429,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.967Z",
+        "evaluatedAt": "2026-05-05T23:45:42.906Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53018,7 +55484,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.967Z",
+          "evaluatedAt": "2026-05-05T23:45:42.906Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53036,7 +55502,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.967Z",
+          "evaluatedAt": "2026-05-05T23:45:42.906Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53100,7 +55566,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.968Z",
+        "evaluatedAt": "2026-05-05T23:45:42.908Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53155,7 +55621,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.968Z",
+          "evaluatedAt": "2026-05-05T23:45:42.908Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53173,7 +55639,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.968Z",
+          "evaluatedAt": "2026-05-05T23:45:42.908Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53237,7 +55703,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.970Z",
+        "evaluatedAt": "2026-05-05T23:45:42.910Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53292,7 +55758,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.970Z",
+          "evaluatedAt": "2026-05-05T23:45:42.910Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53310,7 +55776,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.970Z",
+          "evaluatedAt": "2026-05-05T23:45:42.910Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53374,7 +55840,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.972Z",
+        "evaluatedAt": "2026-05-05T23:45:42.912Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53429,7 +55895,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.972Z",
+          "evaluatedAt": "2026-05-05T23:45:42.912Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53447,7 +55913,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.972Z",
+          "evaluatedAt": "2026-05-05T23:45:42.912Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53511,7 +55977,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.974Z",
+        "evaluatedAt": "2026-05-05T23:45:42.913Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53566,7 +56032,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.974Z",
+          "evaluatedAt": "2026-05-05T23:45:42.913Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53584,7 +56050,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.974Z",
+          "evaluatedAt": "2026-05-05T23:45:42.913Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53648,7 +56114,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.976Z",
+        "evaluatedAt": "2026-05-05T23:45:42.915Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53703,7 +56169,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.976Z",
+          "evaluatedAt": "2026-05-05T23:45:42.915Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53721,7 +56187,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.976Z",
+          "evaluatedAt": "2026-05-05T23:45:42.915Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53785,7 +56251,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.977Z",
+        "evaluatedAt": "2026-05-05T23:45:42.917Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53840,7 +56306,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.977Z",
+          "evaluatedAt": "2026-05-05T23:45:42.917Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53858,7 +56324,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.977Z",
+          "evaluatedAt": "2026-05-05T23:45:42.917Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -53922,7 +56388,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.979Z",
+        "evaluatedAt": "2026-05-05T23:45:42.919Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -53977,7 +56443,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.979Z",
+          "evaluatedAt": "2026-05-05T23:45:42.919Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -53995,7 +56461,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.979Z",
+          "evaluatedAt": "2026-05-05T23:45:42.919Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54059,7 +56525,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.980Z",
+        "evaluatedAt": "2026-05-05T23:45:42.920Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54114,7 +56580,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.980Z",
+          "evaluatedAt": "2026-05-05T23:45:42.920Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54132,7 +56598,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.980Z",
+          "evaluatedAt": "2026-05-05T23:45:42.920Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54196,7 +56662,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.981Z",
+        "evaluatedAt": "2026-05-05T23:45:42.921Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54251,7 +56717,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.981Z",
+          "evaluatedAt": "2026-05-05T23:45:42.921Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54269,7 +56735,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.981Z",
+          "evaluatedAt": "2026-05-05T23:45:42.921Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54333,7 +56799,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.982Z",
+        "evaluatedAt": "2026-05-05T23:45:42.922Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54388,7 +56854,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.982Z",
+          "evaluatedAt": "2026-05-05T23:45:42.922Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54406,7 +56872,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.982Z",
+          "evaluatedAt": "2026-05-05T23:45:42.922Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54470,7 +56936,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.982Z",
+        "evaluatedAt": "2026-05-05T23:45:42.923Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54525,7 +56991,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.982Z",
+          "evaluatedAt": "2026-05-05T23:45:42.923Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54543,7 +57009,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.982Z",
+          "evaluatedAt": "2026-05-05T23:45:42.923Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54607,7 +57073,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.984Z",
+        "evaluatedAt": "2026-05-05T23:45:42.924Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54662,7 +57128,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.984Z",
+          "evaluatedAt": "2026-05-05T23:45:42.924Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54680,7 +57146,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.984Z",
+          "evaluatedAt": "2026-05-05T23:45:42.924Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54744,7 +57210,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.986Z",
+        "evaluatedAt": "2026-05-05T23:45:42.926Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54799,7 +57265,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.986Z",
+          "evaluatedAt": "2026-05-05T23:45:42.926Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54817,7 +57283,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.986Z",
+          "evaluatedAt": "2026-05-05T23:45:42.926Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -54881,7 +57347,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.987Z",
+        "evaluatedAt": "2026-05-05T23:45:42.928Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -54936,7 +57402,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.987Z",
+          "evaluatedAt": "2026-05-05T23:45:42.928Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -54954,7 +57420,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.987Z",
+          "evaluatedAt": "2026-05-05T23:45:42.928Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55018,7 +57484,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.988Z",
+        "evaluatedAt": "2026-05-05T23:45:42.930Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55073,7 +57539,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.988Z",
+          "evaluatedAt": "2026-05-05T23:45:42.930Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55091,7 +57557,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.988Z",
+          "evaluatedAt": "2026-05-05T23:45:42.930Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55155,7 +57621,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.989Z",
+        "evaluatedAt": "2026-05-05T23:45:42.931Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55210,7 +57676,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.989Z",
+          "evaluatedAt": "2026-05-05T23:45:42.931Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55228,7 +57694,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.989Z",
+          "evaluatedAt": "2026-05-05T23:45:42.931Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55292,7 +57758,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.990Z",
+        "evaluatedAt": "2026-05-05T23:45:42.932Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55347,7 +57813,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.990Z",
+          "evaluatedAt": "2026-05-05T23:45:42.932Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55365,7 +57831,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.990Z",
+          "evaluatedAt": "2026-05-05T23:45:42.932Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55429,7 +57895,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.992Z",
+        "evaluatedAt": "2026-05-05T23:45:42.933Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55484,7 +57950,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.992Z",
+          "evaluatedAt": "2026-05-05T23:45:42.933Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55502,7 +57968,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.992Z",
+          "evaluatedAt": "2026-05-05T23:45:42.933Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55566,7 +58032,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.993Z",
+        "evaluatedAt": "2026-05-05T23:45:42.936Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55621,7 +58087,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.994Z",
+          "evaluatedAt": "2026-05-05T23:45:42.936Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55639,7 +58105,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.994Z",
+          "evaluatedAt": "2026-05-05T23:45:42.936Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55703,7 +58169,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.995Z",
+        "evaluatedAt": "2026-05-05T23:45:42.937Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55758,7 +58224,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.995Z",
+          "evaluatedAt": "2026-05-05T23:45:42.937Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55776,7 +58242,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.995Z",
+          "evaluatedAt": "2026-05-05T23:45:42.937Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55840,7 +58306,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.997Z",
+        "evaluatedAt": "2026-05-05T23:45:42.939Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -55895,7 +58361,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.997Z",
+          "evaluatedAt": "2026-05-05T23:45:42.939Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -55913,7 +58379,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.997Z",
+          "evaluatedAt": "2026-05-05T23:45:42.939Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -55977,7 +58443,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:29.999Z",
+        "evaluatedAt": "2026-05-05T23:45:42.941Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56032,7 +58498,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.999Z",
+          "evaluatedAt": "2026-05-05T23:45:42.941Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56050,7 +58516,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:29.999Z",
+          "evaluatedAt": "2026-05-05T23:45:42.941Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56114,7 +58580,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.000Z",
+        "evaluatedAt": "2026-05-05T23:45:42.943Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56169,7 +58635,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.000Z",
+          "evaluatedAt": "2026-05-05T23:45:42.943Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56187,7 +58653,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.000Z",
+          "evaluatedAt": "2026-05-05T23:45:42.943Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56251,7 +58717,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.002Z",
+        "evaluatedAt": "2026-05-05T23:45:42.945Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56306,7 +58772,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.002Z",
+          "evaluatedAt": "2026-05-05T23:45:42.945Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56324,7 +58790,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.002Z",
+          "evaluatedAt": "2026-05-05T23:45:42.945Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56388,7 +58854,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.003Z",
+        "evaluatedAt": "2026-05-05T23:45:42.946Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56443,7 +58909,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.003Z",
+          "evaluatedAt": "2026-05-05T23:45:42.946Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56461,7 +58927,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.003Z",
+          "evaluatedAt": "2026-05-05T23:45:42.946Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56525,7 +58991,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.004Z",
+        "evaluatedAt": "2026-05-05T23:45:42.947Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56580,7 +59046,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.004Z",
+          "evaluatedAt": "2026-05-05T23:45:42.947Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56598,7 +59064,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.004Z",
+          "evaluatedAt": "2026-05-05T23:45:42.947Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56662,7 +59128,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.005Z",
+        "evaluatedAt": "2026-05-05T23:45:42.948Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56717,7 +59183,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.005Z",
+          "evaluatedAt": "2026-05-05T23:45:42.948Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56735,7 +59201,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.005Z",
+          "evaluatedAt": "2026-05-05T23:45:42.948Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56799,7 +59265,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.006Z",
+        "evaluatedAt": "2026-05-05T23:45:42.948Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56854,7 +59320,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.006Z",
+          "evaluatedAt": "2026-05-05T23:45:42.948Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -56872,7 +59338,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.006Z",
+          "evaluatedAt": "2026-05-05T23:45:42.948Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -56936,7 +59402,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.006Z",
+        "evaluatedAt": "2026-05-05T23:45:42.949Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -56991,7 +59457,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.007Z",
+          "evaluatedAt": "2026-05-05T23:45:42.949Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57009,7 +59475,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.007Z",
+          "evaluatedAt": "2026-05-05T23:45:42.949Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57073,7 +59539,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.007Z",
+        "evaluatedAt": "2026-05-05T23:45:42.950Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57128,7 +59594,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.007Z",
+          "evaluatedAt": "2026-05-05T23:45:42.950Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57146,7 +59612,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.007Z",
+          "evaluatedAt": "2026-05-05T23:45:42.950Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57210,7 +59676,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.008Z",
+        "evaluatedAt": "2026-05-05T23:45:42.951Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57265,7 +59731,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.008Z",
+          "evaluatedAt": "2026-05-05T23:45:42.951Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57283,7 +59749,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.008Z",
+          "evaluatedAt": "2026-05-05T23:45:42.951Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57347,7 +59813,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.010Z",
+        "evaluatedAt": "2026-05-05T23:45:42.953Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57402,7 +59868,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.010Z",
+          "evaluatedAt": "2026-05-05T23:45:42.953Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57420,7 +59886,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.010Z",
+          "evaluatedAt": "2026-05-05T23:45:42.953Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57484,7 +59950,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.011Z",
+        "evaluatedAt": "2026-05-05T23:45:42.954Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57539,7 +60005,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.011Z",
+          "evaluatedAt": "2026-05-05T23:45:42.954Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57557,7 +60023,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.011Z",
+          "evaluatedAt": "2026-05-05T23:45:42.954Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57621,7 +60087,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.013Z",
+        "evaluatedAt": "2026-05-05T23:45:42.956Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57676,7 +60142,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.013Z",
+          "evaluatedAt": "2026-05-05T23:45:42.956Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57694,7 +60160,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.013Z",
+          "evaluatedAt": "2026-05-05T23:45:42.956Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57758,7 +60224,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.015Z",
+        "evaluatedAt": "2026-05-05T23:45:42.957Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57813,7 +60279,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.015Z",
+          "evaluatedAt": "2026-05-05T23:45:42.957Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57831,7 +60297,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.015Z",
+          "evaluatedAt": "2026-05-05T23:45:42.957Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -57895,7 +60361,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.016Z",
+        "evaluatedAt": "2026-05-05T23:45:42.959Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -57950,7 +60416,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.016Z",
+          "evaluatedAt": "2026-05-05T23:45:42.959Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -57968,7 +60434,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.016Z",
+          "evaluatedAt": "2026-05-05T23:45:42.959Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58032,7 +60498,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.018Z",
+        "evaluatedAt": "2026-05-05T23:45:42.961Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58087,7 +60553,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.018Z",
+          "evaluatedAt": "2026-05-05T23:45:42.961Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58105,7 +60571,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.018Z",
+          "evaluatedAt": "2026-05-05T23:45:42.961Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58169,7 +60635,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.021Z",
+        "evaluatedAt": "2026-05-05T23:45:42.964Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58224,7 +60690,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.021Z",
+          "evaluatedAt": "2026-05-05T23:45:42.964Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58242,7 +60708,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.021Z",
+          "evaluatedAt": "2026-05-05T23:45:42.964Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58306,7 +60772,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.024Z",
+        "evaluatedAt": "2026-05-05T23:45:42.966Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58361,7 +60827,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.024Z",
+          "evaluatedAt": "2026-05-05T23:45:42.967Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58379,7 +60845,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.024Z",
+          "evaluatedAt": "2026-05-05T23:45:42.967Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58443,7 +60909,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.025Z",
+        "evaluatedAt": "2026-05-05T23:45:42.968Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58498,7 +60964,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.025Z",
+          "evaluatedAt": "2026-05-05T23:45:42.968Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58516,7 +60982,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.025Z",
+          "evaluatedAt": "2026-05-05T23:45:42.968Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58580,7 +61046,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.026Z",
+        "evaluatedAt": "2026-05-05T23:45:42.969Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58635,7 +61101,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.026Z",
+          "evaluatedAt": "2026-05-05T23:45:42.969Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58653,7 +61119,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.026Z",
+          "evaluatedAt": "2026-05-05T23:45:42.969Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58717,7 +61183,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.028Z",
+        "evaluatedAt": "2026-05-05T23:45:42.971Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58772,7 +61238,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.028Z",
+          "evaluatedAt": "2026-05-05T23:45:42.971Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58790,7 +61256,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.028Z",
+          "evaluatedAt": "2026-05-05T23:45:42.971Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58854,7 +61320,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.030Z",
+        "evaluatedAt": "2026-05-05T23:45:42.972Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -58909,7 +61375,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.030Z",
+          "evaluatedAt": "2026-05-05T23:45:42.972Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -58927,7 +61393,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.030Z",
+          "evaluatedAt": "2026-05-05T23:45:42.972Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -58991,7 +61457,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.030Z",
+        "evaluatedAt": "2026-05-05T23:45:42.973Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59046,7 +61512,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.030Z",
+          "evaluatedAt": "2026-05-05T23:45:42.973Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59064,7 +61530,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.030Z",
+          "evaluatedAt": "2026-05-05T23:45:42.973Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59128,7 +61594,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.031Z",
+        "evaluatedAt": "2026-05-05T23:45:42.974Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59183,7 +61649,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.032Z",
+          "evaluatedAt": "2026-05-05T23:45:42.974Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59201,7 +61667,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.032Z",
+          "evaluatedAt": "2026-05-05T23:45:42.974Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59265,7 +61731,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.033Z",
+        "evaluatedAt": "2026-05-05T23:45:42.976Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59320,7 +61786,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.033Z",
+          "evaluatedAt": "2026-05-05T23:45:42.976Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59338,7 +61804,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.033Z",
+          "evaluatedAt": "2026-05-05T23:45:42.976Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59402,7 +61868,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.035Z",
+        "evaluatedAt": "2026-05-05T23:45:42.978Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59457,7 +61923,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.035Z",
+          "evaluatedAt": "2026-05-05T23:45:42.978Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59475,7 +61941,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.035Z",
+          "evaluatedAt": "2026-05-05T23:45:42.978Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59539,7 +62005,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.036Z",
+        "evaluatedAt": "2026-05-05T23:45:42.979Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59594,7 +62060,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.036Z",
+          "evaluatedAt": "2026-05-05T23:45:42.979Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59612,7 +62078,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.036Z",
+          "evaluatedAt": "2026-05-05T23:45:42.979Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59676,7 +62142,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.037Z",
+        "evaluatedAt": "2026-05-05T23:45:42.980Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59731,7 +62197,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.037Z",
+          "evaluatedAt": "2026-05-05T23:45:42.980Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59749,7 +62215,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.037Z",
+          "evaluatedAt": "2026-05-05T23:45:42.980Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59813,7 +62279,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.037Z",
+        "evaluatedAt": "2026-05-05T23:45:42.981Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -59868,7 +62334,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.037Z",
+          "evaluatedAt": "2026-05-05T23:45:42.981Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -59886,7 +62352,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.037Z",
+          "evaluatedAt": "2026-05-05T23:45:42.981Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -59950,7 +62416,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.038Z",
+        "evaluatedAt": "2026-05-05T23:45:42.981Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60005,7 +62471,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.038Z",
+          "evaluatedAt": "2026-05-05T23:45:42.981Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60023,7 +62489,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.038Z",
+          "evaluatedAt": "2026-05-05T23:45:42.981Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60087,7 +62553,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.039Z",
+        "evaluatedAt": "2026-05-05T23:45:42.983Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60142,7 +62608,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.039Z",
+          "evaluatedAt": "2026-05-05T23:45:42.983Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60160,7 +62626,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.039Z",
+          "evaluatedAt": "2026-05-05T23:45:42.983Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60224,7 +62690,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.040Z",
+        "evaluatedAt": "2026-05-05T23:45:42.984Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60279,7 +62745,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.040Z",
+          "evaluatedAt": "2026-05-05T23:45:42.984Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60297,7 +62763,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.040Z",
+          "evaluatedAt": "2026-05-05T23:45:42.984Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60361,7 +62827,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.041Z",
+        "evaluatedAt": "2026-05-05T23:45:42.985Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60416,7 +62882,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.041Z",
+          "evaluatedAt": "2026-05-05T23:45:42.985Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60434,7 +62900,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.041Z",
+          "evaluatedAt": "2026-05-05T23:45:42.985Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60498,7 +62964,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.042Z",
+        "evaluatedAt": "2026-05-05T23:45:42.986Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60553,7 +63019,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.042Z",
+          "evaluatedAt": "2026-05-05T23:45:42.986Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60571,7 +63037,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.042Z",
+          "evaluatedAt": "2026-05-05T23:45:42.986Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60635,7 +63101,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.044Z",
+        "evaluatedAt": "2026-05-05T23:45:42.987Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60690,7 +63156,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.044Z",
+          "evaluatedAt": "2026-05-05T23:45:42.987Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60708,7 +63174,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.044Z",
+          "evaluatedAt": "2026-05-05T23:45:42.987Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60772,7 +63238,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.045Z",
+        "evaluatedAt": "2026-05-05T23:45:42.989Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60827,7 +63293,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.045Z",
+          "evaluatedAt": "2026-05-05T23:45:42.989Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60845,7 +63311,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.045Z",
+          "evaluatedAt": "2026-05-05T23:45:42.989Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -60909,7 +63375,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.046Z",
+        "evaluatedAt": "2026-05-05T23:45:42.989Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -60964,7 +63430,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.046Z",
+          "evaluatedAt": "2026-05-05T23:45:42.989Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -60982,7 +63448,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.046Z",
+          "evaluatedAt": "2026-05-05T23:45:42.989Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61046,7 +63512,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.047Z",
+        "evaluatedAt": "2026-05-05T23:45:42.990Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61101,7 +63567,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.047Z",
+          "evaluatedAt": "2026-05-05T23:45:42.990Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61119,7 +63585,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.047Z",
+          "evaluatedAt": "2026-05-05T23:45:42.991Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61183,7 +63649,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.048Z",
+        "evaluatedAt": "2026-05-05T23:45:42.991Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61238,7 +63704,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.048Z",
+          "evaluatedAt": "2026-05-05T23:45:42.991Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61256,7 +63722,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.048Z",
+          "evaluatedAt": "2026-05-05T23:45:42.991Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61320,7 +63786,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.048Z",
+        "evaluatedAt": "2026-05-05T23:45:42.992Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61375,7 +63841,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.048Z",
+          "evaluatedAt": "2026-05-05T23:45:42.992Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61393,7 +63859,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.048Z",
+          "evaluatedAt": "2026-05-05T23:45:42.992Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "web-coder",
+      "description": "Expert 10x engineer with comprehensive knowledge of web development, internet protocols, and web standards. Use when working with HTML, CSS, JavaScript, web APIs, HTTP/HTTPS, web security, performance optimization, accessibility, or any web/internet concepts. Specializes in translating web terminology accurately and implementing modern web standards across frontend and backend development.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:github/awesome-copilot:plugins/cms-development/skills/web-coder",
+      "relPath": "plugins/cms-development/skills/web-coder",
+      "verified": true,
+      "tokenCount": 5171,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:42.994Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.994Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:42.994Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61457,7 +64060,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.050Z",
+        "evaluatedAt": "2026-05-05T23:45:42.997Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61512,7 +64115,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.050Z",
+          "evaluatedAt": "2026-05-05T23:45:42.997Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61530,7 +64133,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.050Z",
+          "evaluatedAt": "2026-05-05T23:45:42.997Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61594,7 +64197,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.053Z",
+        "evaluatedAt": "2026-05-05T23:45:43.000Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61649,7 +64252,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.053Z",
+          "evaluatedAt": "2026-05-05T23:45:43.000Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61667,7 +64270,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.053Z",
+          "evaluatedAt": "2026-05-05T23:45:43.000Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61731,7 +64334,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.054Z",
+        "evaluatedAt": "2026-05-05T23:45:43.001Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61786,7 +64389,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.054Z",
+          "evaluatedAt": "2026-05-05T23:45:43.001Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61804,7 +64407,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.054Z",
+          "evaluatedAt": "2026-05-05T23:45:43.001Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -61868,7 +64471,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.055Z",
+        "evaluatedAt": "2026-05-05T23:45:43.002Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -61923,7 +64526,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.055Z",
+          "evaluatedAt": "2026-05-05T23:45:43.002Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -61941,7 +64544,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.055Z",
+          "evaluatedAt": "2026-05-05T23:45:43.002Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62005,7 +64608,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.055Z",
+        "evaluatedAt": "2026-05-05T23:45:43.003Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62060,7 +64663,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.055Z",
+          "evaluatedAt": "2026-05-05T23:45:43.003Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62078,14 +64681,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.055Z",
+          "evaluatedAt": "2026-05-05T23:45:43.003Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "winapp-cli",
-      "description": "Windows App Development CLI (winapp) for building, packaging, and deploying Windows applications. Use when asked to initialize Windows app projects, create MSIX packages, generate AppxManifest.xml, manage development certificates, add package identity for debugging, sign packages, publish to the Microsoft Store, create external catalogs, or access Windows SDK build tools. Supports .NET (csproj), C++, Electron, Rust, Tauri, and cross-platform frameworks targeting Windows.",
+      "description": "Windows App Development CLI (winapp) for building, packaging, signing, debugging, and UI-automating Windows applications. Use when asked to initialize Windows app projects, create MSIX packages, manage AppxManifest.xml or development certificates, run an app as packaged for debugging, automate Windows UI via Microsoft UI Automation, publish to the Microsoft Store, or access Windows SDK build tools. Covers commands like init, pack, run, unregister, manifest, cert, sign, store, ui, and tool. Supports .NET (csproj), C++, Electron, Rust, Tauri, Flutter, and other Windows frameworks.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -62094,9 +64697,9 @@
       "installUrl": "github:github/awesome-copilot:skills/winapp-cli",
       "relPath": "skills/winapp-cli",
       "verified": true,
-      "tokenCount": 2318,
+      "tokenCount": 1900,
       "evalSummary": {
-        "overallScore": 76,
+        "overallScore": 69,
         "grade": "C",
         "categories": [
           {
@@ -62114,7 +64717,7 @@
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 10,
+            "score": 7,
             "max": 10
           },
           {
@@ -62126,7 +64729,7 @@
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 9,
+            "score": 7,
             "max": 10
           },
           {
@@ -62142,7 +64745,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.056Z",
+        "evaluatedAt": "2026-05-05T23:45:43.004Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62151,7 +64754,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 76,
+          "overallScore": 69,
           "grade": "C",
           "categories": [
             {
@@ -62169,7 +64772,7 @@
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 10,
+              "score": 7,
               "max": 10
             },
             {
@@ -62181,7 +64784,7 @@
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 9,
+              "score": 7,
               "max": 10
             },
             {
@@ -62197,7 +64800,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.056Z",
+          "evaluatedAt": "2026-05-05T23:45:43.004Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62215,7 +64818,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.056Z",
+          "evaluatedAt": "2026-05-05T23:45:43.004Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62279,7 +64882,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.058Z",
+        "evaluatedAt": "2026-05-05T23:45:43.005Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62334,7 +64937,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.058Z",
+          "evaluatedAt": "2026-05-05T23:45:43.005Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62352,7 +64955,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.058Z",
+          "evaluatedAt": "2026-05-05T23:45:43.005Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62416,7 +65019,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.059Z",
+        "evaluatedAt": "2026-05-05T23:45:43.007Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62471,7 +65074,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.060Z",
+          "evaluatedAt": "2026-05-05T23:45:43.007Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62489,7 +65092,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.060Z",
+          "evaluatedAt": "2026-05-05T23:45:43.007Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62553,7 +65156,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.061Z",
+        "evaluatedAt": "2026-05-05T23:45:43.009Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62608,7 +65211,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.061Z",
+          "evaluatedAt": "2026-05-05T23:45:43.009Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62626,7 +65229,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.061Z",
+          "evaluatedAt": "2026-05-05T23:45:43.009Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62690,7 +65293,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.063Z",
+        "evaluatedAt": "2026-05-05T23:45:43.011Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62745,7 +65348,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.063Z",
+          "evaluatedAt": "2026-05-05T23:45:43.011Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62763,7 +65366,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.063Z",
+          "evaluatedAt": "2026-05-05T23:45:43.011Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -62827,7 +65430,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:30.065Z",
+        "evaluatedAt": "2026-05-05T23:45:43.013Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -62882,7 +65485,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.065Z",
+          "evaluatedAt": "2026-05-05T23:45:43.013Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -62900,7 +65503,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:30.065Z",
+          "evaluatedAt": "2026-05-05T23:45:43.013Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/google_skills.json
+++ b/data/skill-index/google_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/google/skills.git",
   "owner": "google",
   "repo": "skills",
-  "updatedAt": "2026-04-30T23:05:44.122Z",
+  "updatedAt": "2026-05-05T23:45:57.544Z",
   "skillCount": 13,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.102Z",
+        "evaluatedAt": "2026-05-05T23:45:57.525Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.102Z",
+          "evaluatedAt": "2026-05-05T23:45:57.525Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.102Z",
+          "evaluatedAt": "2026-05-05T23:45:57.525Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.103Z",
+        "evaluatedAt": "2026-05-05T23:45:57.526Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.103Z",
+          "evaluatedAt": "2026-05-05T23:45:57.526Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.103Z",
+          "evaluatedAt": "2026-05-05T23:45:57.526Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.105Z",
+        "evaluatedAt": "2026-05-05T23:45:57.528Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.105Z",
+          "evaluatedAt": "2026-05-05T23:45:57.528Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.105Z",
+          "evaluatedAt": "2026-05-05T23:45:57.528Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.107Z",
+        "evaluatedAt": "2026-05-05T23:45:57.529Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.107Z",
+          "evaluatedAt": "2026-05-05T23:45:57.529Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.107Z",
+          "evaluatedAt": "2026-05-05T23:45:57.529Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.108Z",
+        "evaluatedAt": "2026-05-05T23:45:57.530Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.108Z",
+          "evaluatedAt": "2026-05-05T23:45:57.530Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.108Z",
+          "evaluatedAt": "2026-05-05T23:45:57.530Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -701,7 +701,7 @@
       "installUrl": "github:google/skills:skills/cloud/gemini-api",
       "relPath": "skills/cloud/gemini-api",
       "verified": true,
-      "tokenCount": 2031,
+      "tokenCount": 2048,
       "evalSummary": {
         "overallScore": 71,
         "grade": "C",
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.110Z",
+        "evaluatedAt": "2026-05-05T23:45:57.532Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.110Z",
+          "evaluatedAt": "2026-05-05T23:45:57.532Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.110Z",
+          "evaluatedAt": "2026-05-05T23:45:57.532Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.111Z",
+        "evaluatedAt": "2026-05-05T23:45:57.533Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.111Z",
+          "evaluatedAt": "2026-05-05T23:45:57.533Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.111Z",
+          "evaluatedAt": "2026-05-05T23:45:57.533Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.113Z",
+        "evaluatedAt": "2026-05-05T23:45:57.535Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.113Z",
+          "evaluatedAt": "2026-05-05T23:45:57.535Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.113Z",
+          "evaluatedAt": "2026-05-05T23:45:57.535Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.115Z",
+        "evaluatedAt": "2026-05-05T23:45:57.537Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.115Z",
+          "evaluatedAt": "2026-05-05T23:45:57.537Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.115Z",
+          "evaluatedAt": "2026-05-05T23:45:57.537Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1249,7 +1249,7 @@
       "installUrl": "github:google/skills:skills/cloud/google-cloud-recipe-onboarding",
       "relPath": "skills/cloud/google-cloud-recipe-onboarding",
       "verified": true,
-      "tokenCount": 1443,
+      "tokenCount": 1440,
       "evalSummary": {
         "overallScore": 76,
         "grade": "C",
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.116Z",
+        "evaluatedAt": "2026-05-05T23:45:57.538Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.116Z",
+          "evaluatedAt": "2026-05-05T23:45:57.538Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.116Z",
+          "evaluatedAt": "2026-05-05T23:45:57.538Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.117Z",
+        "evaluatedAt": "2026-05-05T23:45:57.540Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.117Z",
+          "evaluatedAt": "2026-05-05T23:45:57.540Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.117Z",
+          "evaluatedAt": "2026-05-05T23:45:57.540Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.119Z",
+        "evaluatedAt": "2026-05-05T23:45:57.541Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.119Z",
+          "evaluatedAt": "2026-05-05T23:45:57.541Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.119Z",
+          "evaluatedAt": "2026-05-05T23:45:57.541Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:44.121Z",
+        "evaluatedAt": "2026-05-05T23:45:57.543Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.121Z",
+          "evaluatedAt": "2026-05-05T23:45:57.543Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:44.121Z",
+          "evaluatedAt": "2026-05-05T23:45:57.543Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/heygen-com_hyperframes.json
+++ b/data/skill-index/heygen-com_hyperframes.json
@@ -2,8 +2,8 @@
   "repoUrl": "https://github.com/heygen-com/hyperframes.git",
   "owner": "heygen-com",
   "repo": "hyperframes",
-  "updatedAt": "2026-04-30T23:05:43.299Z",
-  "skillCount": 12,
+  "updatedAt": "2026-05-05T23:45:56.781Z",
+  "skillCount": 13,
   "skills": [
     {
       "name": "animejs",
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.283Z",
+        "evaluatedAt": "2026-05-05T23:45:56.764Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.283Z",
+          "evaluatedAt": "2026-05-05T23:45:56.764Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.283Z",
+          "evaluatedAt": "2026-05-05T23:45:56.764Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.284Z",
+        "evaluatedAt": "2026-05-05T23:45:56.764Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.284Z",
+          "evaluatedAt": "2026-05-05T23:45:56.764Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.284Z",
+          "evaluatedAt": "2026-05-05T23:45:56.764Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.285Z",
+        "evaluatedAt": "2026-05-05T23:45:56.766Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.285Z",
+          "evaluatedAt": "2026-05-05T23:45:56.766Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,14 +411,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.285Z",
+          "evaluatedAt": "2026-05-05T23:45:56.766Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "hyperframes",
-      "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For CLI commands (init, lint, preview, render, transcribe, tts) see the hyperframes-cli skill.",
+      "description": "Create video compositions, animations, title cards, overlays, captions, voiceovers, audio-reactive visuals, and scene transitions in HyperFrames HTML. Use when asked to build any HTML-based video content, add captions or subtitles synced to audio, generate text-to-speech narration, create audio-reactive animation (beat sync, glow, pulse driven by music), add animated text highlighting (marker sweeps, hand-drawn circles, burst lines, scribble, sketchout), or add transitions between scenes (crossfades, wipes, reveals, shader transitions). Covers composition authoring, timing, media, and the full video production workflow. For dev-loop CLI commands (init, lint, inspect, preview, render) see the hyperframes-cli skill; for asset preprocessing commands (tts, transcribe, remove-background) see the hyperframes-media skill.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -427,9 +427,9 @@
       "installUrl": "github:heygen-com/hyperframes:skills/hyperframes",
       "relPath": "skills/hyperframes",
       "verified": true,
-      "tokenCount": 7475,
+      "tokenCount": 8608,
       "evalSummary": {
-        "overallScore": 67,
+        "overallScore": 70,
         "grade": "C",
         "categories": [
           {
@@ -465,7 +465,7 @@
           {
             "id": "testability",
             "name": "Testability",
-            "score": 3,
+            "score": 5,
             "max": 10
           },
           {
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.288Z",
+        "evaluatedAt": "2026-05-05T23:45:56.769Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -484,7 +484,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 67,
+          "overallScore": 70,
           "grade": "C",
           "categories": [
             {
@@ -520,7 +520,7 @@
             {
               "id": "testability",
               "name": "Testability",
-              "score": 3,
+              "score": 5,
               "max": 10
             },
             {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.288Z",
+          "evaluatedAt": "2026-05-05T23:45:56.769Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,14 +548,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.288Z",
+          "evaluatedAt": "2026-05-05T23:45:56.769Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "hyperframes-cli",
-      "description": "HyperFrames CLI tool — hyperframes init, lint, inspect, preview, render, transcribe, tts, doctor, browser, info, upgrade, compositions, docs, benchmark. Use when scaffolding a project, linting, validating, inspecting visual layout in compositions, previewing in the studio, rendering to video, transcribing audio, generating TTS, or troubleshooting the HyperFrames environment.",
+      "description": "HyperFrames CLI dev loop — `npx hyperframes` for scaffolding (init), validation (lint, inspect), preview, render, and environment troubleshooting (doctor, browser, info, upgrade). Use when running any of these commands or troubleshooting the HyperFrames build/render environment. For asset preprocessing commands (`tts`, `transcribe`, `remove-background`), invoke the `hyperframes-media` skill instead.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -564,7 +564,7 @@
       "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-cli",
       "relPath": "skills/hyperframes-cli",
       "verified": true,
-      "tokenCount": 2460,
+      "tokenCount": 3349,
       "evalSummary": {
         "overallScore": 69,
         "grade": "C",
@@ -596,13 +596,13 @@
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 9,
+            "score": 7,
             "max": 10
           },
           {
             "id": "testability",
             "name": "Testability",
-            "score": 0,
+            "score": 2,
             "max": 10
           },
           {
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.291Z",
+        "evaluatedAt": "2026-05-05T23:45:56.772Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -651,13 +651,13 @@
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 9,
+              "score": 7,
               "max": 10
             },
             {
               "id": "testability",
               "name": "Testability",
-              "score": 0,
+              "score": 2,
               "max": 10
             },
             {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.291Z",
+          "evaluatedAt": "2026-05-05T23:45:56.772Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,144 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.291Z",
+          "evaluatedAt": "2026-05-05T23:45:56.772Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "hyperframes-media",
+      "description": "Asset preprocessing for HyperFrames compositions — text-to-speech narration (Kokoro), audio/video transcription (Whisper), and background removal for transparent overlays (u2net). Use when generating voiceover from text, transcribing speech for captions, removing the background from a video or image to use as a transparent overlay, choosing a TTS voice or whisper model, or chaining these (TTS → transcribe → captions). Each command downloads its own model on first run.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:heygen-com/hyperframes:skills/hyperframes-media",
+      "relPath": "skills/hyperframes-media",
+      "verified": true,
+      "tokenCount": 3592,
+      "evalSummary": {
+        "overallScore": 61,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 6,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:56.773Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 61,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 6,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:56.773Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:56.773Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.292Z",
+        "evaluatedAt": "2026-05-05T23:45:56.775Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.292Z",
+          "evaluatedAt": "2026-05-05T23:45:56.775Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.292Z",
+          "evaluatedAt": "2026-05-05T23:45:56.775Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.293Z",
+        "evaluatedAt": "2026-05-05T23:45:56.775Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.293Z",
+          "evaluatedAt": "2026-05-05T23:45:56.775Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,14 +1096,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.293Z",
+          "evaluatedAt": "2026-05-05T23:45:56.775Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "remotion-to-hyperframes",
-      "description": "Translate a Remotion (React-based) video composition into a HyperFrames HTML composition. Use when (1) the user provides Remotion source (`.tsx` files using `useCurrentFrame`, `Sequence`, `AbsoluteFill`, `interpolate`, `spring`, `staticFile`, etc.) and asks to port, convert, or migrate it to HyperFrames; (2) the user pastes a Remotion entry point (`Root.tsx`, `Composition`) and wants HTML; (3) the user links a Remotion repo and asks for the HyperFrames equivalent; (4) the user says \"port my Remotion project\", \"translate this Remotion code\", \"rewrite as HTML\", or \"I have a Remotion comp, make it HyperFrames\". Skill detects unsupported patterns (useState, useEffect with side effects, async calculateMetadata, third-party React component libraries, `@remotion/lambda` features) and recommends the runtime interop escape hatch instead of attempting a lossy translation.",
+      "description": "Translate an existing Remotion (React-based) video composition into a HyperFrames HTML composition. Use ONLY when the user explicitly asks to port, convert, migrate, translate, or rewrite a Remotion composition as HyperFrames — for example \"port my Remotion project to HyperFrames\", \"convert this Remotion code to HyperFrames\", \"migrate from Remotion\", \"translate this Remotion comp\", or \"rewrite this as HyperFrames HTML\". Do NOT use when (a) the user is authoring a NEW HyperFrames composition, even if they have or are A/B-testing a similar Remotion video; (b) the user mentions Remotion in passing without asking for migration; (c) the user shares Remotion code as reference material rather than asking for a translation; (d) the user asks for \"the same video as my Remotion one\" without explicitly asking to migrate the source — treat that as a fresh HyperFrames build. When in doubt, default to authoring a native HyperFrames composition with the `hyperframes` skill instead. Skill detects unsupported patterns (useState, useEffect with side effects, async calculateMetadata, third-party React component libraries, `@remotion/lambda` features) and recommends the runtime interop escape hatch instead of attempting a lossy translation.",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -975,7 +1112,7 @@
       "installUrl": "github:heygen-com/hyperframes:skills/remotion-to-hyperframes",
       "relPath": "skills/remotion-to-hyperframes",
       "verified": true,
-      "tokenCount": 2226,
+      "tokenCount": 2350,
       "evalSummary": {
         "overallScore": 71,
         "grade": "C",
@@ -1023,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.294Z",
+        "evaluatedAt": "2026-05-05T23:45:56.776Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.294Z",
+          "evaluatedAt": "2026-05-05T23:45:56.777Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1086,17 +1223,17 @@
           "providerVersion": "1.1.0",
           "schemaVersion": 1,
           "passed": false,
-          "overallScore": 69,
-          "grade": "C",
+          "overallScore": 62,
+          "grade": "D",
           "categories": [
             {
               "id": "validation",
               "name": "Deterministic validation",
-              "score": 9,
+              "score": 8,
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.294Z",
+          "evaluatedAt": "2026-05-05T23:45:56.777Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.295Z",
+        "evaluatedAt": "2026-05-05T23:45:56.778Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.295Z",
+          "evaluatedAt": "2026-05-05T23:45:56.778Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.295Z",
+          "evaluatedAt": "2026-05-05T23:45:56.778Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.296Z",
+        "evaluatedAt": "2026-05-05T23:45:56.779Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.296Z",
+          "evaluatedAt": "2026-05-05T23:45:56.779Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.296Z",
+          "evaluatedAt": "2026-05-05T23:45:56.779Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.297Z",
+        "evaluatedAt": "2026-05-05T23:45:56.779Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.297Z",
+          "evaluatedAt": "2026-05-05T23:45:56.779Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.297Z",
+          "evaluatedAt": "2026-05-05T23:45:56.779Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:43.298Z",
+        "evaluatedAt": "2026-05-05T23:45:56.780Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.298Z",
+          "evaluatedAt": "2026-05-05T23:45:56.780Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:43.298Z",
+          "evaluatedAt": "2026-05-05T23:45:56.780Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/himself65_finance-skills.json
+++ b/data/skill-index/himself65_finance-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/himself65/finance-skills.git",
   "owner": "himself65",
   "repo": "finance-skills",
-  "updatedAt": "2026-04-30T23:05:19.253Z",
+  "updatedAt": "2026-05-05T23:45:32.096Z",
   "skillCount": 23,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.210Z",
+        "evaluatedAt": "2026-05-05T23:45:32.052Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.210Z",
+          "evaluatedAt": "2026-05-05T23:45:32.052Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.210Z",
+          "evaluatedAt": "2026-05-05T23:45:32.052Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.212Z",
+        "evaluatedAt": "2026-05-05T23:45:32.055Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.212Z",
+          "evaluatedAt": "2026-05-05T23:45:32.055Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.212Z",
+          "evaluatedAt": "2026-05-05T23:45:32.055Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.214Z",
+        "evaluatedAt": "2026-05-05T23:45:32.056Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.214Z",
+          "evaluatedAt": "2026-05-05T23:45:32.056Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.214Z",
+          "evaluatedAt": "2026-05-05T23:45:32.056Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.216Z",
+        "evaluatedAt": "2026-05-05T23:45:32.058Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.216Z",
+          "evaluatedAt": "2026-05-05T23:45:32.058Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.216Z",
+          "evaluatedAt": "2026-05-05T23:45:32.058Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.217Z",
+        "evaluatedAt": "2026-05-05T23:45:32.060Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.217Z",
+          "evaluatedAt": "2026-05-05T23:45:32.060Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.217Z",
+          "evaluatedAt": "2026-05-05T23:45:32.060Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.219Z",
+        "evaluatedAt": "2026-05-05T23:45:32.062Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.219Z",
+          "evaluatedAt": "2026-05-05T23:45:32.062Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.220Z",
+          "evaluatedAt": "2026-05-05T23:45:32.062Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.222Z",
+        "evaluatedAt": "2026-05-05T23:45:32.064Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.222Z",
+          "evaluatedAt": "2026-05-05T23:45:32.064Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.222Z",
+          "evaluatedAt": "2026-05-05T23:45:32.064Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.224Z",
+        "evaluatedAt": "2026-05-05T23:45:32.066Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.224Z",
+          "evaluatedAt": "2026-05-05T23:45:32.066Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.224Z",
+          "evaluatedAt": "2026-05-05T23:45:32.066Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.226Z",
+        "evaluatedAt": "2026-05-05T23:45:32.069Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.226Z",
+          "evaluatedAt": "2026-05-05T23:45:32.069Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.226Z",
+          "evaluatedAt": "2026-05-05T23:45:32.069Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.228Z",
+        "evaluatedAt": "2026-05-05T23:45:32.070Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.228Z",
+          "evaluatedAt": "2026-05-05T23:45:32.070Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.228Z",
+          "evaluatedAt": "2026-05-05T23:45:32.070Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.230Z",
+        "evaluatedAt": "2026-05-05T23:45:32.072Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.230Z",
+          "evaluatedAt": "2026-05-05T23:45:32.072Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.230Z",
+          "evaluatedAt": "2026-05-05T23:45:32.072Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.231Z",
+        "evaluatedAt": "2026-05-05T23:45:32.074Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.231Z",
+          "evaluatedAt": "2026-05-05T23:45:32.074Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.231Z",
+          "evaluatedAt": "2026-05-05T23:45:32.074Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.233Z",
+        "evaluatedAt": "2026-05-05T23:45:32.075Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.233Z",
+          "evaluatedAt": "2026-05-05T23:45:32.075Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.233Z",
+          "evaluatedAt": "2026-05-05T23:45:32.075Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.235Z",
+        "evaluatedAt": "2026-05-05T23:45:32.077Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.235Z",
+          "evaluatedAt": "2026-05-05T23:45:32.077Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.235Z",
+          "evaluatedAt": "2026-05-05T23:45:32.077Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.237Z",
+        "evaluatedAt": "2026-05-05T23:45:32.079Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.237Z",
+          "evaluatedAt": "2026-05-05T23:45:32.079Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.237Z",
+          "evaluatedAt": "2026-05-05T23:45:32.079Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.239Z",
+        "evaluatedAt": "2026-05-05T23:45:32.082Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.239Z",
+          "evaluatedAt": "2026-05-05T23:45:32.082Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.239Z",
+          "evaluatedAt": "2026-05-05T23:45:32.082Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.241Z",
+        "evaluatedAt": "2026-05-05T23:45:32.084Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.241Z",
+          "evaluatedAt": "2026-05-05T23:45:32.084Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.241Z",
+          "evaluatedAt": "2026-05-05T23:45:32.084Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.243Z",
+        "evaluatedAt": "2026-05-05T23:45:32.086Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.243Z",
+          "evaluatedAt": "2026-05-05T23:45:32.086Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.243Z",
+          "evaluatedAt": "2026-05-05T23:45:32.086Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.245Z",
+        "evaluatedAt": "2026-05-05T23:45:32.088Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.245Z",
+          "evaluatedAt": "2026-05-05T23:45:32.088Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.245Z",
+          "evaluatedAt": "2026-05-05T23:45:32.088Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.248Z",
+        "evaluatedAt": "2026-05-05T23:45:32.091Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.248Z",
+          "evaluatedAt": "2026-05-05T23:45:32.091Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.248Z",
+          "evaluatedAt": "2026-05-05T23:45:32.091Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.249Z",
+        "evaluatedAt": "2026-05-05T23:45:32.092Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.249Z",
+          "evaluatedAt": "2026-05-05T23:45:32.092Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.249Z",
+          "evaluatedAt": "2026-05-05T23:45:32.092Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.251Z",
+        "evaluatedAt": "2026-05-05T23:45:32.094Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.251Z",
+          "evaluatedAt": "2026-05-05T23:45:32.094Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.251Z",
+          "evaluatedAt": "2026-05-05T23:45:32.094Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -3078,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:19.252Z",
+        "evaluatedAt": "2026-05-05T23:45:32.095Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -3133,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.252Z",
+          "evaluatedAt": "2026-05-05T23:45:32.095Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3151,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:19.252Z",
+          "evaluatedAt": "2026-05-05T23:45:32.095Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/kemiljk_fluid-design.json
+++ b/data/skill-index/kemiljk_fluid-design.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/kemiljk/fluid-design.git",
   "owner": "kemiljk",
   "repo": "fluid-design",
-  "updatedAt": "2026-04-30T23:05:15.359Z",
+  "updatedAt": "2026-05-05T23:45:28.248Z",
   "skillCount": 1,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:15.356Z",
+        "evaluatedAt": "2026-05-05T23:45:28.246Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:15.357Z",
+          "evaluatedAt": "2026-05-05T23:45:28.246Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:15.357Z",
+          "evaluatedAt": "2026-05-05T23:45:28.246Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/kepano_obsidian-skills.json
+++ b/data/skill-index/kepano_obsidian-skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/kepano/obsidian-skills.git",
   "owner": "kepano",
   "repo": "obsidian-skills",
-  "updatedAt": "2026-04-30T23:05:17.515Z",
+  "updatedAt": "2026-05-05T23:45:30.326Z",
   "skillCount": 5,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:17.509Z",
+        "evaluatedAt": "2026-05-05T23:45:30.318Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:17.509Z",
+          "evaluatedAt": "2026-05-05T23:45:30.318Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:17.509Z",
+          "evaluatedAt": "2026-05-05T23:45:30.318Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:17.510Z",
+        "evaluatedAt": "2026-05-05T23:45:30.319Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:17.510Z",
+          "evaluatedAt": "2026-05-05T23:45:30.319Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:17.510Z",
+          "evaluatedAt": "2026-05-05T23:45:30.319Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:17.512Z",
+        "evaluatedAt": "2026-05-05T23:45:30.322Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:17.512Z",
+          "evaluatedAt": "2026-05-05T23:45:30.322Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:17.512Z",
+          "evaluatedAt": "2026-05-05T23:45:30.322Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:17.514Z",
+        "evaluatedAt": "2026-05-05T23:45:30.324Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:17.514Z",
+          "evaluatedAt": "2026-05-05T23:45:30.324Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:17.514Z",
+          "evaluatedAt": "2026-05-05T23:45:30.324Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:17.515Z",
+        "evaluatedAt": "2026-05-05T23:45:30.325Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:17.515Z",
+          "evaluatedAt": "2026-05-05T23:45:30.325Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:17.515Z",
+          "evaluatedAt": "2026-05-05T23:45:30.325Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/luongnv89_skills.json
+++ b/data/skill-index/luongnv89_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/luongnv89/skills.git",
   "owner": "luongnv89",
   "repo": "skills",
-  "updatedAt": "2026-04-30T23:05:13.127Z",
+  "updatedAt": "2026-05-05T23:45:26.035Z",
   "skillCount": 28,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.080Z",
+        "evaluatedAt": "2026-05-05T23:45:25.982Z",
         "evaluatedVersion": "1.3.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.080Z",
+          "evaluatedAt": "2026-05-05T23:45:25.982Z",
           "evaluatedVersion": "1.3.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.080Z",
+          "evaluatedAt": "2026-05-05T23:45:25.982Z",
           "evaluatedVersion": "1.3.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.082Z",
+        "evaluatedAt": "2026-05-05T23:45:25.984Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.082Z",
+          "evaluatedAt": "2026-05-05T23:45:25.984Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.082Z",
+          "evaluatedAt": "2026-05-05T23:45:25.984Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.083Z",
+        "evaluatedAt": "2026-05-05T23:45:25.986Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.083Z",
+          "evaluatedAt": "2026-05-05T23:45:25.986Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.083Z",
+          "evaluatedAt": "2026-05-05T23:45:25.986Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.084Z",
+        "evaluatedAt": "2026-05-05T23:45:25.987Z",
         "evaluatedVersion": "1.0.2"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.084Z",
+          "evaluatedAt": "2026-05-05T23:45:25.988Z",
           "evaluatedVersion": "1.0.2"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.084Z",
+          "evaluatedAt": "2026-05-05T23:45:25.988Z",
           "evaluatedVersion": "1.0.2"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.086Z",
+        "evaluatedAt": "2026-05-05T23:45:25.989Z",
         "evaluatedVersion": "1.3.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.086Z",
+          "evaluatedAt": "2026-05-05T23:45:25.989Z",
           "evaluatedVersion": "1.3.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.086Z",
+          "evaluatedAt": "2026-05-05T23:45:25.989Z",
           "evaluatedVersion": "1.3.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.087Z",
+        "evaluatedAt": "2026-05-05T23:45:25.992Z",
         "evaluatedVersion": "1.0.3"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.087Z",
+          "evaluatedAt": "2026-05-05T23:45:25.992Z",
           "evaluatedVersion": "1.0.3"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.087Z",
+          "evaluatedAt": "2026-05-05T23:45:25.992Z",
           "evaluatedVersion": "1.0.3"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.089Z",
+        "evaluatedAt": "2026-05-05T23:45:25.993Z",
         "evaluatedVersion": "1.3.1"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.089Z",
+          "evaluatedAt": "2026-05-05T23:45:25.993Z",
           "evaluatedVersion": "1.3.1"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.089Z",
+          "evaluatedAt": "2026-05-05T23:45:25.993Z",
           "evaluatedVersion": "1.3.1"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.091Z",
+        "evaluatedAt": "2026-05-05T23:45:25.995Z",
         "evaluatedVersion": "1.1.4"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.091Z",
+          "evaluatedAt": "2026-05-05T23:45:25.996Z",
           "evaluatedVersion": "1.1.4"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.091Z",
+          "evaluatedAt": "2026-05-05T23:45:25.996Z",
           "evaluatedVersion": "1.1.4"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.093Z",
+        "evaluatedAt": "2026-05-05T23:45:25.998Z",
         "evaluatedVersion": "2.0.1"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.093Z",
+          "evaluatedAt": "2026-05-05T23:45:25.998Z",
           "evaluatedVersion": "2.0.1"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.093Z",
+          "evaluatedAt": "2026-05-05T23:45:25.998Z",
           "evaluatedVersion": "2.0.1"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.095Z",
+        "evaluatedAt": "2026-05-05T23:45:26.000Z",
         "evaluatedVersion": "1.2.3"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.095Z",
+          "evaluatedAt": "2026-05-05T23:45:26.000Z",
           "evaluatedVersion": "1.2.3"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.095Z",
+          "evaluatedAt": "2026-05-05T23:45:26.000Z",
           "evaluatedVersion": "1.2.3"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.096Z",
+        "evaluatedAt": "2026-05-05T23:45:26.002Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.096Z",
+          "evaluatedAt": "2026-05-05T23:45:26.002Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.096Z",
+          "evaluatedAt": "2026-05-05T23:45:26.002Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.098Z",
+        "evaluatedAt": "2026-05-05T23:45:26.003Z",
         "evaluatedVersion": "1.3.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.098Z",
+          "evaluatedAt": "2026-05-05T23:45:26.003Z",
           "evaluatedVersion": "1.3.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.098Z",
+          "evaluatedAt": "2026-05-05T23:45:26.003Z",
           "evaluatedVersion": "1.3.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.100Z",
+        "evaluatedAt": "2026-05-05T23:45:26.005Z",
         "evaluatedVersion": "1.2.2"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.100Z",
+          "evaluatedAt": "2026-05-05T23:45:26.005Z",
           "evaluatedVersion": "1.2.2"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.100Z",
+          "evaluatedAt": "2026-05-05T23:45:26.005Z",
           "evaluatedVersion": "1.2.2"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.102Z",
+        "evaluatedAt": "2026-05-05T23:45:26.008Z",
         "evaluatedVersion": "1.3.1"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.102Z",
+          "evaluatedAt": "2026-05-05T23:45:26.008Z",
           "evaluatedVersion": "1.3.1"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.102Z",
+          "evaluatedAt": "2026-05-05T23:45:26.008Z",
           "evaluatedVersion": "1.3.1"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.104Z",
+        "evaluatedAt": "2026-05-05T23:45:26.010Z",
         "evaluatedVersion": "2.1.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.104Z",
+          "evaluatedAt": "2026-05-05T23:45:26.010Z",
           "evaluatedVersion": "2.1.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.104Z",
+          "evaluatedAt": "2026-05-05T23:45:26.010Z",
           "evaluatedVersion": "2.1.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.105Z",
+        "evaluatedAt": "2026-05-05T23:45:26.011Z",
         "evaluatedVersion": "1.2.1"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.105Z",
+          "evaluatedAt": "2026-05-05T23:45:26.011Z",
           "evaluatedVersion": "1.2.1"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.105Z",
+          "evaluatedAt": "2026-05-05T23:45:26.011Z",
           "evaluatedVersion": "1.2.1"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.107Z",
+        "evaluatedAt": "2026-05-05T23:45:26.013Z",
         "evaluatedVersion": "1.0.4"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.107Z",
+          "evaluatedAt": "2026-05-05T23:45:26.013Z",
           "evaluatedVersion": "1.0.4"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.107Z",
+          "evaluatedAt": "2026-05-05T23:45:26.013Z",
           "evaluatedVersion": "1.0.4"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.109Z",
+        "evaluatedAt": "2026-05-05T23:45:26.015Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.109Z",
+          "evaluatedAt": "2026-05-05T23:45:26.015Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.109Z",
+          "evaluatedAt": "2026-05-05T23:45:26.015Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.110Z",
+        "evaluatedAt": "2026-05-05T23:45:26.017Z",
         "evaluatedVersion": "1.3.1"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.110Z",
+          "evaluatedAt": "2026-05-05T23:45:26.017Z",
           "evaluatedVersion": "1.3.1"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.110Z",
+          "evaluatedAt": "2026-05-05T23:45:26.017Z",
           "evaluatedVersion": "1.3.1"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.112Z",
+        "evaluatedAt": "2026-05-05T23:45:26.019Z",
         "evaluatedVersion": "2.1.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.112Z",
+          "evaluatedAt": "2026-05-05T23:45:26.019Z",
           "evaluatedVersion": "2.1.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.112Z",
+          "evaluatedAt": "2026-05-05T23:45:26.019Z",
           "evaluatedVersion": "2.1.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.114Z",
+        "evaluatedAt": "2026-05-05T23:45:26.021Z",
         "evaluatedVersion": "2.4.1"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.114Z",
+          "evaluatedAt": "2026-05-05T23:45:26.021Z",
           "evaluatedVersion": "2.4.1"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.114Z",
+          "evaluatedAt": "2026-05-05T23:45:26.021Z",
           "evaluatedVersion": "2.4.1"
         }
       }
@@ -2885,7 +2885,7 @@
     {
       "name": "security-setup",
       "description": "Install local-first security hardening: pre-commit secret detection, offline dependency scans, static analysis, reports, and gated free CI. Use when hardening repos or adding security hooks. Don't use for incident response or cloud security reviews.",
-      "version": "1.2.2",
+      "version": "1.3.1",
       "license": "MIT",
       "creator": "",
       "compatibility": "Cross-platform (macOS, Linux, Windows). Requires git, Python 3.8+, and project write access. Uses pre-commit plus free local tools such as gitleaks, trivy, semgrep, bandit, or cargo-audit when appropriate. Semgrep on Windows requires WSL2.",
@@ -2893,9 +2893,146 @@
       "installUrl": "github:luongnv89/skills:skills/security-setup",
       "relPath": "skills/security-setup",
       "verified": true,
-      "tokenCount": 2969,
+      "tokenCount": 3775,
       "evalSummary": {
-        "overallScore": 99,
+        "overallScore": 96,
+        "grade": "A",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:26.022Z",
+        "evaluatedVersion": "1.3.1"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 96,
+          "grade": "A",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:26.023Z",
+          "evaluatedVersion": "1.3.1"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 100,
+          "grade": "A",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 15,
+              "max": 15
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:26.023Z",
+          "evaluatedVersion": "1.3.1"
+        }
+      }
+    },
+    {
+      "name": "seo-ai-optimizer",
+      "description": "Audit and optimize websites for technical SEO, content SEO, and AI bot accessibility. Fixes meta tags, sitemaps, robots.txt, structured data, llms.txt, and GPTBot/ClaudeBot directives. Not for App Store ASO, paid search, or blog writing.",
+      "version": "1.2.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:luongnv89/skills:skills/seo-ai-optimizer",
+      "relPath": "skills/seo-ai-optimizer",
+      "verified": true,
+      "tokenCount": 1535,
+      "evalSummary": {
+        "overallScore": 94,
         "grade": "A",
         "categories": [
           {
@@ -2925,13 +3062,13 @@
           {
             "id": "safety",
             "name": "Safety & guardrails",
-            "score": 10,
+            "score": 9,
             "max": 10
           },
           {
             "id": "testability",
             "name": "Testability",
-            "score": 10,
+            "score": 8,
             "max": 10
           },
           {
@@ -2941,8 +3078,8 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.115Z",
-        "evaluatedVersion": "1.2.2"
+        "evaluatedAt": "2026-05-05T23:45:26.024Z",
+        "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
         "quality": {
@@ -2950,7 +3087,7 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 99,
+          "overallScore": 94,
           "grade": "A",
           "categories": [
             {
@@ -2980,13 +3117,13 @@
             {
               "id": "safety",
               "name": "Safety & guardrails",
-              "score": 10,
+              "score": 9,
               "max": 10
             },
             {
               "id": "testability",
               "name": "Testability",
-              "score": 10,
+              "score": 8,
               "max": 10
             },
             {
@@ -2996,145 +3133,8 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.115Z",
-          "evaluatedVersion": "1.2.2"
-        },
-        "skill-best-practice": {
-          "providerId": "skill-best-practice",
-          "providerVersion": "1.1.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 100,
-          "grade": "A",
-          "categories": [
-            {
-              "id": "validation",
-              "name": "Deterministic validation",
-              "score": 15,
-              "max": 15
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:13.115Z",
-          "evaluatedVersion": "1.2.2"
-        }
-      }
-    },
-    {
-      "name": "seo-ai-optimizer",
-      "description": "Audit and optimize websites for technical SEO, content SEO, and AI bot accessibility. Fixes meta tags, sitemaps, robots.txt, structured data, llms.txt, and GPTBot/ClaudeBot directives. Not for App Store ASO, paid search, or blog writing.",
-      "version": "1.1.2",
-      "license": "MIT",
-      "creator": "",
-      "compatibility": "",
-      "allowedTools": [],
-      "installUrl": "github:luongnv89/skills:skills/seo-ai-optimizer",
-      "relPath": "skills/seo-ai-optimizer",
-      "verified": true,
-      "tokenCount": 3100,
-      "evalSummary": {
-        "overallScore": 91,
-        "grade": "A",
-        "categories": [
-          {
-            "id": "structure",
-            "name": "Structure & completeness",
-            "score": 10,
-            "max": 10
-          },
-          {
-            "id": "description",
-            "name": "Description quality",
-            "score": 10,
-            "max": 10
-          },
-          {
-            "id": "prompt-engineering",
-            "name": "Prompt engineering",
-            "score": 10,
-            "max": 10
-          },
-          {
-            "id": "context-efficiency",
-            "name": "Context efficiency",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "safety",
-            "name": "Safety & guardrails",
-            "score": 7,
-            "max": 10
-          },
-          {
-            "id": "testability",
-            "name": "Testability",
-            "score": 10,
-            "max": 10
-          },
-          {
-            "id": "naming",
-            "name": "Naming & conventions",
-            "score": 10,
-            "max": 10
-          }
-        ],
-        "evaluatedAt": "2026-04-30T23:05:13.117Z",
-        "evaluatedVersion": "1.1.2"
-      },
-      "evalSummaries": {
-        "quality": {
-          "providerId": "quality",
-          "providerVersion": "1.0.0",
-          "schemaVersion": 1,
-          "passed": true,
-          "overallScore": 91,
-          "grade": "A",
-          "categories": [
-            {
-              "id": "structure",
-              "name": "Structure & completeness",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "description",
-              "name": "Description quality",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "prompt-engineering",
-              "name": "Prompt engineering",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "context-efficiency",
-              "name": "Context efficiency",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "safety",
-              "name": "Safety & guardrails",
-              "score": 7,
-              "max": 10
-            },
-            {
-              "id": "testability",
-              "name": "Testability",
-              "score": 10,
-              "max": 10
-            },
-            {
-              "id": "naming",
-              "name": "Naming & conventions",
-              "score": 10,
-              "max": 10
-            }
-          ],
-          "evaluatedAt": "2026-04-30T23:05:13.117Z",
-          "evaluatedVersion": "1.1.2"
+          "evaluatedAt": "2026-05-05T23:45:26.024Z",
+          "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
           "providerId": "skill-best-practice",
@@ -3151,8 +3151,8 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.117Z",
-          "evaluatedVersion": "1.1.2"
+          "evaluatedAt": "2026-05-05T23:45:26.025Z",
+          "evaluatedVersion": "1.2.0"
         }
       }
     },
@@ -3215,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.119Z",
+        "evaluatedAt": "2026-05-05T23:45:26.026Z",
         "evaluatedVersion": "1.1.1"
       },
       "evalSummaries": {
@@ -3270,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.119Z",
+          "evaluatedAt": "2026-05-05T23:45:26.026Z",
           "evaluatedVersion": "1.1.1"
         },
         "skill-best-practice": {
@@ -3288,7 +3288,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.119Z",
+          "evaluatedAt": "2026-05-05T23:45:26.026Z",
           "evaluatedVersion": "1.1.1"
         }
       }
@@ -3352,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.121Z",
+        "evaluatedAt": "2026-05-05T23:45:26.029Z",
         "evaluatedVersion": "1.3.0"
       },
       "evalSummaries": {
@@ -3407,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.121Z",
+          "evaluatedAt": "2026-05-05T23:45:26.029Z",
           "evaluatedVersion": "1.3.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3425,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.121Z",
+          "evaluatedAt": "2026-05-05T23:45:26.029Z",
           "evaluatedVersion": "1.3.0"
         }
       }
@@ -3489,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.123Z",
+        "evaluatedAt": "2026-05-05T23:45:26.031Z",
         "evaluatedVersion": "1.2.1"
       },
       "evalSummaries": {
@@ -3544,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.123Z",
+          "evaluatedAt": "2026-05-05T23:45:26.031Z",
           "evaluatedVersion": "1.2.1"
         },
         "skill-best-practice": {
@@ -3562,7 +3562,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.123Z",
+          "evaluatedAt": "2026-05-05T23:45:26.031Z",
           "evaluatedVersion": "1.2.1"
         }
       }
@@ -3626,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.125Z",
+        "evaluatedAt": "2026-05-05T23:45:26.033Z",
         "evaluatedVersion": "1.2.3"
       },
       "evalSummaries": {
@@ -3681,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.125Z",
+          "evaluatedAt": "2026-05-05T23:45:26.033Z",
           "evaluatedVersion": "1.2.3"
         },
         "skill-best-practice": {
@@ -3699,7 +3699,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.125Z",
+          "evaluatedAt": "2026-05-05T23:45:26.033Z",
           "evaluatedVersion": "1.2.3"
         }
       }
@@ -3763,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:13.126Z",
+        "evaluatedAt": "2026-05-05T23:45:26.034Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -3818,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.126Z",
+          "evaluatedAt": "2026-05-05T23:45:26.034Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3836,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:13.126Z",
+          "evaluatedAt": "2026-05-05T23:45:26.034Z",
           "evaluatedVersion": "1.2.0"
         }
       }

--- a/data/skill-index/mattpocock_skills.json
+++ b/data/skill-index/mattpocock_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/mattpocock/skills.git",
   "owner": "mattpocock",
   "repo": "skills",
-  "updatedAt": "2026-04-30T23:05:16.786Z",
+  "updatedAt": "2026-05-05T23:45:29.708Z",
   "skillCount": 22,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.762Z",
+        "evaluatedAt": "2026-05-05T23:45:29.683Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.762Z",
+          "evaluatedAt": "2026-05-05T23:45:29.683Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.762Z",
+          "evaluatedAt": "2026-05-05T23:45:29.683Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.763Z",
+        "evaluatedAt": "2026-05-05T23:45:29.684Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.763Z",
+          "evaluatedAt": "2026-05-05T23:45:29.684Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.763Z",
+          "evaluatedAt": "2026-05-05T23:45:29.684Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.764Z",
+        "evaluatedAt": "2026-05-05T23:45:29.685Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.765Z",
+          "evaluatedAt": "2026-05-05T23:45:29.685Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.765Z",
+          "evaluatedAt": "2026-05-05T23:45:29.685Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.766Z",
+        "evaluatedAt": "2026-05-05T23:45:29.687Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.766Z",
+          "evaluatedAt": "2026-05-05T23:45:29.687Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.766Z",
+          "evaluatedAt": "2026-05-05T23:45:29.687Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.766Z",
+        "evaluatedAt": "2026-05-05T23:45:29.688Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.766Z",
+          "evaluatedAt": "2026-05-05T23:45:29.688Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.766Z",
+          "evaluatedAt": "2026-05-05T23:45:29.688Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.767Z",
+        "evaluatedAt": "2026-05-05T23:45:29.688Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.767Z",
+          "evaluatedAt": "2026-05-05T23:45:29.689Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.767Z",
+          "evaluatedAt": "2026-05-05T23:45:29.689Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.768Z",
+        "evaluatedAt": "2026-05-05T23:45:29.689Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.768Z",
+          "evaluatedAt": "2026-05-05T23:45:29.689Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.768Z",
+          "evaluatedAt": "2026-05-05T23:45:29.689Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.769Z",
+        "evaluatedAt": "2026-05-05T23:45:29.691Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.769Z",
+          "evaluatedAt": "2026-05-05T23:45:29.691Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.769Z",
+          "evaluatedAt": "2026-05-05T23:45:29.691Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.770Z",
+        "evaluatedAt": "2026-05-05T23:45:29.692Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.770Z",
+          "evaluatedAt": "2026-05-05T23:45:29.692Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.770Z",
+          "evaluatedAt": "2026-05-05T23:45:29.692Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.771Z",
+        "evaluatedAt": "2026-05-05T23:45:29.693Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.772Z",
+          "evaluatedAt": "2026-05-05T23:45:29.693Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.771Z",
+          "evaluatedAt": "2026-05-05T23:45:29.693Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.773Z",
+        "evaluatedAt": "2026-05-05T23:45:29.694Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.773Z",
+          "evaluatedAt": "2026-05-05T23:45:29.694Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.773Z",
+          "evaluatedAt": "2026-05-05T23:45:29.694Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.774Z",
+        "evaluatedAt": "2026-05-05T23:45:29.695Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.774Z",
+          "evaluatedAt": "2026-05-05T23:45:29.695Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.774Z",
+          "evaluatedAt": "2026-05-05T23:45:29.695Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.775Z",
+        "evaluatedAt": "2026-05-05T23:45:29.696Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.775Z",
+          "evaluatedAt": "2026-05-05T23:45:29.696Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.775Z",
+          "evaluatedAt": "2026-05-05T23:45:29.696Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.776Z",
+        "evaluatedAt": "2026-05-05T23:45:29.698Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.777Z",
+          "evaluatedAt": "2026-05-05T23:45:29.698Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.777Z",
+          "evaluatedAt": "2026-05-05T23:45:29.698Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1982,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.778Z",
+        "evaluatedAt": "2026-05-05T23:45:29.699Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.778Z",
+          "evaluatedAt": "2026-05-05T23:45:29.699Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2055,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.778Z",
+          "evaluatedAt": "2026-05-05T23:45:29.699Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2119,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.779Z",
+        "evaluatedAt": "2026-05-05T23:45:29.701Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2174,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.779Z",
+          "evaluatedAt": "2026-05-05T23:45:29.701Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2192,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.779Z",
+          "evaluatedAt": "2026-05-05T23:45:29.701Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2256,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.780Z",
+        "evaluatedAt": "2026-05-05T23:45:29.702Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2311,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.780Z",
+          "evaluatedAt": "2026-05-05T23:45:29.702Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2329,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.780Z",
+          "evaluatedAt": "2026-05-05T23:45:29.702Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2393,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.781Z",
+        "evaluatedAt": "2026-05-05T23:45:29.703Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2448,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.781Z",
+          "evaluatedAt": "2026-05-05T23:45:29.703Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2466,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.781Z",
+          "evaluatedAt": "2026-05-05T23:45:29.703Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2530,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.783Z",
+        "evaluatedAt": "2026-05-05T23:45:29.704Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.783Z",
+          "evaluatedAt": "2026-05-05T23:45:29.704Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2603,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.783Z",
+          "evaluatedAt": "2026-05-05T23:45:29.704Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2667,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.784Z",
+        "evaluatedAt": "2026-05-05T23:45:29.705Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2722,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.784Z",
+          "evaluatedAt": "2026-05-05T23:45:29.706Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2740,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.784Z",
+          "evaluatedAt": "2026-05-05T23:45:29.706Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2804,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.785Z",
+        "evaluatedAt": "2026-05-05T23:45:29.707Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.785Z",
+          "evaluatedAt": "2026-05-05T23:45:29.707Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +2877,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.785Z",
+          "evaluatedAt": "2026-05-05T23:45:29.707Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -2941,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:16.786Z",
+        "evaluatedAt": "2026-05-05T23:45:29.707Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -2996,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.786Z",
+          "evaluatedAt": "2026-05-05T23:45:29.707Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3014,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:16.786Z",
+          "evaluatedAt": "2026-05-05T23:45:29.707Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/nextlevelbuilder_ui-ux-pro-max-skill.json
+++ b/data/skill-index/nextlevelbuilder_ui-ux-pro-max-skill.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill.git",
   "owner": "nextlevelbuilder",
   "repo": "ui-ux-pro-max-skill",
-  "updatedAt": "2026-04-30T23:04:55.147Z",
+  "updatedAt": "2026-05-05T23:45:08.652Z",
   "skillCount": 7,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:55.133Z",
+        "evaluatedAt": "2026-05-05T23:45:08.638Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.133Z",
+          "evaluatedAt": "2026-05-05T23:45:08.638Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.133Z",
+          "evaluatedAt": "2026-05-05T23:45:08.638Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:55.135Z",
+        "evaluatedAt": "2026-05-05T23:45:08.639Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.135Z",
+          "evaluatedAt": "2026-05-05T23:45:08.639Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.135Z",
+          "evaluatedAt": "2026-05-05T23:45:08.639Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:55.136Z",
+        "evaluatedAt": "2026-05-05T23:45:08.641Z",
         "evaluatedVersion": "2.1.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.136Z",
+          "evaluatedAt": "2026-05-05T23:45:08.641Z",
           "evaluatedVersion": "2.1.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.136Z",
+          "evaluatedAt": "2026-05-05T23:45:08.641Z",
           "evaluatedVersion": "2.1.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:55.138Z",
+        "evaluatedAt": "2026-05-05T23:45:08.642Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.138Z",
+          "evaluatedAt": "2026-05-05T23:45:08.643Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.138Z",
+          "evaluatedAt": "2026-05-05T23:45:08.642Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:55.139Z",
+        "evaluatedAt": "2026-05-05T23:45:08.643Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.139Z",
+          "evaluatedAt": "2026-05-05T23:45:08.643Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.139Z",
+          "evaluatedAt": "2026-05-05T23:45:08.644Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:55.140Z",
+        "evaluatedAt": "2026-05-05T23:45:08.645Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.141Z",
+          "evaluatedAt": "2026-05-05T23:45:08.645Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.141Z",
+          "evaluatedAt": "2026-05-05T23:45:08.645Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:55.144Z",
+        "evaluatedAt": "2026-05-05T23:45:08.649Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.144Z",
+          "evaluatedAt": "2026-05-05T23:45:08.649Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:55.144Z",
+          "evaluatedAt": "2026-05-05T23:45:08.649Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/obra_superpowers.json
+++ b/data/skill-index/obra_superpowers.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/obra/superpowers.git",
   "owner": "obra",
   "repo": "superpowers",
-  "updatedAt": "2026-04-30T23:04:51.320Z",
+  "updatedAt": "2026-05-05T23:45:04.713Z",
   "skillCount": 14,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.299Z",
+        "evaluatedAt": "2026-05-05T23:45:04.690Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.299Z",
+          "evaluatedAt": "2026-05-05T23:45:04.690Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.299Z",
+          "evaluatedAt": "2026-05-05T23:45:04.690Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.301Z",
+        "evaluatedAt": "2026-05-05T23:45:04.692Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.301Z",
+          "evaluatedAt": "2026-05-05T23:45:04.692Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.301Z",
+          "evaluatedAt": "2026-05-05T23:45:04.692Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -290,7 +290,7 @@
       "installUrl": "github:obra/superpowers:skills/executing-plans",
       "relPath": "skills/executing-plans",
       "verified": true,
-      "tokenCount": 670,
+      "tokenCount": 672,
       "evalSummary": {
         "overallScore": 69,
         "grade": "C",
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.302Z",
+        "evaluatedAt": "2026-05-05T23:45:04.694Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.302Z",
+          "evaluatedAt": "2026-05-05T23:45:04.694Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.302Z",
+          "evaluatedAt": "2026-05-05T23:45:04.694Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -427,10 +427,10 @@
       "installUrl": "github:obra/superpowers:skills/finishing-a-development-branch",
       "relPath": "skills/finishing-a-development-branch",
       "verified": true,
-      "tokenCount": 1221,
+      "tokenCount": 1968,
       "evalSummary": {
-        "overallScore": 79,
-        "grade": "C",
+        "overallScore": 81,
+        "grade": "B",
         "categories": [
           {
             "id": "structure",
@@ -453,7 +453,7 @@
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 7,
+            "score": 9,
             "max": 10
           },
           {
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.303Z",
+        "evaluatedAt": "2026-05-05T23:45:04.695Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -484,8 +484,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 79,
-          "grade": "C",
+          "overallScore": 81,
+          "grade": "B",
           "categories": [
             {
               "id": "structure",
@@ -508,7 +508,7 @@
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 7,
+              "score": 9,
               "max": 10
             },
             {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.303Z",
+          "evaluatedAt": "2026-05-05T23:45:04.695Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.303Z",
+          "evaluatedAt": "2026-05-05T23:45:04.695Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.304Z",
+        "evaluatedAt": "2026-05-05T23:45:04.696Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.304Z",
+          "evaluatedAt": "2026-05-05T23:45:04.696Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.304Z",
+          "evaluatedAt": "2026-05-05T23:45:04.696Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -701,7 +701,7 @@
       "installUrl": "github:obra/superpowers:skills/requesting-code-review",
       "relPath": "skills/requesting-code-review",
       "verified": true,
-      "tokenCount": 747,
+      "tokenCount": 737,
       "evalSummary": {
         "overallScore": 70,
         "grade": "C",
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.305Z",
+        "evaluatedAt": "2026-05-05T23:45:04.698Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.305Z",
+          "evaluatedAt": "2026-05-05T23:45:04.698Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.305Z",
+          "evaluatedAt": "2026-05-05T23:45:04.698Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -838,7 +838,7 @@
       "installUrl": "github:obra/superpowers:skills/subagent-driven-development",
       "relPath": "skills/subagent-driven-development",
       "verified": true,
-      "tokenCount": 3110,
+      "tokenCount": 3237,
       "evalSummary": {
         "overallScore": 73,
         "grade": "C",
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.307Z",
+        "evaluatedAt": "2026-05-05T23:45:04.699Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.307Z",
+          "evaluatedAt": "2026-05-05T23:45:04.699Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.307Z",
+          "evaluatedAt": "2026-05-05T23:45:04.699Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.309Z",
+        "evaluatedAt": "2026-05-05T23:45:04.702Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.309Z",
+          "evaluatedAt": "2026-05-05T23:45:04.702Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.309Z",
+          "evaluatedAt": "2026-05-05T23:45:04.702Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.311Z",
+        "evaluatedAt": "2026-05-05T23:45:04.703Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.311Z",
+          "evaluatedAt": "2026-05-05T23:45:04.703Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,14 +1233,14 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.311Z",
+          "evaluatedAt": "2026-05-05T23:45:04.703Z",
           "evaluatedVersion": "0.0.0"
         }
       }
     },
     {
       "name": "using-git-worktrees",
-      "description": "Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory selection and safety verification",
+      "description": "Use when starting feature work that needs isolation from current workspace or before executing implementation plans - ensures an isolated workspace exists via native tools or git worktree fallback",
       "version": "0.0.0",
       "license": "",
       "creator": "",
@@ -1249,10 +1249,10 @@
       "installUrl": "github:obra/superpowers:skills/using-git-worktrees",
       "relPath": "skills/using-git-worktrees",
       "verified": true,
-      "tokenCount": 1446,
+      "tokenCount": 2314,
       "evalSummary": {
-        "overallScore": 79,
-        "grade": "C",
+        "overallScore": 80,
+        "grade": "B",
         "categories": [
           {
             "id": "structure",
@@ -1269,13 +1269,13 @@
           {
             "id": "prompt-engineering",
             "name": "Prompt engineering",
-            "score": 10,
+            "score": 9,
             "max": 10
           },
           {
             "id": "context-efficiency",
             "name": "Context efficiency",
-            "score": 7,
+            "score": 9,
             "max": 10
           },
           {
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.312Z",
+        "evaluatedAt": "2026-05-05T23:45:04.705Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1306,8 +1306,8 @@
           "providerVersion": "1.0.0",
           "schemaVersion": 1,
           "passed": true,
-          "overallScore": 79,
-          "grade": "C",
+          "overallScore": 80,
+          "grade": "B",
           "categories": [
             {
               "id": "structure",
@@ -1324,13 +1324,13 @@
             {
               "id": "prompt-engineering",
               "name": "Prompt engineering",
-              "score": 10,
+              "score": 9,
               "max": 10
             },
             {
               "id": "context-efficiency",
               "name": "Context efficiency",
-              "score": 7,
+              "score": 9,
               "max": 10
             },
             {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.312Z",
+          "evaluatedAt": "2026-05-05T23:45:04.705Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.312Z",
+          "evaluatedAt": "2026-05-05T23:45:04.705Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1434,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.314Z",
+        "evaluatedAt": "2026-05-05T23:45:04.707Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1489,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.314Z",
+          "evaluatedAt": "2026-05-05T23:45:04.707Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1507,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.314Z",
+          "evaluatedAt": "2026-05-05T23:45:04.707Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1571,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.315Z",
+        "evaluatedAt": "2026-05-05T23:45:04.708Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1626,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.315Z",
+          "evaluatedAt": "2026-05-05T23:45:04.708Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1644,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.315Z",
+          "evaluatedAt": "2026-05-05T23:45:04.708Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1660,7 +1660,7 @@
       "installUrl": "github:obra/superpowers:skills/writing-plans",
       "relPath": "skills/writing-plans",
       "verified": true,
-      "tokenCount": 1741,
+      "tokenCount": 1753,
       "evalSummary": {
         "overallScore": 87,
         "grade": "B",
@@ -1708,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.316Z",
+        "evaluatedAt": "2026-05-05T23:45:04.709Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1763,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.316Z",
+          "evaluatedAt": "2026-05-05T23:45:04.709Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1781,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.316Z",
+          "evaluatedAt": "2026-05-05T23:45:04.709Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1845,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:04:51.319Z",
+        "evaluatedAt": "2026-05-05T23:45:04.711Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.319Z",
+          "evaluatedAt": "2026-05-05T23:45:04.711Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +1918,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:04:51.319Z",
+          "evaluatedAt": "2026-05-05T23:45:04.711Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/slavingia_skills.json
+++ b/data/skill-index/slavingia_skills.json
@@ -2,7 +2,7 @@
   "repoUrl": "https://github.com/slavingia/skills.git",
   "owner": "slavingia",
   "repo": "skills",
-  "updatedAt": "2026-04-30T23:05:14.770Z",
+  "updatedAt": "2026-05-05T23:45:27.622Z",
   "skillCount": 10,
   "skills": [
     {
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.759Z",
+        "evaluatedAt": "2026-05-05T23:45:27.609Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.759Z",
+          "evaluatedAt": "2026-05-05T23:45:27.609Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.759Z",
+          "evaluatedAt": "2026-05-05T23:45:27.609Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.760Z",
+        "evaluatedAt": "2026-05-05T23:45:27.610Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.760Z",
+          "evaluatedAt": "2026-05-05T23:45:27.610Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.760Z",
+          "evaluatedAt": "2026-05-05T23:45:27.610Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.761Z",
+        "evaluatedAt": "2026-05-05T23:45:27.612Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.761Z",
+          "evaluatedAt": "2026-05-05T23:45:27.612Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.761Z",
+          "evaluatedAt": "2026-05-05T23:45:27.612Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.763Z",
+        "evaluatedAt": "2026-05-05T23:45:27.613Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.763Z",
+          "evaluatedAt": "2026-05-05T23:45:27.613Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.763Z",
+          "evaluatedAt": "2026-05-05T23:45:27.613Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.764Z",
+        "evaluatedAt": "2026-05-05T23:45:27.614Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.764Z",
+          "evaluatedAt": "2026-05-05T23:45:27.614Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.764Z",
+          "evaluatedAt": "2026-05-05T23:45:27.614Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.765Z",
+        "evaluatedAt": "2026-05-05T23:45:27.616Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.765Z",
+          "evaluatedAt": "2026-05-05T23:45:27.616Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -822,7 +822,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.765Z",
+          "evaluatedAt": "2026-05-05T23:45:27.616Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -886,7 +886,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.766Z",
+        "evaluatedAt": "2026-05-05T23:45:27.617Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -941,7 +941,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.766Z",
+          "evaluatedAt": "2026-05-05T23:45:27.617Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -959,7 +959,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.766Z",
+          "evaluatedAt": "2026-05-05T23:45:27.617Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1023,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.767Z",
+        "evaluatedAt": "2026-05-05T23:45:27.618Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.767Z",
+          "evaluatedAt": "2026-05-05T23:45:27.618Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1096,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.767Z",
+          "evaluatedAt": "2026-05-05T23:45:27.618Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1160,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.768Z",
+        "evaluatedAt": "2026-05-05T23:45:27.620Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1215,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.768Z",
+          "evaluatedAt": "2026-05-05T23:45:27.620Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1233,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.768Z",
+          "evaluatedAt": "2026-05-05T23:45:27.620Z",
           "evaluatedVersion": "0.0.0"
         }
       }
@@ -1297,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-04-30T23:05:14.769Z",
+        "evaluatedAt": "2026-05-05T23:45:27.621Z",
         "evaluatedVersion": "0.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.769Z",
+          "evaluatedAt": "2026-05-05T23:45:27.621Z",
           "evaluatedVersion": "0.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1370,7 @@
               "max": 13
             }
           ],
-          "evaluatedAt": "2026-04-30T23:05:14.769Z",
+          "evaluatedAt": "2026-05-05T23:45:27.621Z",
           "evaluatedVersion": "0.0.0"
         }
       }

--- a/data/skill-index/warpdotdev_oz-skills.json
+++ b/data/skill-index/warpdotdev_oz-skills.json
@@ -1,0 +1,2064 @@
+{
+  "repoUrl": "https://github.com/warpdotdev/oz-skills.git",
+  "owner": "warpdotdev",
+  "repo": "oz-skills",
+  "updatedAt": "2026-05-05T23:45:59.787Z",
+  "skillCount": 15,
+  "skills": [
+    {
+      "name": "analysis-artifacts",
+      "description": "Generate reproducible analysis artifacts — SQL queries, Python visualizations, and summary tables — as you work through a BigQuery data analysis. Use when asked to conduct a deep dive, exploratory analysis, or investigation that goes beyond a simple data lookup.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/analysis-artifacts",
+      "relPath": ".agents/skills/analysis-artifacts",
+      "verified": true,
+      "tokenCount": 1314,
+      "evalSummary": {
+        "overallScore": 66,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.763Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 66,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.763Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.763Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "ci-fix",
+      "description": "Diagnose and fix GitHub Actions CI failures. Inspects workflow runs and logs, identifies root causes, implements minimal fixes, and pushes to a fix branch. Use when CI is failing, red, broken, or needs diagnosis.",
+      "version": "0.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/ci-fix",
+      "relPath": ".agents/skills/ci-fix",
+      "verified": true,
+      "tokenCount": 844,
+      "evalSummary": {
+        "overallScore": 79,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.764Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.764Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.764Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "create-pull-request",
+      "description": "Create a GitHub pull request following project conventions. Use when the user asks to create a PR, submit changes for review, or open a pull request. Handles commit analysis, branch management, and PR creation using the gh CLI tool.",
+      "version": "0.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/create-pull-request",
+      "relPath": ".agents/skills/create-pull-request",
+      "verified": true,
+      "tokenCount": 3179,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.765Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 81,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.765Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.765Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "dbt-model-index",
+      "description": "Provide a lookup index of dbt models (BigQuery tables) to guide query writing against a data warehouse. Use when you need to query, analyze, or look up data in a dbt-powered data warehouse, or when resolving a vague data question into the right BigQuery tables to query.",
+      "version": "0.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/dbt-model-index",
+      "relPath": ".agents/skills/dbt-model-index",
+      "verified": true,
+      "tokenCount": 1050,
+      "evalSummary": {
+        "overallScore": 53,
+        "grade": "D",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 1,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.767Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 53,
+          "grade": "D",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 1,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.767Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.767Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "docs-update",
+      "description": "Update user-facing documentation when code changes. Use when asked to update docs, review docs, handle documentation changes, run scheduled documentation tasks, or analyze recent commits for documentation needs.",
+      "version": "0.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/docs-update",
+      "relPath": ".agents/skills/docs-update",
+      "verified": true,
+      "tokenCount": 1161,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.768Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.768Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.768Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "github-bug-report-triage",
+      "description": "Triage GitHub bug reports for actionability. Use when evaluating whether a bug issue has sufficient detail and identifying missing information from the reporter.",
+      "version": "0.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/github-bug-report-triage",
+      "relPath": ".agents/skills/github-bug-report-triage",
+      "verified": true,
+      "tokenCount": 1135,
+      "evalSummary": {
+        "overallScore": 86,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.769Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 86,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.769Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.769Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "github-issue-dedupe",
+      "description": "Detect duplicate GitHub issues using semantic search and keyword matching. Use when asked to find duplicates, check for similar issues, or set up automated duplicate detection.",
+      "version": "0.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/github-issue-dedupe",
+      "relPath": ".agents/skills/github-issue-dedupe",
+      "verified": true,
+      "tokenCount": 966,
+      "evalSummary": {
+        "overallScore": 71,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 4,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.770Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 71,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 4,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.770Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.770Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "mcp-builder",
+      "description": "Build high-quality MCP (Model Context Protocol) servers that let LLMs interact with external services through well-designed tools. Use when creating MCP servers to integrate APIs or services in Python (FastMCP) or Node/TypeScript (MCP SDK).",
+      "version": "0.0.0",
+      "license": "Complete terms in LICENSE.txt",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/mcp-builder",
+      "relPath": ".agents/skills/mcp-builder",
+      "verified": true,
+      "tokenCount": 2144,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 8,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.772Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 81,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 8,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.772Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.772Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "scheduler",
+      "description": "Schedule on-device reminders and local actions only. Use this skill to set personal reminders or run lightweight, local tasks at a specific time or interval (e.g., notifications, local scripts), on the user's computer or with platforms like Slack. Do NOT use for scheduling cloud agents, background agentic jobs, or Oz-managed workflows.",
+      "version": "0.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/scheduler",
+      "relPath": ".agents/skills/scheduler",
+      "verified": true,
+      "tokenCount": 2289,
+      "evalSummary": {
+        "overallScore": 73,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 2,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.774Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 73,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 2,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.774Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.774Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "seo-aeo-audit",
+      "description": "Optimize for search engine visibility, ranking, and AI citations. Use when asked to improve SEO, optimize for search, fix meta tags, add structured data, or improve AEO and AI visibility.",
+      "version": "2.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/seo-aeo-audit",
+      "relPath": ".agents/skills/seo-aeo-audit",
+      "verified": true,
+      "tokenCount": 4950,
+      "evalSummary": {
+        "overallScore": 84,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.777Z",
+        "evaluatedVersion": "2.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 84,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.778Z",
+          "evaluatedVersion": "2.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 11,
+              "max": 14
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.778Z",
+          "evaluatedVersion": "2.0"
+        }
+      }
+    },
+    {
+      "name": "slack-qa-investigate",
+      "description": "Investigate and answer repository questions in read-only mode. Use when asked for research-backed answers that require codebase and documentation investigation without making file changes.",
+      "version": "0.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/slack-qa-investigate",
+      "relPath": ".agents/skills/slack-qa-investigate",
+      "verified": true,
+      "tokenCount": 949,
+      "evalSummary": {
+        "overallScore": 70,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.780Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 70,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.780Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.780Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "terraform-style-check",
+      "description": "Generate Terraform HCL code following HashiCorp's official style conventions and best practices. Use when writing, reviewing, or generating Terraform configurations.",
+      "version": "0.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/terraform-style-check",
+      "relPath": ".agents/skills/terraform-style-check",
+      "verified": true,
+      "tokenCount": 2093,
+      "evalSummary": {
+        "overallScore": 76,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 0,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.781Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 76,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 0,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.781Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.781Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "web-accessibility-audit",
+      "description": "Audit web applications for WCAG accessibility compliance. Use when asked to run accessibility checks, identify common violations, and provide remediation guidance.",
+      "version": "0.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/web-accessibility-audit",
+      "relPath": ".agents/skills/web-accessibility-audit",
+      "verified": true,
+      "tokenCount": 3095,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.783Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 81,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.783Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 9,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.783Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "web-performance-audit",
+      "description": "Audit web performance using Chrome DevTools MCP. Use when asked to audit, profile, debug, or optimize page load performance, Lighthouse scores, or site speed.",
+      "version": "0.0.0",
+      "license": "MIT",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/web-performance-audit",
+      "relPath": ".agents/skills/web-performance-audit",
+      "verified": true,
+      "tokenCount": 1975,
+      "evalSummary": {
+        "overallScore": 81,
+        "grade": "B",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 7,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.785Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 81,
+          "grade": "B",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 7,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.785Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.785Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    },
+    {
+      "name": "webapp-testing",
+      "description": "Test local web applications with Playwright. Use when asked to verify frontend functionality, debug UI behavior, capture browser screenshots, or inspect browser logs.",
+      "version": "0.0.0",
+      "license": "Complete terms in LICENSE.txt",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:warpdotdev/oz-skills:.agents/skills/webapp-testing",
+      "relPath": ".agents/skills/webapp-testing",
+      "verified": true,
+      "tokenCount": 1043,
+      "evalSummary": {
+        "overallScore": 77,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-05T23:45:59.787Z",
+        "evaluatedVersion": "0.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.787Z",
+          "evaluatedVersion": "0.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": false,
+          "overallScore": 77,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 10,
+              "max": 13
+            }
+          ],
+          "evaluatedAt": "2026-05-05T23:45:59.787Z",
+          "evaluatedVersion": "0.0.0"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Index two new skill sources in the ASM skill catalog:

1. **warpdotdev/oz-skills** - 15 Agent Skills for Warp AI agents and Oz (located in `.agents/skills/`)
2. **entireio/skills** - 5 cross-agent skills for context and session handoff (located in `skills/` folder)

## Changes

- Added 2 new repos to `data/skill-index-resources.json`
- Generated index files for both repos with asm-eval quality scores
- Regenerated skill catalog (7036 skills, 31 repos)

## Acceptance Criteria Verification

| Criteria | Status |
|----------|--------|
| Clone and audit warpdotdev/oz-skills repo | ✓ 15 skills indexed |
| Clone and audit entireio/skills repo | ✓ 5 skills indexed |
| Run asm-eval on discovered skills | ✓ Eval summaries included |
| Add valid skills to the index | ✓ All skills verified |
| Regenerate the skill catalog | ✓ Catalog rebuilt |

## New Skills Added

### warpdotdev/oz-skills (15 skills)
- analysis-artifacts, ci-fix, create-pull-request, dbt-model-index
- docs-update, github-bug-report-triage, github-issue-dedupe
- mcp-builder, scheduler, seo-aeo-audit, slack-qa-investigate
- terraform-style-check, web-accessibility-audit, web-performance-audit

### entireio/skills (5 skills)
- explain, find, hand-off, session-summary, snapshot

Closes #263