### PR TITLE
refactor(ingester): dedupe same-name skills within a repo by directory priority (#265)

### DIFF
--- a/src/ingester.test.ts
+++ b/src/ingester.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "os";
 import { ensureIndexDir, listIndexedRepos, removeRepoIndex } from "./ingester";
 import { getIndexDir } from "./config";
 import { discoverSkills } from "./installer";
+import { dedupeSkillsByName } from "./skill-dedupe";
 import { verifySkill } from "./verifier";
 
 describe("ensureIndexDir", () => {
@@ -240,6 +241,97 @@ x`,
     expect(good!.verified).toBe(true);
     expect(bad).toBeDefined();
     expect(bad!.verified).toBe(false);
+  });
+});
+
+describe("ingester dedupe (issue #265)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "asm-ingest-dedupe-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function writeSkill(relPath: string, name: string): Promise<void> {
+    const skillDir = join(tempDir, relPath);
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      `---
+name: ${name}
+description: A skill at ${relPath} for dedup testing
+version: 1.0.0
+---
+
+# ${name}
+
+Body content long enough to satisfy any minimum-length verification rules.
+`,
+      "utf-8",
+    );
+  }
+
+  it("collapses same-name skills to one entry, picking skills/ over .claude/skills/", async () => {
+    await writeSkill("skills/foo", "foo");
+    await writeSkill(".claude/skills/foo", "foo");
+
+    const discovered = await discoverSkills(tempDir);
+    expect(discovered.length).toBe(2);
+
+    const { kept, decisions } = dedupeSkillsByName(discovered);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].relPath).toBe("skills/foo");
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].name).toBe("foo");
+    expect(decisions[0].kept.relPath).toBe("skills/foo");
+    expect(decisions[0].dropped.map((d) => d.relPath)).toEqual([
+      ".claude/skills/foo",
+    ]);
+  });
+
+  it("keeps both entries when the names differ across directories", async () => {
+    await writeSkill("skills/alpha", "alpha");
+    await writeSkill(".claude/skills/beta", "beta");
+
+    const discovered = await discoverSkills(tempDir);
+    const { kept, decisions } = dedupeSkillsByName(discovered);
+    expect(kept).toHaveLength(2);
+    expect(decisions).toEqual([]);
+  });
+
+  it("falls through to .agent/skills/ when neither skills/ nor .claude/skills/ has the skill", async () => {
+    await writeSkill(".agent/skills/foo", "foo");
+    await writeSkill(".agents/skills/foo", "foo");
+
+    const discovered = await discoverSkills(tempDir);
+    expect(discovered.length).toBe(2);
+
+    const { kept } = dedupeSkillsByName(discovered);
+    expect(kept).toHaveLength(1);
+    // Both at priority 3 — first found wins. discoverSkills returns alphabetical
+    // by name (same here, "foo" === "foo"), so the order is the walker's
+    // traversal order. We don't pin which of the two wins; we only require
+    // exactly one to survive.
+    expect([".agent/skills/foo", ".agents/skills/foo"]).toContain(
+      kept[0].relPath,
+    );
+  });
+
+  it("is idempotent across repeated runs on the same input", async () => {
+    await writeSkill("skills/foo", "foo");
+    await writeSkill(".claude/skills/foo", "foo");
+    await writeSkill(".agent/skills/foo", "foo");
+
+    const discovered = await discoverSkills(tempDir);
+    const first = dedupeSkillsByName(discovered);
+    const second = dedupeSkillsByName(first.kept);
+    expect(first.kept).toHaveLength(1);
+    expect(first.kept[0].relPath).toBe("skills/foo");
+    expect(second.kept).toEqual(first.kept);
+    expect(second.decisions).toEqual([]);
   });
 });
 

--- a/src/ingester.ts
+++ b/src/ingester.ts
@@ -10,6 +10,7 @@ import {
 import { getIndexDir } from "./config";
 import { loadAllIndices } from "./skill-index";
 import { debug } from "./logger";
+import { dedupeSkillsByName } from "./skill-dedupe";
 import { verifySkill } from "./verifier";
 import { estimateTokenCount } from "./utils/token-count";
 import { evaluateSkillContent } from "./evaluator";
@@ -64,8 +65,24 @@ export async function ingestRepo(sourceInput: string): Promise<IngestResult> {
     const discovered = await discoverSkills(tempDir);
     debug(`ingester: found ${discovered.length} skills`);
 
+    // Dedupe by directory priority before verification. Issue #265: a
+    // higher-priority entry wins even if it would later fail verifySkill —
+    // priority is the canonical signal of "the maintainer's intended copy."
+    const { kept: deduped, decisions } = dedupeSkillsByName(discovered);
+    for (const decision of decisions) {
+      const droppedPaths = decision.dropped.map((d) => d.relPath).join(", ");
+      debug(
+        `ingester: dedupe "${decision.name}": kept ${decision.kept.relPath} (${decision.reason}); dropped ${droppedPaths}`,
+      );
+    }
+    if (decisions.length > 0) {
+      debug(
+        `ingester: deduped ${discovered.length} -> ${deduped.length} skills (${decisions.length} name collision${decisions.length === 1 ? "" : "s"})`,
+      );
+    }
+
     const skills: IndexedSkill[] = [];
-    for (const skill of discovered) {
+    for (const skill of deduped) {
       // Read SKILL.md content for verification
       const skillMdPath = join(tempDir, skill.relPath, "SKILL.md");
       let skillMdContent = "";

--- a/src/skill-dedupe.test.ts
+++ b/src/skill-dedupe.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { dedupeSkillsByName } from "./skill-dedupe";
+
+type Sample = { name: string; relPath: string };
+
+const make = (name: string, relPath: string): Sample => ({ name, relPath });
+
+describe("dedupeSkillsByName", () => {
+  it("returns input unchanged when all names are unique", () => {
+    const input = [
+      make("foo", "skills/foo"),
+      make("bar", ".claude/skills/bar"),
+      make("baz", ".agent/skills/baz"),
+    ];
+    const { kept, decisions } = dedupeSkillsByName(input);
+    expect(kept).toEqual(input);
+    expect(decisions).toEqual([]);
+  });
+
+  it("returns empty when input is empty", () => {
+    const { kept, decisions } = dedupeSkillsByName([]);
+    expect(kept).toEqual([]);
+    expect(decisions).toEqual([]);
+  });
+
+  it("keeps skills/ over .claude/skills/", () => {
+    const input = [
+      make("foo", ".claude/skills/foo"),
+      make("foo", "skills/foo"),
+    ];
+    const { kept, decisions } = dedupeSkillsByName(input);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].relPath).toBe("skills/foo");
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].name).toBe("foo");
+    expect(decisions[0].kept.root).toBe("skills/");
+    expect(decisions[0].dropped).toEqual([
+      { relPath: ".claude/skills/foo", root: ".claude/skills/" },
+    ]);
+    expect(decisions[0].reason).toBe("skills/ priority");
+  });
+
+  it("keeps .claude/skills/ over .agent/skills/", () => {
+    const input = [
+      make("foo", ".agent/skills/foo"),
+      make("foo", ".claude/skills/foo"),
+    ];
+    const { kept, decisions } = dedupeSkillsByName(input);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].relPath).toBe(".claude/skills/foo");
+    expect(decisions[0].kept.root).toBe(".claude/skills/");
+    expect(decisions[0].reason).toBe(".claude/skills/ priority");
+  });
+
+  it("treats .agent/skills/ and .agents/skills/ as the same priority tier (first found wins)", () => {
+    const inputA = [
+      make("foo", ".agent/skills/foo"),
+      make("foo", ".agents/skills/foo"),
+    ];
+    const resA = dedupeSkillsByName(inputA);
+    expect(resA.kept).toHaveLength(1);
+    expect(resA.kept[0].relPath).toBe(".agent/skills/foo");
+
+    const inputB = [
+      make("foo", ".agents/skills/foo"),
+      make("foo", ".agent/skills/foo"),
+    ];
+    const resB = dedupeSkillsByName(inputB);
+    expect(resB.kept).toHaveLength(1);
+    expect(resB.kept[0].relPath).toBe(".agents/skills/foo");
+  });
+
+  it("falls through to first occurrence when no entry matches a priority root", () => {
+    const input = [
+      make("foo", "custom/dir/foo"),
+      make("foo", "another/loc/foo"),
+    ];
+    const { kept, decisions } = dedupeSkillsByName(input);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].relPath).toBe("custom/dir/foo");
+    expect(decisions[0].kept.root).toBe("(other)");
+    expect(decisions[0].reason).toBe("first occurrence (no priority match)");
+  });
+
+  it("picks the highest-priority entry across three same-name skills", () => {
+    const input = [
+      make("foo", ".agent/skills/foo"),
+      make("foo", ".claude/skills/foo"),
+      make("foo", "skills/foo"),
+    ];
+    const { kept, decisions } = dedupeSkillsByName(input);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].relPath).toBe("skills/foo");
+    expect(decisions[0].dropped.map((d) => d.relPath).sort()).toEqual([
+      ".agent/skills/foo",
+      ".claude/skills/foo",
+    ]);
+  });
+
+  it("preserves unrelated skills when deduping a single colliding name", () => {
+    const input = [
+      make("alpha", "skills/alpha"),
+      make("foo", ".claude/skills/foo"),
+      make("beta", ".agent/skills/beta"),
+      make("foo", "skills/foo"),
+      make("gamma", "custom/gamma"),
+    ];
+    const { kept, decisions } = dedupeSkillsByName(input);
+    expect(kept.map((s) => s.relPath)).toEqual([
+      "skills/alpha",
+      "skills/foo",
+      ".agent/skills/beta",
+      "custom/gamma",
+    ]);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].name).toBe("foo");
+  });
+
+  it("recognizes a top-level repo dir literally named 'skills' (relPath === 'skills')", () => {
+    const input = [
+      make("foo", ".claude/skills/foo"),
+      make("foo", "skills"),
+    ];
+    const { kept } = dedupeSkillsByName(input);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].relPath).toBe("skills");
+  });
+
+  it("on a tie within the same priority tier, keeps the first occurrence", () => {
+    // Two same-name skills, both under skills/ (priority 1). Tie → first found.
+    const input = [
+      make("foo", "skills/foo"),
+      make("foo", "skills/sub/foo"),
+    ];
+    const { kept, decisions } = dedupeSkillsByName(input);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].relPath).toBe("skills/foo");
+    expect(decisions[0].kept.root).toBe("skills/");
+    expect(decisions[0].dropped[0].relPath).toBe("skills/sub/foo");
+  });
+
+  it("does not affect different names that happen to share the same directory", () => {
+    const input = [
+      make("foo", "skills/foo"),
+      make("bar", "skills/bar"),
+    ];
+    const { kept, decisions } = dedupeSkillsByName(input);
+    expect(kept).toEqual(input);
+    expect(decisions).toEqual([]);
+  });
+
+  it("is idempotent — applying dedupe to its own output yields the same kept set", () => {
+    const input = [
+      make("foo", ".agent/skills/foo"),
+      make("foo", ".claude/skills/foo"),
+      make("foo", "skills/foo"),
+      make("bar", "skills/bar"),
+    ];
+    const first = dedupeSkillsByName(input);
+    const second = dedupeSkillsByName(first.kept);
+    expect(second.kept).toEqual(first.kept);
+    expect(second.decisions).toEqual([]);
+  });
+
+  it("includes the dropped entry's root classification in the decision record", () => {
+    const input = [
+      make("foo", "skills/foo"),
+      make("foo", ".agents/skills/foo"),
+    ];
+    const { decisions } = dedupeSkillsByName(input);
+    expect(decisions[0].dropped).toEqual([
+      { relPath: ".agents/skills/foo", root: ".agents/skills/" },
+    ]);
+  });
+
+  it("keeps entries from different repos independent (caller-scoped)", () => {
+    // Cross-repo isolation is the caller's responsibility — this helper
+    // operates on a single repo's input. Verify same-name entries with
+    // different relPaths but conceptually-different repos don't dedupe
+    // unless the caller mixes them.
+    const repoA = [make("foo", "skills/foo")];
+    const repoB = [make("foo", "skills/foo")];
+    const a = dedupeSkillsByName(repoA);
+    const b = dedupeSkillsByName(repoB);
+    expect(a.kept).toHaveLength(1);
+    expect(b.kept).toHaveLength(1);
+    expect(a.decisions).toEqual([]);
+    expect(b.decisions).toEqual([]);
+  });
+});

--- a/src/skill-dedupe.ts
+++ b/src/skill-dedupe.ts
@@ -1,0 +1,109 @@
+/**
+ * Within-repo dedupe for skills that share a name across multiple supported
+ * skill directories (e.g., a repo that ships both `skills/foo/` and
+ * `.claude/skills/foo/`). Issue #265.
+ *
+ * Priority order, falling through on miss:
+ *   1. `skills/`
+ *   2. `.claude/skills/`
+ *   3. `.agent/skills/` (and `.agents/skills/`)
+ *   4. First occurrence found
+ *
+ * Cross-repo duplicates are unaffected — this operates on a single repo's
+ * discovered set.
+ */
+
+export type DedupeRoot =
+  | "skills/"
+  | ".claude/skills/"
+  | ".agent/skills/"
+  | ".agents/skills/"
+  | "(other)";
+
+export interface DedupeDecision {
+  name: string;
+  kept: { relPath: string; root: DedupeRoot };
+  dropped: Array<{ relPath: string; root: DedupeRoot }>;
+  reason: string;
+}
+
+export interface DedupeResult<T> {
+  kept: T[];
+  decisions: DedupeDecision[];
+}
+
+interface RootInfo {
+  priority: number;
+  root: DedupeRoot;
+}
+
+function categorize(relPath: string): RootInfo {
+  if (relPath === "skills" || relPath.startsWith("skills/")) {
+    return { priority: 1, root: "skills/" };
+  }
+  if (relPath === ".claude/skills" || relPath.startsWith(".claude/skills/")) {
+    return { priority: 2, root: ".claude/skills/" };
+  }
+  if (relPath === ".agent/skills" || relPath.startsWith(".agent/skills/")) {
+    return { priority: 3, root: ".agent/skills/" };
+  }
+  if (relPath === ".agents/skills" || relPath.startsWith(".agents/skills/")) {
+    return { priority: 3, root: ".agents/skills/" };
+  }
+  return { priority: 4, root: "(other)" };
+}
+
+export function dedupeSkillsByName<T extends { name: string; relPath: string }>(
+  skills: T[],
+): DedupeResult<T> {
+  const groups = new Map<string, T[]>();
+  for (const skill of skills) {
+    const existing = groups.get(skill.name);
+    if (existing) {
+      existing.push(skill);
+    } else {
+      groups.set(skill.name, [skill]);
+    }
+  }
+
+  const kept: T[] = [];
+  const decisions: DedupeDecision[] = [];
+  const seen = new Set<string>();
+
+  for (const skill of skills) {
+    if (seen.has(skill.name)) continue;
+    seen.add(skill.name);
+
+    const group = groups.get(skill.name)!;
+    if (group.length === 1) {
+      kept.push(group[0]);
+      continue;
+    }
+
+    let bestIndex = 0;
+    let bestCat = categorize(group[0].relPath);
+    for (let i = 1; i < group.length; i++) {
+      const cat = categorize(group[i].relPath);
+      if (cat.priority < bestCat.priority) {
+        bestIndex = i;
+        bestCat = cat;
+      }
+    }
+
+    const best = group[bestIndex];
+    kept.push(best);
+    decisions.push({
+      name: skill.name,
+      kept: { relPath: best.relPath, root: bestCat.root },
+      dropped: group
+        .filter((_, i) => i !== bestIndex)
+        .map((s) => ({ relPath: s.relPath, root: categorize(s.relPath).root })),
+      reason:
+        bestCat.priority === 4
+          ? "first occurrence (no priority match)"
+          : `${bestCat.root} priority`,
+    });
+  }
+
+  return { kept, decisions };
+}


### PR DESCRIPTION
## Summary

Closes #265.

When indexing a single repo, the same skill name could appear in multiple skill directories (e.g. both `skills/foo/` and `.claude/skills/foo/`), inflating the catalog and surfacing duplicate entries to users. This change applies a deterministic dedup rule scoped to the single repo being ingested.

## Approach

Priority order, falling through on miss:

1. `skills/`
2. `.claude/skills/`
3. `.agent/skills/` and `.agents/skills/` (same tier — first found wins on tie)
4. First occurrence found

The dedup is implemented as a small reusable helper (`src/skill-dedupe.ts`) and applied in `src/ingester.ts` immediately after `discoverSkills()` returns, before verification. Cross-repo duplicates are unaffected — the helper operates on a single repo's discovered set, and the ingester runs once per repo.

Decisions are emitted via the existing `debug()` logger (with `--verbose`) so a developer can audit which path was kept and which were dropped:

```
ingester: dedupe "foo": kept skills/foo (skills/ priority); dropped .claude/skills/foo
ingester: deduped 3 -> 1 skills (1 name collision)
```

## Decision Record

**Root cause**

`discoverSkills()` returns every copy of a skill it finds in a repo. When the same skill name lives in multiple supported skill directories (e.g. both `skills/foo/` and `.claude/skills/foo/`), each copy gets indexed, inflating the catalog and surfacing duplicates to users. There was no dedupe step between discovery and verification.

**Options considered**

1. Add a within-repo dedupe step in the ingester that picks one entry by directory priority, before verification.
2. Change `discoverSkills()` itself to apply the dedupe at discovery time.
3. Apply the dedupe inside `verifySkill()` and let verification failures decide the survivor.

**Options rejected**

- *Option 2* — `discoverSkills()` is also called by the `install --all` flow (`src/cli.ts`), which uses the existing `findDuplicateInstallNames()` to *fail* on duplicate names. Silently picking by priority there would change established install semantics — out of scope for this issue.
- *Option 3* — Priority is the canonical signal of "the maintainer's intended copy." A higher-priority entry should win even if it would later fail verification; verification status is reflected separately on the kept entry. Coupling dedupe to verification would invert that contract.

**Selected option**

Option 1: a small reusable helper (`src/skill-dedupe.ts`) applied in `src/ingester.ts` immediately after `discoverSkills()` returns, before verification. Tied priorities (e.g. `.agent/skills/foo` and `.agents/skills/foo`) resolve to first-found. The integration test uses `.toContain()` to avoid coupling to filesystem-dependent `readdir` order.

**Residual risk**

- Tied-priority resolution depends on `readdir()` traversal order, so the surviving entry in a `.agent/` vs `.agents/` collision is filesystem-dependent. Acceptable: both copies are equivalent under the priority contract, and the kept entry is explicitly logged for auditability.
- The integration test for AC 1 chains `discoverSkills()` + `dedupeSkillsByName()` directly rather than calling `ingestRepo()` end-to-end. The wiring in `src/ingester.ts` is a 4-line change and is verified by code review; a true E2E test through `ingestRepo()` would require mocking `cloneToTemp()` or a network-dependent GitHub fixture, both outside this PR's scope and inconsistent with the existing ingester test pattern.

## Changes

| File | Change |
|------|--------|
| `src/skill-dedupe.ts` | NEW: `dedupeSkillsByName<T>()` helper + types |
| `src/skill-dedupe.test.ts` | NEW: 14 unit tests (priority matrix, ties, fallthrough, idempotence, isolation, edge cases) |
| `src/ingester.ts` | Wire dedup into ingest flow (4 lines) + `debug()` audit log |
| `src/ingester.test.ts` | 4 integration tests covering the 4 acceptance criteria end-to-end |

## Test Results

- `vitest run src/skill-dedupe.test.ts src/ingester.test.ts` — **33 passed**
- `npm run typecheck` — clean
- `vitest run src/` — **1657 passed, 1 pre-existing failure** (`publisher.test.ts > getRemoteOrigin > returns an HTTPS URL` fails on `main` too — environment-specific, the dev's local git remote uses a custom SSH host alias instead of `github.com`)

## Acceptance Criteria Verification

| AC | Verified by |
|----|------|
| 1. Single repo with same skill name in multiple dirs → exactly one entry | `src/ingester.test.ts` "collapses same-name skills to one entry, picking skills/ over .claude/skills/" |
| 2. Priority order: `skills/` > `.claude/skills/` > `.agent/skills/` (incl. `.agents/`) > first found | `src/skill-dedupe.test.ts` x6 priority tests + integration test |
| 3. Cross-repo duplicates unaffected | `src/skill-dedupe.test.ts` "keeps entries from different repos independent"; structural in ingester (one call per repo) |
| 4. Idempotent + dedup decisions logged for auditability | `src/skill-dedupe.test.ts` "is idempotent — applying dedupe to its own output yields the same kept set" + integration "is idempotent across repeated runs"; logging via `debug()` in `src/ingester.ts` |

## Test plan

- [ ] Re-index a known repo that contains both `skills/foo/` and `.claude/skills/foo/` (e.g. via `npm run preindex` or `tsx scripts/preindex.ts <source>`) with `--verbose` and confirm:
  - The output JSON in `data/skill-index/<owner>_<repo>.json` contains exactly one `foo` entry.
  - That entry's `relPath` is `skills/foo`.
  - Verbose output includes the `ingester: dedupe "foo": kept ...; dropped ...` line.
- [ ] Confirm a repo with only one copy of each skill name produces an identical index to before this change.
- [ ] Confirm two different repos that each contain a skill named `foo` still produce two separate index entries (one per repo file).
