### PR TITLE
feat(index): re-sync coreyhaines31/marketingskills (1 new skill)

### DIFF
--- a/data/skill-index-resources.json
+++ b/data/skill-index-resources.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-05-01T00:00:00Z",
+  "updatedAt": "2026-05-09T00:00:00Z",
   "repos": [
     {
       "source": "github:luongnv89/asm",

--- a/data/skill-index/coreyhaines31_marketingskills.json
+++ b/data/skill-index/coreyhaines31_marketingskills.json
@@ -2,8 +2,8 @@
   "repoUrl": "https://github.com/coreyhaines31/marketingskills.git",
   "owner": "coreyhaines31",
   "repo": "marketingskills",
-  "updatedAt": "2026-05-05T23:45:23.300Z",
-  "skillCount": 40,
+  "updatedAt": "2026-05-09T06:07:53.776Z",
+  "skillCount": 41,
   "skills": [
     {
       "name": "ab-test-setup",
@@ -64,7 +64,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.216Z",
+        "evaluatedAt": "2026-05-09T06:07:53.667Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -119,7 +119,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.216Z",
+          "evaluatedAt": "2026-05-09T06:07:53.669Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -137,7 +137,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.216Z",
+          "evaluatedAt": "2026-05-09T06:07:53.670Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -201,7 +201,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.219Z",
+        "evaluatedAt": "2026-05-09T06:07:53.677Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -256,7 +256,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.219Z",
+          "evaluatedAt": "2026-05-09T06:07:53.677Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -274,7 +274,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.219Z",
+          "evaluatedAt": "2026-05-09T06:07:53.677Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -338,7 +338,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.222Z",
+        "evaluatedAt": "2026-05-09T06:07:53.681Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -393,7 +393,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.222Z",
+          "evaluatedAt": "2026-05-09T06:07:53.681Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -411,7 +411,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.222Z",
+          "evaluatedAt": "2026-05-09T06:07:53.681Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -475,7 +475,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.224Z",
+        "evaluatedAt": "2026-05-09T06:07:53.684Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -530,7 +530,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.224Z",
+          "evaluatedAt": "2026-05-09T06:07:53.684Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -548,7 +548,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.224Z",
+          "evaluatedAt": "2026-05-09T06:07:53.684Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -612,7 +612,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.227Z",
+        "evaluatedAt": "2026-05-09T06:07:53.687Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -667,7 +667,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.227Z",
+          "evaluatedAt": "2026-05-09T06:07:53.687Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -685,7 +685,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.227Z",
+          "evaluatedAt": "2026-05-09T06:07:53.687Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -749,7 +749,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.229Z",
+        "evaluatedAt": "2026-05-09T06:07:53.691Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -804,7 +804,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.230Z",
+          "evaluatedAt": "2026-05-09T06:07:53.691Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -822,8 +822,145 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.230Z",
+          "evaluatedAt": "2026-05-09T06:07:53.691Z",
           "evaluatedVersion": "1.1.0"
+        }
+      }
+    },
+    {
+      "name": "co-marketing",
+      "description": "When the user wants to find co-marketing partners, plan joint campaigns, or brainstorm partnership opportunities. Use when the user says 'co-marketing,' 'partner marketing,' 'joint campaign,' 'who should we partner with,' 'integration marketing,' 'cross-promotion,' 'collaborate with another company,' 'partnership ideas,' or 'co-brand.' For customer referral programs, see referral-program. For launch-specific partnerships, see launch-strategy.",
+      "version": "1.0.0",
+      "license": "",
+      "creator": "",
+      "compatibility": "",
+      "allowedTools": [],
+      "installUrl": "github:coreyhaines31/marketingskills:skills/co-marketing",
+      "relPath": "skills/co-marketing",
+      "verified": true,
+      "tokenCount": 2836,
+      "evalSummary": {
+        "overallScore": 69,
+        "grade": "C",
+        "categories": [
+          {
+            "id": "structure",
+            "name": "Structure & completeness",
+            "score": 8,
+            "max": 10
+          },
+          {
+            "id": "description",
+            "name": "Description quality",
+            "score": 5,
+            "max": 10
+          },
+          {
+            "id": "prompt-engineering",
+            "name": "Prompt engineering",
+            "score": 9,
+            "max": 10
+          },
+          {
+            "id": "context-efficiency",
+            "name": "Context efficiency",
+            "score": 10,
+            "max": 10
+          },
+          {
+            "id": "safety",
+            "name": "Safety & guardrails",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "testability",
+            "name": "Testability",
+            "score": 3,
+            "max": 10
+          },
+          {
+            "id": "naming",
+            "name": "Naming & conventions",
+            "score": 10,
+            "max": 10
+          }
+        ],
+        "evaluatedAt": "2026-05-09T06:07:53.693Z",
+        "evaluatedVersion": "1.0.0"
+      },
+      "evalSummaries": {
+        "quality": {
+          "providerId": "quality",
+          "providerVersion": "1.0.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 69,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "structure",
+              "name": "Structure & completeness",
+              "score": 8,
+              "max": 10
+            },
+            {
+              "id": "description",
+              "name": "Description quality",
+              "score": 5,
+              "max": 10
+            },
+            {
+              "id": "prompt-engineering",
+              "name": "Prompt engineering",
+              "score": 9,
+              "max": 10
+            },
+            {
+              "id": "context-efficiency",
+              "name": "Context efficiency",
+              "score": 10,
+              "max": 10
+            },
+            {
+              "id": "safety",
+              "name": "Safety & guardrails",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "testability",
+              "name": "Testability",
+              "score": 3,
+              "max": 10
+            },
+            {
+              "id": "naming",
+              "name": "Naming & conventions",
+              "score": 10,
+              "max": 10
+            }
+          ],
+          "evaluatedAt": "2026-05-09T06:07:53.693Z",
+          "evaluatedVersion": "1.0.0"
+        },
+        "skill-best-practice": {
+          "providerId": "skill-best-practice",
+          "providerVersion": "1.1.0",
+          "schemaVersion": 1,
+          "passed": true,
+          "overallScore": 79,
+          "grade": "C",
+          "categories": [
+            {
+              "id": "validation",
+              "name": "Deterministic validation",
+              "score": 11,
+              "max": 14
+            }
+          ],
+          "evaluatedAt": "2026-05-09T06:07:53.693Z",
+          "evaluatedVersion": "1.0.0"
         }
       }
     },
@@ -886,7 +1023,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.232Z",
+        "evaluatedAt": "2026-05-09T06:07:53.695Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -941,7 +1078,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.232Z",
+          "evaluatedAt": "2026-05-09T06:07:53.695Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -959,7 +1096,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.232Z",
+          "evaluatedAt": "2026-05-09T06:07:53.695Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -1023,7 +1160,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.233Z",
+        "evaluatedAt": "2026-05-09T06:07:53.698Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1078,7 +1215,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.233Z",
+          "evaluatedAt": "2026-05-09T06:07:53.698Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1096,7 +1233,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.233Z",
+          "evaluatedAt": "2026-05-09T06:07:53.698Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1160,7 +1297,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.235Z",
+        "evaluatedAt": "2026-05-09T06:07:53.700Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -1215,7 +1352,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.235Z",
+          "evaluatedAt": "2026-05-09T06:07:53.700Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -1233,7 +1370,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.235Z",
+          "evaluatedAt": "2026-05-09T06:07:53.700Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -1297,7 +1434,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.237Z",
+        "evaluatedAt": "2026-05-09T06:07:53.702Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1352,7 +1489,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.237Z",
+          "evaluatedAt": "2026-05-09T06:07:53.702Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1370,7 +1507,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.237Z",
+          "evaluatedAt": "2026-05-09T06:07:53.702Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1434,7 +1571,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.240Z",
+        "evaluatedAt": "2026-05-09T06:07:53.706Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -1489,7 +1626,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.240Z",
+          "evaluatedAt": "2026-05-09T06:07:53.706Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -1507,7 +1644,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.240Z",
+          "evaluatedAt": "2026-05-09T06:07:53.706Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -1571,7 +1708,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.242Z",
+        "evaluatedAt": "2026-05-09T06:07:53.709Z",
         "evaluatedVersion": "1.3.0"
       },
       "evalSummaries": {
@@ -1626,7 +1763,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.243Z",
+          "evaluatedAt": "2026-05-09T06:07:53.709Z",
           "evaluatedVersion": "1.3.0"
         },
         "skill-best-practice": {
@@ -1644,7 +1781,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.243Z",
+          "evaluatedAt": "2026-05-09T06:07:53.709Z",
           "evaluatedVersion": "1.3.0"
         }
       }
@@ -1708,7 +1845,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.245Z",
+        "evaluatedAt": "2026-05-09T06:07:53.711Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -1763,7 +1900,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.245Z",
+          "evaluatedAt": "2026-05-09T06:07:53.711Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -1781,7 +1918,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.245Z",
+          "evaluatedAt": "2026-05-09T06:07:53.711Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -1845,7 +1982,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.247Z",
+        "evaluatedAt": "2026-05-09T06:07:53.714Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -1900,7 +2037,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.247Z",
+          "evaluatedAt": "2026-05-09T06:07:53.714Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -1918,7 +2055,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.247Z",
+          "evaluatedAt": "2026-05-09T06:07:53.714Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -1982,7 +2119,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.250Z",
+        "evaluatedAt": "2026-05-09T06:07:53.717Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2037,7 +2174,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.250Z",
+          "evaluatedAt": "2026-05-09T06:07:53.717Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2055,7 +2192,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.250Z",
+          "evaluatedAt": "2026-05-09T06:07:53.717Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2119,7 +2256,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.252Z",
+        "evaluatedAt": "2026-05-09T06:07:53.720Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -2174,7 +2311,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.253Z",
+          "evaluatedAt": "2026-05-09T06:07:53.720Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -2192,7 +2329,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.253Z",
+          "evaluatedAt": "2026-05-09T06:07:53.720Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -2256,7 +2393,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.255Z",
+        "evaluatedAt": "2026-05-09T06:07:53.723Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -2311,7 +2448,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.255Z",
+          "evaluatedAt": "2026-05-09T06:07:53.723Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -2329,7 +2466,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.255Z",
+          "evaluatedAt": "2026-05-09T06:07:53.723Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -2393,7 +2530,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.256Z",
+        "evaluatedAt": "2026-05-09T06:07:53.725Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -2448,7 +2585,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.257Z",
+          "evaluatedAt": "2026-05-09T06:07:53.725Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -2466,7 +2603,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.257Z",
+          "evaluatedAt": "2026-05-09T06:07:53.725Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -2530,7 +2667,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.258Z",
+        "evaluatedAt": "2026-05-09T06:07:53.727Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2585,7 +2722,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.258Z",
+          "evaluatedAt": "2026-05-09T06:07:53.727Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2603,7 +2740,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.258Z",
+          "evaluatedAt": "2026-05-09T06:07:53.727Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2667,7 +2804,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.261Z",
+        "evaluatedAt": "2026-05-09T06:07:53.729Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -2722,7 +2859,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.261Z",
+          "evaluatedAt": "2026-05-09T06:07:53.729Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -2740,7 +2877,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.261Z",
+          "evaluatedAt": "2026-05-09T06:07:53.729Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -2804,7 +2941,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.263Z",
+        "evaluatedAt": "2026-05-09T06:07:53.732Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -2859,7 +2996,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.263Z",
+          "evaluatedAt": "2026-05-09T06:07:53.732Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -2877,7 +3014,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.263Z",
+          "evaluatedAt": "2026-05-09T06:07:53.732Z",
           "evaluatedVersion": "1.0.0"
         }
       }
@@ -2941,7 +3078,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.265Z",
+        "evaluatedAt": "2026-05-09T06:07:53.734Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -2996,7 +3133,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.265Z",
+          "evaluatedAt": "2026-05-09T06:07:53.734Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3014,7 +3151,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.265Z",
+          "evaluatedAt": "2026-05-09T06:07:53.734Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3078,7 +3215,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.267Z",
+        "evaluatedAt": "2026-05-09T06:07:53.737Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3133,7 +3270,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.267Z",
+          "evaluatedAt": "2026-05-09T06:07:53.737Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3151,7 +3288,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.267Z",
+          "evaluatedAt": "2026-05-09T06:07:53.737Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3215,7 +3352,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.269Z",
+        "evaluatedAt": "2026-05-09T06:07:53.740Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3270,7 +3407,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.269Z",
+          "evaluatedAt": "2026-05-09T06:07:53.740Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3288,7 +3425,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.269Z",
+          "evaluatedAt": "2026-05-09T06:07:53.740Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3352,7 +3489,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.271Z",
+        "evaluatedAt": "2026-05-09T06:07:53.741Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3407,7 +3544,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.271Z",
+          "evaluatedAt": "2026-05-09T06:07:53.741Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3425,7 +3562,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.271Z",
+          "evaluatedAt": "2026-05-09T06:07:53.741Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3489,7 +3626,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.272Z",
+        "evaluatedAt": "2026-05-09T06:07:53.743Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -3544,7 +3681,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.272Z",
+          "evaluatedAt": "2026-05-09T06:07:53.743Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -3562,7 +3699,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.273Z",
+          "evaluatedAt": "2026-05-09T06:07:53.743Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -3626,7 +3763,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.274Z",
+        "evaluatedAt": "2026-05-09T06:07:53.745Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3681,7 +3818,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.274Z",
+          "evaluatedAt": "2026-05-09T06:07:53.745Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3699,7 +3836,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.274Z",
+          "evaluatedAt": "2026-05-09T06:07:53.745Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3763,7 +3900,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.276Z",
+        "evaluatedAt": "2026-05-09T06:07:53.747Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3818,7 +3955,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.276Z",
+          "evaluatedAt": "2026-05-09T06:07:53.747Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3836,7 +3973,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.276Z",
+          "evaluatedAt": "2026-05-09T06:07:53.747Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -3900,7 +4037,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.278Z",
+        "evaluatedAt": "2026-05-09T06:07:53.749Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -3955,7 +4092,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.278Z",
+          "evaluatedAt": "2026-05-09T06:07:53.749Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -3973,7 +4110,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.278Z",
+          "evaluatedAt": "2026-05-09T06:07:53.749Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4037,7 +4174,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.279Z",
+        "evaluatedAt": "2026-05-09T06:07:53.751Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4092,7 +4229,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.279Z",
+          "evaluatedAt": "2026-05-09T06:07:53.751Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4110,7 +4247,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.279Z",
+          "evaluatedAt": "2026-05-09T06:07:53.751Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4174,7 +4311,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.281Z",
+        "evaluatedAt": "2026-05-09T06:07:53.752Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4229,7 +4366,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.281Z",
+          "evaluatedAt": "2026-05-09T06:07:53.752Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4247,7 +4384,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.281Z",
+          "evaluatedAt": "2026-05-09T06:07:53.753Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4311,7 +4448,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.282Z",
+        "evaluatedAt": "2026-05-09T06:07:53.754Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4366,7 +4503,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.282Z",
+          "evaluatedAt": "2026-05-09T06:07:53.754Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4384,7 +4521,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.282Z",
+          "evaluatedAt": "2026-05-09T06:07:53.754Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4448,7 +4585,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.284Z",
+        "evaluatedAt": "2026-05-09T06:07:53.757Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4503,7 +4640,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.284Z",
+          "evaluatedAt": "2026-05-09T06:07:53.757Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4521,7 +4658,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.284Z",
+          "evaluatedAt": "2026-05-09T06:07:53.757Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4585,7 +4722,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.287Z",
+        "evaluatedAt": "2026-05-09T06:07:53.760Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4640,7 +4777,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.287Z",
+          "evaluatedAt": "2026-05-09T06:07:53.760Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4658,7 +4795,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.287Z",
+          "evaluatedAt": "2026-05-09T06:07:53.760Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4722,7 +4859,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.288Z",
+        "evaluatedAt": "2026-05-09T06:07:53.762Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -4777,7 +4914,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.288Z",
+          "evaluatedAt": "2026-05-09T06:07:53.762Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -4795,7 +4932,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.288Z",
+          "evaluatedAt": "2026-05-09T06:07:53.762Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -4859,7 +4996,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.290Z",
+        "evaluatedAt": "2026-05-09T06:07:53.764Z",
         "evaluatedVersion": "1.2.0"
       },
       "evalSummaries": {
@@ -4914,7 +5051,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.290Z",
+          "evaluatedAt": "2026-05-09T06:07:53.764Z",
           "evaluatedVersion": "1.2.0"
         },
         "skill-best-practice": {
@@ -4932,7 +5069,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.290Z",
+          "evaluatedAt": "2026-05-09T06:07:53.764Z",
           "evaluatedVersion": "1.2.0"
         }
       }
@@ -4996,7 +5133,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.292Z",
+        "evaluatedAt": "2026-05-09T06:07:53.767Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -5051,7 +5188,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.292Z",
+          "evaluatedAt": "2026-05-09T06:07:53.767Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -5069,7 +5206,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.292Z",
+          "evaluatedAt": "2026-05-09T06:07:53.767Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -5133,7 +5270,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.294Z",
+        "evaluatedAt": "2026-05-09T06:07:53.769Z",
         "evaluatedVersion": "1.1.0"
       },
       "evalSummaries": {
@@ -5188,7 +5325,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.294Z",
+          "evaluatedAt": "2026-05-09T06:07:53.769Z",
           "evaluatedVersion": "1.1.0"
         },
         "skill-best-practice": {
@@ -5206,7 +5343,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.294Z",
+          "evaluatedAt": "2026-05-09T06:07:53.769Z",
           "evaluatedVersion": "1.1.0"
         }
       }
@@ -5270,7 +5407,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.297Z",
+        "evaluatedAt": "2026-05-09T06:07:53.772Z",
         "evaluatedVersion": "1.3.0"
       },
       "evalSummaries": {
@@ -5325,7 +5462,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.297Z",
+          "evaluatedAt": "2026-05-09T06:07:53.772Z",
           "evaluatedVersion": "1.3.0"
         },
         "skill-best-practice": {
@@ -5343,7 +5480,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.297Z",
+          "evaluatedAt": "2026-05-09T06:07:53.772Z",
           "evaluatedVersion": "1.3.0"
         }
       }
@@ -5407,7 +5544,7 @@
             "max": 10
           }
         ],
-        "evaluatedAt": "2026-05-05T23:45:23.299Z",
+        "evaluatedAt": "2026-05-09T06:07:53.775Z",
         "evaluatedVersion": "1.0.0"
       },
       "evalSummaries": {
@@ -5462,7 +5599,7 @@
               "max": 10
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.299Z",
+          "evaluatedAt": "2026-05-09T06:07:53.775Z",
           "evaluatedVersion": "1.0.0"
         },
         "skill-best-practice": {
@@ -5480,7 +5617,7 @@
               "max": 14
             }
           ],
-          "evaluatedAt": "2026-05-05T23:45:23.299Z",
+          "evaluatedAt": "2026-05-09T06:07:53.775Z",
           "evaluatedVersion": "1.0.0"
         }
       }


### PR DESCRIPTION
## Summary
- Re-synced `coreyhaines31/marketingskills` index after upstream additions
- 1 new skill discovered: `co-marketing`
- Repo skill count: 40 → 41

### Updated Repo
| Repo | Skills | Description |
|------|--------|-------------|
| [coreyhaines31/marketingskills](https://github.com/coreyhaines31/marketingskills) | 41 (+1) | Marketing skills for Claude Code and AI agents. CRO, copywriting, SEO, analytics, and growth engineering. |

### New Skill
| Name | Eval | Notes |
|------|------|-------|
| co-marketing | 69 / C | name + description present, no security flags. Description >250 chars and missing negative-trigger clause (warnings only). |

### Audit Summary
No critical security flags. Permissive policy → accepted.

## Test Plan
- [x] `data/skill-index-resources.json` is valid JSON, `updatedAt` bumped to 2026-05-09
- [x] `data/skill-index/coreyhaines31_marketingskills.json` regenerated, 41 skills, `co-marketing` entry has `tokenCount` and `evalSummary`
- [x] `bun scripts/build-catalog.ts` rebuilt website catalog; `co-marketing` present
- [ ] CI passes